### PR TITLE
fix: replace arx bundler with AppImage

### DIFF
--- a/.github/workflows/adversary-CI.yaml
+++ b/.github/workflows/adversary-CI.yaml
@@ -27,14 +27,14 @@ jobs:
         with:
           name: cardano-utxo-csmt-image
           path: ./components/adversary/output-docker-image
-      - name: Build arx
-        run: nix bundle -o output-linux-tarball
+      - name: Build AppImage
+        run: nix --quiet bundle --bundler github:ralismark/nix-appimage .#adversary -o adversary.AppImage
         working-directory: ./components/adversary
-      - name: Upload tarball Artifact
+      - name: Upload AppImage Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cardano-utxo-csmt
-          path: ./components/adversary/output-linux-tarball
+          name: adversary-appimage
+          path: ./components/adversary/adversary.AppImage
   unit:
     name: Run unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tracer-sidecar-CI.yaml
+++ b/.github/workflows/tracer-sidecar-CI.yaml
@@ -27,14 +27,14 @@ jobs:
         with:
           name: cardano-utxo-csmt-image
           path: ./components/tracer-sidecar/output-docker-image
-      - name: Build arx
-        run: nix bundle -o output-linux-tarball
+      - name: Build AppImage
+        run: nix --quiet bundle --bundler github:ralismark/nix-appimage .#tracer-sidecar -o tracer-sidecar.AppImage
         working-directory: ./components/tracer-sidecar
-      - name: Upload tarball Artifact
+      - name: Upload AppImage Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cardano-utxo-csmt
-          path: ./components/tracer-sidecar/output-linux-tarball
+          name: tracer-sidecar-appimage
+          path: ./components/tracer-sidecar/tracer-sidecar.AppImage
   unit:
     name: Run unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace `nix bundle` (arx) with `nix bundle --bundler github:ralismark/nix-appimage` in both adversary and tracer-sidecar CI
- arx depends on `bytestring-nums` which is marked broken in nixpkgs, failing both builds
- Same pattern already used in `paolino/haskell-csmt`

Closes #17
Closes #16