### PR TITLE
Surface Warning+ tracer events to Antithesis Logs Explorer

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -199,6 +199,19 @@ services:
       tracer:
         condition: service_started
 
+  log-tailer:
+    image: alpine:3
+    container_name: log-tailer
+    hostname: log-tailer.example
+    entrypoint: ["/bin/sh", "/log-tailer.sh"]
+    volumes:
+      - tracer:/tracer:ro
+      - ./log-tailer.sh:/log-tailer.sh:ro
+    restart: always
+    depends_on:
+      tracer:
+        condition: service_started
+
 volumes:
   tracer:
   p1-configs:

--- a/testnets/cardano_node_master/log-tailer.sh
+++ b/testnets/cardano_node_master/log-tailer.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Tail cardano-tracer ForMachine JSON logs, emit only Warning+ events to stdout.
+# stdout is captured by Antithesis Logs Explorer (indexed as source=log-tailer).
+#
+# cardano-tracer rotates files periodically — we poll for new files every 15s
+# and spawn one background `tail -F` per file, so rotation is picked up without
+# missing events.
+
+set -eu
+
+LOG_ROOT="${LOG_ROOT:-/tracer/logs}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+PATTERN="${PATTERN:-\"sev\":\"(Warning|Error|Critical)\"}"
+
+SEEN=/tmp/log-tailer-seen
+mkdir -p "$SEEN"
+
+start_tail() {
+  f="$1"
+  key=$(printf '%s' "$f" | tr -c 'a-zA-Z0-9' _)
+  [ -e "$SEEN/$key" ] && return
+  touch "$SEEN/$key"
+  tail -n +1 -F "$f" 2>/dev/null \
+    | awk -v p="$PATTERN" '$0 ~ p { print; fflush() }' &
+}
+
+while :; do
+  for f in "$LOG_ROOT"/*/node-*.json; do
+    [ -f "$f" ] && start_tail "$f"
+  done
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Problem

Antithesis Logs Explorer indexes **container stdout only**. The rich per-node trace stream that `cardano-tracer` writes to the shared tracer volume never reaches the triage report, so failed-run investigations show \"zero tracer log events\" despite the volume holding 1–2 MB of ForMachine JSON per host.

See the triage notes added in #42 — section \"Log sources — what Antithesis indexes and what it does not\" for the empirical verification (`TraceAddBlockEvent` = 0, `ForgedBlock` = 0, `ConnectionHandler` = 0 hits on PR #41's run).

## Change

Add a `log-tailer` sidecar that:
- mounts the shared `tracer` volume **read-only**
- polls every 15s for new `node-*.json` files (rotation-safe)
- spawns one `tail -F` per file, piping through `awk` that matches `\"sev\":\"(Warning|Error|Critical)\"`
- surviving lines go to stdout → Antithesis indexes them as `source=log-tailer`

Severity filter keeps load to **~0.3%** of total tracer volume (259 Warning+ events out of 78,485 total lines in the smoke test) while surfacing every real problem: `ConnectionError`, `NotEnoughBigLedgerPeers`, `ShutdownArmedAt`, `TracerConsistencyWarnings`, etc.

## Local verification

| Scenario | Tailer PID | Restarts | Outcome |
|---|---|---|---|
| Baseline smoke test | — | — | 500 Warning+ lines surfaced from existing volume |
| Kill `p1` (producer) + restart | unchanged | 0 | tracer rotated `p1/node-*.json`, tailer picked up new file via 15s poll |
| Kill `tracer` + restart | unchanged | 0 | tracer rotated all 5 host files on reconnect, tailer picked them all up |

## Follow-up

Tailer is subject to Antithesis fault injection like any other container; on kill it rescans from line 1 on restart, so duplicates in the index but no gap. Out-of-band ask to Antithesis support for chaos exemption is in flight.