### PR TITLE
Add relay nodes and Oura N2N client to testnet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,6 @@ These are docker containers useful to set up the test environment for Antithesis
 
 Currently we provide and maintain only one testnet configuration, but we plan to expand this list in the future. Some old famoud testnets are broken in the old-broken directory for historical reference [link](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/old-broken)
 
-- `cardano-node-master/`: A testnet that runs the latest Cardano Node from the latest published image. It's made of 5 producer nodes, a tracer, a tracer-sidecar and a sidecar. The testnet is configured to run with the latest Cardano Node version and is used to validate the basic functionality of Antithesis.
+- `cardano-node-master/`: A mixed-version testnet with 3 block producers (10.5.3, 10.6.2, 10.7.1), 2 relay nodes (10.6.2, 10.7.1), and an Oura N2N client (Rust/Pallas). Includes a tracer, tracer-sidecar, and sidecar for observability and assertions. The topology exercises node-to-node protocol diversity across Haskell and Rust implementations.
 You can find the configuration files in the [testnets/cardano-node-master](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/testnets/cardano_node_master) directory.
 

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -1,7 +1,13 @@
 # Cardano Node Master
 
-A 5 pools testnet using cardano-node latest image from ghcr.io/IntersectMBO/cardano-node:latest
+A mixed-version Cardano testnet for Antithesis fault-injection testing.
 
 ## Overview
 
-This testnet is designed to run the latest Cardano Node from the latest published image. It consists of 5 producer nodes, a tracer, a tracer-sidecar, and a sidecar. The testnet is configured to run with the latest Cardano Node version and is used to validate the basic functionality of Antithesis.
+This testnet exercises the node-to-node protocol across multiple cardano-node versions and ecosystem clients:
+
+- **3 block producers**: p1 (10.5.3), p2 (10.6.2), p3 (10.7.1) — forge blocks with a ring topology
+- **2 relay nodes**: relay1 (10.6.2), relay2 (10.7.1) — non-producing nodes connected to all producers
+- **Oura**: a Rust/Pallas N2N client connected to relay1 via TCP, exercising ChainSync and BlockFetch mini-protocols
+
+Supporting services: tracer (cardano-tracer), tracer-sidecar (log processing and Antithesis assertions), sidecar (network health checks), and configurator (genesis and config generation).

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-cardano-node: &cardano-node
-  image: ghcr.io/intersectmbo/cardano-node:10.5.1
+  image: ghcr.io/intersectmbo/cardano-node:10.5.3
   environment:
     CARDANO_BLOCK_PRODUCER: true
   command: >
@@ -21,6 +21,25 @@ x-cardano-node: &cardano-node
     tracer-sidecar:
       condition: service_started
 
+x-cardano-relay: &cardano-relay
+  environment:
+    CARDANO_BLOCK_PRODUCER: false
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    tracer-sidecar:
+      condition: service_started
+
 services:
   configurator:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:aa43ea4
@@ -30,9 +49,6 @@ services:
       - p1-configs:/configs/1 # configs for p1
       - p2-configs:/configs/2 # configs for p2
       - p3-configs:/configs/3 # configs for p3
-      - p4-configs:/configs/4 # configs for p4
-      - p5-configs:/configs/5 # configs for p5
-      - p6-configs:/configs/6 # configs for p6
 
   tracer:
     image: ghcr.io/intersectmbo/cardano-tracer:10.6.0
@@ -55,9 +71,10 @@ services:
     volumes:
       - p1-configs:/configs:ro
       - tracer:/tracer
+
   p2:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.5.3
+    image: ghcr.io/intersectmbo/cardano-node:10.6.2
     container_name: p2
     hostname: p2.example
     volumes:
@@ -66,39 +83,44 @@ services:
 
   p3:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2
+    image: ghcr.io/intersectmbo/cardano-node:10.7.1
     container_name: p3
     hostname: p3.example
     volumes:
       - p3-configs:/configs:ro
       - tracer:/tracer
 
