### PR TITLE
Add cardano-node 10.7.1 to testnet population

### DIFF
--- a/components/configurator/Dockerfile
+++ b/components/configurator/Dockerfile
@@ -1,6 +1,6 @@
 # Pin cardano-cli version to match the highest node version in the testnet.
 # Using intersectmbo image (the official source) instead of third-party builds.
-FROM ghcr.io/intersectmbo/cardano-node:10.6.2 AS cardano-bin
+FROM ghcr.io/intersectmbo/cardano-node:10.7.1 AS cardano-bin
 
 FROM debian:bookworm-slim
 

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -57,13 +57,16 @@ services:
       - tracer:/tracer
   p2:
     <<: *cardano-node
+    image: ghcr.io/intersectmbo/cardano-node:10.5.3
     container_name: p2
     hostname: p2.example
     volumes:
       - p2-configs:/configs:ro
       - tracer:/tracer
+
   p3:
     <<: *cardano-node
+    image: ghcr.io/intersectmbo/cardano-node:10.6.2
     container_name: p3
     hostname: p3.example
     volumes:
@@ -72,7 +75,7 @@ services:
 
   p4:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.5.3
+    image: ghcr.io/intersectmbo/cardano-node:10.6.2
     container_name: p4
     hostname: p4.example
     volumes:
@@ -81,7 +84,7 @@ services:
 
   p5:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.5.3
+    image: ghcr.io/intersectmbo/cardano-node:10.7.1
     container_name: p5
     hostname: p5.example
     volumes:
@@ -90,7 +93,7 @@ services:
 
   p6:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2
+    image: ghcr.io/intersectmbo/cardano-node:10.7.1
     container_name: p6
     hostname: p6.example
     volumes:


### PR DESCRIPTION
Rebalance pool versions to 1-1-2-2:
- p1: 10.5.1, p2: 10.5.3, p3-p4: 10.6.2, p5-p6: 10.7.1

Configurator bumped to 10.7.1 for genesis generation.

Tested locally: all 6 pools start, chain converges.