### PR TITLE
fix: pass GITHUB_TOKEN to moog release tag action

### DIFF
--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -69,6 +69,7 @@ jobs:
       uses: pozetroninc/github-action-get-latest-release@master
       with:
         repository: cardano-foundation/moog
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Download moog from latest release
       uses: robinraju/release-downloader@v1.10


### PR DESCRIPTION
## Summary
- Pass `GITHUB_TOKEN` to `pozetroninc/github-action-get-latest-release` to avoid GitHub API rate limiting (403)
- Unauthenticated requests share a 60 req/hour limit across all GitHub-hosted runners; authenticated requests get 1000/hour

Closes #14