-  p4:
-    <<: *cardano-node
+  relay1:
+    <<: *cardano-relay
     image: ghcr.io/intersectmbo/cardano-node:10.6.2
-    container_name: p4
-    hostname: p4.example
+    container_name: relay1
+    hostname: relay1.example
     volumes:
-      - p4-configs:/configs:ro
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
       - tracer:/tracer
 
-  p5:
-    <<: *cardano-node
+  relay2:
+    <<: *cardano-relay
     image: ghcr.io/intersectmbo/cardano-node:10.7.1
-    container_name: p5
-    hostname: p5.example
+    container_name: relay2
+    hostname: relay2.example
     volumes:
-      - p5-configs:/configs:ro
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
       - tracer:/tracer
 
-  p6:
-    <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.7.1
-    container_name: p6
-    hostname: p6.example
+  oura:
+    image: ghcr.io/txpipe/oura:latest
+    container_name: oura
+    hostname: oura.example
+    command: daemon --config /etc/oura/daemon.toml
     volumes:
-      - p6-configs:/configs:ro
-      - tracer:/tracer
+      - ./oura-daemon.toml:/etc/oura/daemon.toml:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
 
   sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:452fae1
@@ -106,7 +128,7 @@ services:
       NETWORKMAGIC: 42
       PORT: 3001
       LIMIT: 100
-      POOLS: "6"
+      POOLS: "3"
       NCONNS: 1
       CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
     container_name: sidecar
@@ -127,7 +149,7 @@ services:
     command:
       - "/opt/cardano-tracer/logs"
     environment:
-      POOLS: "6"
+      POOLS: "3"
       CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
     volumes:
       - tracer:/opt/cardano-tracer
@@ -141,9 +163,6 @@ volumes:
   p1-configs:
   p2-configs:
   p3-configs:
-  p4-configs:
-  p5-configs:
-  p6-configs:
 
 networks:
   default:

--- a/testnets/cardano_node_master/oura-daemon.toml
+++ b/testnets/cardano_node_master/oura-daemon.toml
@@ -1,0 +1,26 @@
+[source]
+type = "N2N"
+address = ["Tcp", "relay1.example:3001"]
+magic = 42
+
+[source.mapper]
+include_block_cbor = false
+
+[chain]
+type = "custom"
+magic = 42
+address_hrp = "addr_test"
+adahandle_policy = ""
+byron_epoch_length = 86400
+byron_slot_length = 1
+byron_known_slot = 0
+byron_known_hash = ""
+byron_known_time = 0
+shelley_epoch_length = 86400
+shelley_slot_length = 1
+shelley_known_slot = 0
+shelley_known_hash = ""
+shelley_known_time = 0
+
+[sink]
+type = "Stdout"

--- a/testnets/cardano_node_master/relay-topology.json
+++ b/testnets/cardano_node_master/relay-topology.json
@@ -1,0 +1,16 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p1.example", "port": 3001},
+        {"address": "p2.example", "port": 3001},
+        {"address": "p3.example", "port": 3001}
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 3
+    }
+  ],
+  "publicRoots": [],
+  "useLedgerAfterSlot": 0
+}

--- a/testnets/cardano_node_master/testnet.yaml
+++ b/testnets/cardano_node_master/testnet.yaml
@@ -1,5 +1,5 @@
 --- # Required Testnet Parameters
-poolCount: 6
+poolCount: 3
 poolCost: 340000000
 poolMargin: 0.0
 poolPledge: 0


### PR DESCRIPTION
## Summary

- Replace 6-producer topology with 3 producers + 2 relays + Oura N2N client
- Producers: p1 (10.5.3), p2 (10.6.2), p3 (10.7.1)
- Relays: relay1 (10.6.2), relay2 (10.7.1)
- Oura: N2N TCP client via Pallas/Rust connecting to relay1
- Dolos excluded pending custom network support (#35)
- Updated docs (index + cardano-node-master page)

## Test plan

- [x] Local: all containers start, chain converges, Oura streams blocks
- [ ] Antithesis 1h run dispatched on this branch