### PR TITLE
Document Antithesis report triage for AI agents

### DIFF
--- a/docs/triage.md
+++ b/docs/triage.md
@@ -31,15 +31,36 @@ The resulting URL is what `antithesis-triage` consumes.
 
 ```bash
 # snouty
-# see https://github.com/antithesishq/snouty#installation
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/antithesishq/snouty/releases/latest/download/snouty-installer.sh | sh
 
 # agent-browser (>= v0.23.4)
-# see https://github.com/vercel-labs/agent-browser#installation
-agent-browser upgrade   # if already installed
+npm install -g agent-browser
+agent-browser install   # downloads Chrome for Testing
 
 # jq
 # https://jqlang.org/download/
 ```
+
+### NixOS note
+
+`agent-browser install` downloads a Chrome binary that depends on system libraries (`libglib-2.0`, `libnspr4`, etc.) missing from a NixOS host. The simplest workaround: install chromium via nix and connect `agent-browser` to it via CDP instead of letting it auto-launch.
+
+```bash
+nix profile add nixpkgs#chromium
+
+# Start headless chromium with remote debugging
+chromium --headless --disable-gpu --no-sandbox \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-agent &
+
+# Point agent-browser at it
+agent-browser connect 9222 --session triage
+agent-browser open "$URL" --session triage
+agent-browser get text body --session triage
+```
+
+See `scripts/agent-browser-nixos.sh` for a wrapper.
 
 ## Using the skill from Claude Code
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,0 +1,62 @@
+# Triaging Antithesis reports
+
+Antithesis delivers test-run results as HTML pages behind single-use signed URLs (PASETO v2.public in the querystring) and notifies the requester via email. There is **no public REST API, no MCP server, and no webhook-in**; outbound webhooks only trigger runs, they do not return results.
+
+This page documents the state of the art for pulling findings out of a run — in particular for AI coding agents that need to dig into assertion failures without a UI.
+
+## What exists upstream
+
+- **`antithesis-skills`** — [github.com/antithesishq/antithesis-skills](https://github.com/antithesishq/antithesis-skills), announced at [antithesis.com/blog/2026/agent_skills](https://antithesis.com/blog/2026/agent_skills/). A collection of Claude-style agent skills. The relevant one for us is **`antithesis-triage`**: look up runs, check status, investigate failed assertions, view metadata, download logs, inspect findings.
+- **`snouty`** — [github.com/antithesishq/snouty](https://github.com/antithesishq/snouty), their Rust CLI. Commands: `launch`, `validate`, `debug`, `docs`, `update`. Launches runs and searches docs; does **not** fetch reports.
+- **`agent-browser`** — [github.com/vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser), a headless-browser wrapper used by `antithesis-triage` to render the signed report page and feed the DOM to the agent.
+- **Outbound webhook** — [antithesis.com/docs/webhook](https://antithesis.com/docs/webhook/), only for launching runs.
+- **GitHub Action** — [antithesis-trigger-action](https://github.com/antithesishq/antithesis-trigger-action), fire-and-forget.
+
+## How it fits the moog flow
+
+The Cardano testnet runs are launched via [moog](https://github.com/cardano-foundation/moog), which submits a test-request on-chain and the agent delivers the report URL back via the requester's wallet. Decrypt with:
+
+```bash
+moog facts test-runs --whose cfhal --no-pretty \
+  | jq -c '.[] | select(.value.phase == "finished") | {commit: .key.commitId[:8], outcome: .value.outcome, url: .value.url}'
+```
+
+(Run as `being_requester` — the report URL is encrypted for the requester identity and auto-decrypted by `moog facts`.)
+
+The resulting URL is what `antithesis-triage` consumes.
+
+## Prerequisites
+
+`antithesis-triage` requires three tools installed locally:
+
+```bash
+# snouty
+# see https://github.com/antithesishq/snouty#installation
+
+# agent-browser (>= v0.23.4)
+# see https://github.com/vercel-labs/agent-browser#installation
+agent-browser upgrade   # if already installed
+
+# jq
+# https://jqlang.org/download/
+```
+
+## Using the skill from Claude Code
+
+The skill is packaged at `/code/llm-settings/shared/skills/antithesis-triage/` and auto-discovered in Claude Code. Invoke with a report URL or tenant name:
+
+```
+/antithesis-triage
+```
+
+When prompted, paste the decrypted Antithesis URL from `moog facts test-runs` or set `ANTITHESIS_TENANT=cardano` in the shell.
+
+The skill walks through the report, extracts failing Sometimes/Always assertions and bug findings, and can download logs for a specific run.
+
+## What is not available
+
+- **No structured JSON report export.** Only the in-container SDK log (`ANTITHESIS_SDK_LOCAL_OUTPUT`) is structured; the triage report itself is HTML behind PASETO.
+- **No MCP server.** Not in the Antithesis org, not in docs, not in the skills blog post.
+- **No inbound webhook.** Results arrive by email to the requester; nothing is pushed to an HTTP endpoint.
+
+If a programmatic path opens up in the future, the Antithesis skills repo changelog is the place to watch — they flagged "parse triage reports" as a planned skill expansion.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,4 +31,5 @@ nav:
   - Testnets:
       - testnets/index.md
       - Cardano Node Master: testnets/cardano-node-master.md
+  - Triage: triage.md
   - Contributing: contributing.md

--- a/scripts/agent-browser-nixos.sh
+++ b/scripts/agent-browser-nixos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Launches a headless chromium (via nix) with remote-debugging and connects
+# agent-browser to it via CDP. Works around the missing system libraries that
+# prevent agent-browser's bundled Chrome from running on NixOS.
+#
+# Usage:
+#   ./agent-browser-nixos.sh <session-name> <url> [agent-browser args...]
+#
+# Example:
+#   ./agent-browser-nixos.sh triage "https://cardano.antithesis.com/report/..."
+#   agent-browser --session triage get text body
+
+set -euo pipefail
+
+SESSION=${1:?session name required}
+URL=${2:?url required}
+shift 2
+
+PORT=$((9222 + RANDOM % 1000))
+USER_DATA=$(mktemp -d -t chrome-agent-XXXXXX)
+
+cleanup() {
+  [[ -n "${CPID:-}" ]] && kill "$CPID" 2>/dev/null || true
+  rm -rf "$USER_DATA"
+}
+trap cleanup EXIT
+
+chromium \
+  --headless \
+  --disable-gpu \
+  --no-sandbox \
+  --remote-debugging-port="$PORT" \
+  --user-data-dir="$USER_DATA" \
+  "about:blank" >/dev/null 2>&1 &
+CPID=$!
+
+# Wait for devtools to come up
+for _ in {1..10}; do
+  if curl -s "http://localhost:$PORT/json/version" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+
+agent-browser connect "$PORT" --session "$SESSION" >/dev/null
+agent-browser open "$URL" --session "$SESSION" "$@"
+
+# Keep chromium alive for subsequent agent-browser calls from another shell.
+# Comment out the trap cleanup if you want to reuse the session.
+echo "chromium pid=$CPID port=$PORT session=$SESSION"
+echo "run further commands: agent-browser <cmd> --session $SESSION"
+wait "$CPID"


### PR DESCRIPTION
## Summary
- Adds `docs/triage.md` documenting the state of programmatic access to Antithesis test reports.
- Key points: no REST API / MCP / inbound webhook; reports are signed HTML URLs delivered by email; official AI-agent path is Antithesis's own [antithesis-skills](https://github.com/antithesishq/antithesis-skills) (specifically [antithesis-triage](https://github.com/antithesishq/antithesis-skills/tree/main/antithesis-triage)) composed with [snouty](https://github.com/antithesishq/snouty), [agent-browser](https://github.com/vercel-labs/agent-browser), and jq.
- Ties into our moog flow — `moog facts test-runs --whose cfhal` decrypts the signed URL, which feeds `antithesis-triage`.
- Includes `scripts/agent-browser-nixos.sh` — a helper that launches chromium via nix and connects `agent-browser` to it via CDP, working around the missing-shared-libraries problem on NixOS hosts.

## Test plan
- [ ] `just serve-docs` renders the new Triage page
- [ ] Links resolve (Antithesis blog, antithesis-skills, snouty, agent-browser, moog)
- [ ] `scripts/agent-browser-nixos.sh` runs on a NixOS host