### PR TITLE
Add tx-generator and Ogmios to testnet

### DIFF
--- a/components/configurator/Dockerfile
+++ b/components/configurator/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && \
         jq && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy Nix store (contains glibc and all cardano binary deps)
+COPY --from=cardano-bin /nix /nix
+
 # Copy pinned cardano binaries from official image
 COPY --from=cardano-bin /usr/local/bin/cardano-node /usr/local/bin/
 COPY --from=cardano-bin /usr/local/bin/cardano-cli /usr/local/bin/

--- a/components/configurator/configurator.sh
+++ b/components/configurator/configurator.sh
@@ -144,6 +144,12 @@ mkdir -p /configs
 cp -r /tmp/testnet/pools/* /configs
 cp -r /tmp/testnet/utxos/* /configs
 
+# Preserve UTxO keys for tx-generator before pool-specific keys overwrite them
+if [ -d "/configs/keys" ] && [ -d "/utxo-keys" ]; then
+  echo "preserving UTxO keys to /utxo-keys"
+  cp -r /configs/keys/* /utxo-keys/ 2>/dev/null || true
+fi
+
 echo "removing /configs/keys"; rm -rf /configs/keys
 
 pools=$(ls -d /configs/*)

--- a/components/n2c-harness/harness.sh
+++ b/components/n2c-harness/harness.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# N2C service harness for Antithesis.
+#
+# Wraps an N2C service (ogmios, kupo) and:
+# - Waits for the node socket before starting
+# - Converts SIGTERM to SIGINT for Haskell processes
+#   (GHC handles SIGINT gracefully but not SIGTERM by default,
+#    see: https://github.com/IntersectMBO/cardano-node/issues/2267)
+# - Logs non-zero exits with signal context
+#
+# Usage: harness.sh <socket-path> <command> [args...]
+
+SOCKET="$1"
+shift
+
+echo "[harness] waiting for socket: $SOCKET"
+while [ ! -S "$SOCKET" ]; do
+    sleep 2
+done
+echo "[harness] socket ready, starting: $*"
+
+# Run child in background so we can forward signals
+"$@" &
+CHILD=$!
+
+# Convert SIGTERM to SIGINT for GHC (Haskell) processes
+# GHC only handles SIGINT (UserInterrupt), SIGTERM kills without cleanup
+SIGNALED=false
+trap 'SIGNALED=true; echo "[harness] SIGTERM received, sending SIGINT to child ($CHILD)"; kill -INT $CHILD 2>/dev/null' TERM
+trap 'SIGNALED=true; echo "[harness] SIGINT received, forwarding to child ($CHILD)"; kill -INT $CHILD 2>/dev/null' INT
+
+# Wait for child to exit
+wait $CHILD
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "[harness] clean exit (0)"
+    exit 0
+fi
+
+if [ "$SIGNALED" = true ]; then
+    echo "[harness] child exited ($EXIT_CODE) after signal"
+fi
+
+exit $EXIT_CODE

--- a/components/tx-generator/Dockerfile
+++ b/components/tx-generator/Dockerfile
@@ -1,0 +1,23 @@
+# Copy cardano-cli and its Nix dependencies from the official node image.
+FROM ghcr.io/intersectmbo/cardano-node:10.7.1 AS cardano-bin
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 python3-pip jq && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy Nix store (contains glibc and all cardano-cli deps)
+COPY --from=cardano-bin /nix /nix
+
+# Copy cardano-cli binary
+COPY --from=cardano-bin /usr/local/bin/cardano-cli /usr/local/bin/
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir --break-system-packages -r /app/requirements.txt
+
+COPY tx_generator.py /app/
+
+WORKDIR /app
+ENTRYPOINT ["python3", "tx_generator.py"]

--- a/components/tx-generator/requirements.txt
+++ b/components/tx-generator/requirements.txt
@@ -1,0 +1,1 @@
+antithesis

--- a/components/tx-generator/tx_generator.py
+++ b/components/tx-generator/tx_generator.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Transaction generator for Antithesis testnet.
+
+Continuously submits ADA self-transfers using cardano-cli via N2C.
+Uses the Antithesis SDK for deterministic randomness (falls back to
+standard random outside Antithesis).
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+
+try:
+    from antithesis.random import get_random
+    from antithesis.lifecycle import setup_complete
+except ImportError:
+    # Fallback when antithesis SDK is not available
+    import random
+
+    def get_random():
+        return random.getrandbits(64)
+
+    def setup_complete(details=None):
+        pass
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("tx-generator")
+
+NETWORK_MAGIC = os.environ.get("NETWORK_MAGIC", "42")
+NETWORK_ID = f"--testnet-magic {NETWORK_MAGIC}"
+SOCKET_PATH = os.environ.get("CARDANO_NODE_SOCKET_PATH", "/state/node.socket")
+WORK_DIR = "/tmp/tx-gen"
+UTXO_KEYS_DIR = "/utxo-keys"
+POOL_KEYS_DIR = "/configs/keys"
+MIN_SLEEP = 5
+MAX_SLEEP = 30
+
+
+def run_cli(*args):
+    """Run cardano-cli and return stdout."""
+    cmd = ["cardano-cli"] + list(args)
+    log.debug("Running: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(f"cardano-cli failed ({' '.join(cmd[:4])}): {result.stderr.strip()[:200]}")
+    return result.stdout.strip()
+
+
+def wait_for_socket():
+    log.info("Waiting for node socket at %s", SOCKET_PATH)
+    while not os.path.exists(SOCKET_PATH):
+        time.sleep(2)
+    log.info("Socket found")
+
+
+def wait_for_sync():
+    log.info("Waiting for node sync")
+    while True:
+        try:
+            tip = json.loads(run_cli("query", "tip", *NETWORK_ID.split()))
+            progress = tip.get("syncProgress", "0")
+            if progress == "100.00":
+                log.info("Node synced, slot %s", tip.get("slot", tip.get("slotInEpoch")))
+                return tip
+        except Exception as e:
+            log.debug("Sync check failed: %s", e)
+        time.sleep(5)
+
+
+def get_era():
+    tip = json.loads(run_cli("query", "tip", *NETWORK_ID.split()))
+    return tip["era"].lower()
+
+
+def find_key_file(name):
+    """Find a key file in utxo-keys or pool keys directory."""
+    for d in [UTXO_KEYS_DIR, POOL_KEYS_DIR]:
+        path = os.path.join(d, name)
+        if os.path.exists(path):
+            return path
+    raise FileNotFoundError(f"Key file {name} not found in {UTXO_KEYS_DIR} or {POOL_KEYS_DIR}")
+
+
+def get_payment_address():
+    """Get a funded payment address and its signing key."""
+    # Look for genesis.N.addr.info + genesis.N.skey pairs in utxo-keys
+    if os.path.isdir(UTXO_KEYS_DIR):
+        for fname in sorted(os.listdir(UTXO_KEYS_DIR)):
+            if fname.startswith("genesis.") and fname.endswith(".addr.info"):
+                # e.g. genesis.1.addr.info → genesis.1.skey
+                num = fname.split(".")[1]
+                skey_name = f"genesis.{num}.skey"
+                skey_path = os.path.join(UTXO_KEYS_DIR, skey_name)
+                if not os.path.exists(skey_path):
+                    continue
+                addr_path = os.path.join(UTXO_KEYS_DIR, fname)
+                with open(addr_path) as f:
+                    info = json.load(f)
+                addr = info["address"]
+                utxos = query_utxos(addr)
+                if utxos:
+                    log.info("Found funded address: %s (key: %s)", addr, skey_path)
+                    return addr, skey_path
+    raise RuntimeError("No funded address found in " + UTXO_KEYS_DIR)
+
+
+def get_protocol_params():
+    path = os.path.join(WORK_DIR, "protocol-params.json")
+    run_cli("query", "protocol-parameters", *NETWORK_ID.split(),
+            "--out-file", path)
+    return path
+
+
+def query_utxos(address):
+    path = os.path.join(WORK_DIR, "utxos.json")
+    run_cli("query", "utxo", *NETWORK_ID.split(),
+            "--address", address, "--out-file", path)
+    with open(path) as f:
+        return json.load(f)
+
+
+def pick_utxo(utxos):
+    """Pick a UTxO using Antithesis deterministic random. Returns (key, lovelace)."""
+    keys = list(utxos.keys())
+    if not keys:
+        return None, 0
+    idx = get_random() % len(keys)
+    key = keys[idx]
+    value = utxos[key].get("value", {})
+    lovelace = value.get("lovelace", 0) if isinstance(value, dict) else 0
+    return key, lovelace
+
+
+def random_sleep():
+    """Sleep for a random interval using Antithesis deterministic random."""
+    seconds = MIN_SLEEP + (get_random() % (MAX_SLEEP - MIN_SLEEP + 1))
+    log.info("Sleeping %ds", seconds)
+    time.sleep(seconds)
+
+
+MIN_SPLIT_OUTPUTS = 1
+MAX_SPLIT_OUTPUTS = 5
+SPLIT_AMOUNT = 2_000_000  # 2 ADA per extra output
+
+
+def build_sign_submit(era, address, utxo_key, utxo_value, protocol_params_path, skey_path):
+    """Build a transaction with random extra outputs to grow the UTxO set."""
+    tip = json.loads(run_cli("query", "tip", *NETWORK_ID.split()))
+    current_slot = tip.get("slot", tip.get("slotInEpoch", 0))
+    ttl = current_slot + 200
+
+    # Decide how many extra outputs (Antithesis deterministic random)
+    n_extra = MIN_SPLIT_OUTPUTS + (get_random() % (MAX_SPLIT_OUTPUTS - MIN_SPLIT_OUTPUTS + 1))
+    # Only split if the UTxO has enough funds
+    needed = n_extra * SPLIT_AMOUNT + 5_000_000  # extra outputs + min change + fees
+    if utxo_value < needed:
+        n_extra = 0
+
+    tx_raw = os.path.join(WORK_DIR, "tx.raw")
+    tx_signed = os.path.join(WORK_DIR, "tx.signed")
+
+    # Build with extra outputs
+    build_args = [era, "transaction", "build",
+                  *NETWORK_ID.split(),
+                  "--tx-in", utxo_key]
+    for _ in range(n_extra):
+        build_args += ["--tx-out", f"{address}+{SPLIT_AMOUNT}"]
+    build_args += ["--change-address", address,
+                   "--invalid-hereafter", str(ttl),
+                   "--out-file", tx_raw]
+    run_cli(*build_args)
+
+    # Sign
+    run_cli(era, "transaction", "sign",
+            *NETWORK_ID.split(),
+            "--signing-key-file", skey_path,
+            "--tx-body-file", tx_raw,
+            "--out-file", tx_signed)
+
+    # Get tx hash for logging
+    tx_id = run_cli(era, "transaction", "txid", "--tx-file", tx_signed)
+
+    # Submit
+    run_cli(era, "transaction", "submit",
+            *NETWORK_ID.split(),
+            "--tx-file", tx_signed)
+
+    return tx_id
+
+
+def main():
+    os.makedirs(WORK_DIR, exist_ok=True)
+
+    wait_for_socket()
+    wait_for_sync()
+
+    era = get_era()
+    address, skey_path = get_payment_address()
+    log.info("Era: %s, Address: %s, Skey: %s", era, address, skey_path)
+
+    setup_complete({"tx_generator": "ready", "era": era, "address": address})
+
+    tx_count = 0
+    error_count = 0
+
+    while True:
+        try:
+            protocol_params = get_protocol_params()
+            utxos = query_utxos(address)
+
+            if not utxos:
+                log.warning("No UTxOs available, waiting...")
+                time.sleep(10)
+                continue
+
+            utxo_key, utxo_value = pick_utxo(utxos)
+            log.info("Using UTxO: %s (%d lovelace, %d UTxOs total)", utxo_key, utxo_value, len(utxos))
+
+            tx_id = build_sign_submit(era, address, utxo_key, utxo_value, protocol_params, skey_path)
+            tx_count += 1
+            log.info("Submitted tx %d: %s", tx_count, tx_id)
+
+            # Wait for the consumed UTxO to disappear (tx included in block)
+            for _ in range(60):
+                time.sleep(2)
+                fresh = query_utxos(address)
+                if utxo_key not in fresh:
+                    log.info("UTxO consumed, %d UTxOs now available", len(fresh))
+                    break
+            else:
+                log.warning("UTxO still present after 120s, proceeding anyway")
+
+        except Exception as e:
+            error_count += 1
+            log.error("Tx failed (error %d): %s", error_count, e)
+            # Re-fetch era in case of hard fork
+            try:
+                era = get_era()
+            except Exception:
+                pass
+            time.sleep(10)
+            continue
+
+        random_sleep()
+
+
+if __name__ == "__main__":
+    main()

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -42,13 +42,14 @@ x-cardano-relay: &cardano-relay
 
 services:
   configurator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:aa43ea4
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:tx-gen-v1
     container_name: configurator
     volumes:
       - ./testnet.yaml:/testnet.yaml #  source of configurations
       - p1-configs:/configs/1 # configs for p1
       - p2-configs:/configs/2 # configs for p2
       - p3-configs:/configs/3 # configs for p3
+      - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
     image: ghcr.io/intersectmbo/cardano-tracer:10.6.0
@@ -98,6 +99,7 @@ services:
     volumes:
       - p1-configs:/configs:ro
       - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay1-state:/state
       - tracer:/tracer
 
   relay2:
@@ -108,6 +110,7 @@ services:
     volumes:
       - p1-configs:/configs:ro
       - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay2-state:/state
       - tracer:/tracer
 
   oura:
@@ -117,6 +120,44 @@ services:
     command: daemon --config /etc/oura/daemon.toml
     volumes:
       - ./oura-daemon.toml:/etc/oura/daemon.toml:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+
+  ogmios:
+    image: docker.io/cardanosolutions/ogmios:latest
+    container_name: ogmios
+    hostname: ogmios.example
+    entrypoint: ["/harness/harness.sh", "/state/node.socket"]
+    command:
+      - "ogmios"
+      - "--node-socket"
+      - "/state/node.socket"
+      - "--node-config"
+      - "/configs/configs/config.json"
+      - "--host"
+      - "0.0.0.0"
+    volumes:
+      - relay2-state:/state:ro
+      - p1-configs:/configs:ro
+      - ./harness.sh:/harness/harness.sh:ro
+    restart: always
+    depends_on:
+      relay2:
+        condition: service_started
+
+  tx-generator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:tx-gen-v1
+    container_name: tx-generator
+    hostname: tx-generator.example
+    environment:
+      CARDANO_NODE_SOCKET_PATH: /state/node.socket
+      NETWORK_MAGIC: "42"
+    volumes:
+      - relay1-state:/state:ro
+      - p1-configs:/configs:ro
+      - utxo-keys:/utxo-keys:ro
     restart: always
     depends_on:
       relay1:
@@ -163,6 +204,9 @@ volumes:
   p1-configs:
   p2-configs:
   p3-configs:
+  relay1-state:
+  relay2-state:
+  utxo-keys:
 
 networks:
   default:

--- a/testnets/cardano_node_master/harness.sh
+++ b/testnets/cardano_node_master/harness.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# N2C service harness for Antithesis.
+#
+# Wraps an N2C service (ogmios, kupo) and:
+# - Waits for the node socket before starting
+# - Converts SIGTERM to SIGINT for Haskell processes
+#   (GHC handles SIGINT gracefully but not SIGTERM by default,
+#    see: https://github.com/IntersectMBO/cardano-node/issues/2267)
+# - Logs non-zero exits with signal context
+#
+# Usage: harness.sh <socket-path> <command> [args...]
+
+SOCKET="$1"
+shift
+
+echo "[harness] waiting for socket: $SOCKET"
+while [ ! -S "$SOCKET" ]; do
+    sleep 2
+done
+echo "[harness] socket ready, starting: $*"
+
+# Run child in background so we can forward signals
+"$@" &
+CHILD=$!
+
+# Convert SIGTERM to SIGINT for GHC (Haskell) processes
+# GHC only handles SIGINT (UserInterrupt), SIGTERM kills without cleanup
+SIGNALED=false
+trap 'SIGNALED=true; echo "[harness] SIGTERM received, sending SIGINT to child ($CHILD)"; kill -INT $CHILD 2>/dev/null' TERM
+trap 'SIGNALED=true; echo "[harness] SIGINT received, forwarding to child ($CHILD)"; kill -INT $CHILD 2>/dev/null' INT
+
+# Wait for child to exit
+wait $CHILD
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "[harness] clean exit (0)"
+    exit 0
+fi
+
+if [ "$SIGNALED" = true ]; then
+    echo "[harness] child exited ($EXIT_CODE) after signal"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Adds tx-generator (Python script splitting/consuming UTxOs via relay1) and Ogmios (N2C via relay2) to the cardano_node_master testnet.
- Supersedes PR #39, which bundled Kupo as well. Kupo was isolated in bisection (`exp/add-kupo` commit 4034fe9) and failed Antithesis on first try while tx-gen and Ogmios both passed — so it's deferred pending investigation.

## Bisection evidence
| Branch | Commit | Antithesis outcome |
|---|---|---|
| exp/add-tx-gen | c5c60ce0 | success |
| exp/add-ogmios | ece303c7 | success |
| exp/add-kupo | 4034fe9 | failure |

Each experiment was the baseline + exactly one service.

## Test plan
- [ ] Trigger Antithesis via `workflow_dispatch` with `duration=1`
- [ ] Verify `phase=finished`, `outcome=success` via `moog facts test-runs`
- [ ] Smoke test: `docker compose up` shows all services healthy