### PR TITLE
tools: add query-logs — headless CLI for Antithesis Logs Explorer

### DIFF
--- a/tools/query-logs/README.md
+++ b/tools/query-logs/README.md
@@ -1,0 +1,193 @@
+# antithesis-query-logs
+
+> **Status: workaround, not a supported API.**
+> Antithesis does not currently publish a programmatic interface for
+> their Logs Explorer. This repo is a stopgap — a reverse-engineered
+> client we use to unblock CI and scripted triage until Antithesis ship
+> an official API. Everything here is observable from a logged-in
+> browser session; nothing is privileged. Expect to delete this repo
+> the day a real API lands.
+
+Query [Antithesis Logs Explorer](https://antithesis.com/) for a specific
+test run **without a GUI browser**. Reverse-engineered recipe for
+pulling matches out of `/search` over CDP.
+
+Works in two modes:
+
+- **Headed** — a real chromium window where you complete Google SSO
+  yourself; the tooling pulls the cookie straight out over CDP.
+- **Headless** — paste a single `Copy as cURL` blob from your laptop's
+  DevTools; the tooling greps the cookie out. No DOM-hunting.
+
+## Prerequisites
+
+- `bb` (Babashka) — <https://babashka.org>
+- `curl`, `base64`, `chromium` (nixpkgs is fine)
+- `agent-browser` on `$PATH` (≥ v0.23.4): `npm install -g agent-browser`
+- A live Antithesis SSO session — you complete the Google login once
+  per ~8h, either through `login.bb` (headed) or by pasting the curl
+  blob (headless)
+
+Set `ANTITHESIS_TENANT` if the tenant is not `cardano` (the default).
+
+## Quickstart
+
+```bash
+# One-time cookie intake (pick A or B below), then:
+scripts/query.bb --latest '"sev":"Warning"' --source log-tailer
+```
+
+Produces a structured summary: match count, breakdown by `source`, by
+`(source, ns, sev)`, and the first 10 distinct rendered rows.
+
+### Selectors (pick one, default `--latest`)
+
+- `--latest` — most recent `Completed` run with a real `session_id`
+- `--commit <sha>` — run whose params mention `<sha>`
+- `--session <id>` — pass the Logs Explorer `s` directly
+
+### Query options
+
+- `--op contains|equals|regex` — matcher on `general.output_text`
+- `--source <name>` — add a `general.source = <name>` AND clause
+- `--count-only` — emit just the integer count (CI-friendly)
+- `--raw` — emit the raw browser body dump, skip parsing
+- `--wait-seconds N` — page-load budget (default 30)
+- `--from-dump <file>` — parse a previously-captured body file instead
+  of launching chromium (useful for debugging the parser)
+
+## Cookie intake
+
+### A. Interactive browser login (requires a display)
+
+```bash
+scripts/login.bb
+```
+
+Opens a real chromium window on the persistent profile
+(`~/.cache/agent-browser-triage/profile`), navigates to
+`https://<tenant>.antithesis.com/`, and waits for you on stderr:
+
+```
+A chromium window is open. Complete the Google login flow.
+When you see the tenant dashboard, come back here and press Enter.
+>
+```
+
+Complete the Google SSO flow normally, return to the terminal, press
+Enter. `login.bb` reads `__Host-antithesis_sso_session` out of chromium
+over CDP, writes it to `$ANTITHESIS_COOKIE_FILE` (default
+`/tmp/antithesis-cookie.txt`) at mode 0600, and prints nickname +
+expiry + a `root=302 follow=200` sanity check. The persistent profile
+keeps Google session state between runs, so subsequent logins are
+often a single click.
+
+`login.bb` fails fast with a helpful message if `$DISPLAY` and
+`$WAYLAND_DISPLAY` are both unset. Use path B on headless machines.
+
+### B. Paste from DevTools (headless machines)
+
+```bash
+scripts/set-cookie.sh
+```
+
+Accepts either shape:
+
+- the bare PASETO value (`v2.public.…`), or
+- the entire `Copy as cURL` blob from DevTools' Network tab — the
+  script greps `__Host-antithesis_sso_session=v2.public.…` out itself.
+
+The fast sequence: in your laptop's already-logged-in tab on
+`<tenant>.antithesis.com`, open DevTools → Network → right-click **any**
+request → **Copy → Copy as cURL**. SSH to the headless machine, run
+the command above, paste the entire curl blob, Enter.
+
+The read prompt is silent (`read -rs`) so the value does **not** land
+in shell history, terminal scrollback, or any transcript the session
+may be capturing.
+
+## Find a run (when not using `--latest`)
+
+```bash
+scripts/pangolin-runs.bb --session-ids            # table: time + session_id
+scripts/pangolin-runs.bb --latest-completed       # single session_id
+scripts/pangolin-runs.bb --by-commit <sha>        # JSONL, filtered
+scripts/pangolin-runs.bb                          # raw JSONL of all runs
+```
+
+### Why the three magic headers are mandatory
+
+`/api/pangolin/v1/WYATT/kv_table/runs` returns **403** with just the
+SSO cookie. It only flips to 200 SSE when the request includes **all
+three**:
+
+- `X-Antithesis-Allow-Effects: 1`
+- A browser `User-Agent`
+- `content-type: application/json`
+
+Missing any one = empty-body 403 that looks like an auth failure.
+`pangolin-runs.bb` sets all three.
+
+### Why session_ids are filtered
+
+Webhook aggregator runs (e.g. `tenant_data_aggregator.nb2`) show up
+with a synthetic session_id like `"OTIS"` that does not open in Logs
+Explorer. The resolver only accepts ids matching
+`^[0-9a-f]{32}-\d+-\d+$`.
+
+## Build & open the search directly
+
+`query.bb` wraps both, but the primitives are independently useful:
+
+```bash
+scripts/build-search-url.bb <session_id> <needle> [--op OP] [--source NAME]
+scripts/open-search.bb      <session_id> <needle> [--op OP] [--source NAME] [--wait-seconds N]
+```
+
+`open-search.bb` launches chromium (headless) on a random CDP port,
+injects the cookie at the tenant origin, navigates to the encoded URL,
+clicks the primary **Search** button
+(`<a-button variant="primary" icon="search">` — **not** the play-icon
+`.action_run_button_wrapper`, which stays disabled until validation),
+and polls the DOM for the results pane to render and for
+`Initializing query…` / `Loading results` to clear before dumping.
+
+The full body is always written to `/tmp/open-search-last.txt` so a
+failed run is inspectable without rerunning.
+
+On failure, see [`references/driver-troubleshooting.md`](references/driver-troubleshooting.md).
+
+## What Antithesis actually indexes
+
+Load [`references/indexed-sources.md`](references/indexed-sources.md)
+before querying for a string that cannot possibly appear. Short
+version: **container stdout only**. If a log stream lives inside a
+docker volume it is not captured. For per-node tracer events indexed
+by Antithesis, emit them via a sidecar that tails the file out to its
+own stdout (e.g. a `log-tailer` container).
+
+## Common failure modes
+
+| Symptom | Likely cause |
+|---|---|
+| `root=302 follow=302` from set-cookie | Cookie expired or wrong tenant |
+| `403` from pangolin-runs | Missing one of the three mandatory headers |
+| Resolver returns `OTIS` | session-id-pattern filter bypassed — bug |
+| Search page loads but no results | Button click not firing — check selector, check `/tmp/open-search-last.txt` |
+| `session_id` mismatch | Using the GUI's `testRunId`; use the pangolin resolver's id |
+| Chromium exits immediately (exit 144) | Sandboxed host; re-run from an unrestricted shell |
+| `login.bb`: `error: no display available` | You're on a headless host — switch to path B |
+
+## Self-review before reporting results
+
+- Did the pangolin fetch return the run you expected? Cross-check
+  commit, try, and `antithesis.images` against what you submitted.
+- Is the `session_id` present (non-empty) for that run? Runs that
+  failed to start (image-pull timeout) have no `session_id`.
+- Did the search page actually render results, or is it stuck on the
+  "Explore your logs" empty state? Empty state = zero matches (a
+  valid negative), not an error.
+
+## License
+
+Apache 2.0 — inherits the repo's top-level [LICENSE](../../LICENSE).

--- a/tools/query-logs/references/driver-troubleshooting.md
+++ b/tools/query-logs/references/driver-troubleshooting.md
@@ -1,0 +1,73 @@
+# open-search.sh troubleshooting
+
+## Chromium won't start
+
+Symptom: `chromium-query-logs.log` shows a missing-library error
+(`libglib-2.0`, `libnspr4`, etc.). Cause: on NixOS, `agent-browser
+install` downloads a Chrome for Testing binary that is dynamically
+linked against glibc-world system libraries not present on a Nix
+host.
+
+Fix: use the nixpkgs chromium. `scripts/open-search.sh` already does
+this — it never asks agent-browser to auto-launch. If you are running
+the commands manually, invoke chromium from `~/.nix-profile/bin`.
+
+## Page loads but search field is empty
+
+Symptom: navigation succeeds but the text dump shows the default
+"Explore your logs" empty state and no query. Cause: the URL's
+`search=v5v…` parameter decoded to something the SPA rejected, so it
+fell back to the empty builder.
+
+Debug: decode your b64 back to JSON and validate against
+`references/search-url-format.md`. Common mistakes:
+
+- Forgot to strip base64 padding (`=` chars).
+- Forgot to url-safe-encode (`+/` → `-_`).
+- Added the `v5v` prefix *inside* the base64 string rather than outside.
+
+## Button click does nothing
+
+The primary Search button is
+`<a-button variant="primary" icon="search">`. The other play-shaped
+button `.action_run_button_wrapper` (`icon="play"`) stays **disabled**
+until query validation — clicking it never fires.
+
+Keyboard alternative: focus the query field, `Ctrl+Enter`.
+
+## Results never appear
+
+Symptom: networkidle never resolves and the text dump stays on the
+loading spinner. Cause: either the session_id is invalid (silent
+failure — see `indexed-sources.md`) or the backend is rate-limiting.
+
+Debug: open the same URL in a real browser with the same cookie. If it
+also hangs, the session_id is stale. If it loads quickly in a real
+browser but hangs in headless, bump the `sleep` in `open-search.sh`.
+
+## Cookie is rejected by the page
+
+Symptom: `get url` after open returns something on `antithesis.com`
+(the login host) instead of `<tenant>.antithesis.com`. Cause: cookie
+expired — PASETO `exp` is typically 8-9h after issue.
+
+Fix: re-run `scripts/set-cookie.sh` with a fresh value. The helper's
+end-of-run sanity check would have caught this at intake time.
+
+## Persistent profile conflicts
+
+`scripts/open-search.sh` uses
+`~/.cache/agent-browser-triage/profile` for the chromium user data
+directory. If a prior chromium didn't shut down cleanly its SingletonLock
+will block a fresh launch. Remove the lock or kill stale processes:
+
+```bash
+rm -f ~/.cache/agent-browser-triage/profile/Singleton*
+pkill -f 'chromium.*remote-debugging-port' || true
+```
+
+## Parallel calls
+
+`agent-browser` is stateful per session. **Do not** fan out multiple
+`agent-browser eval` calls against the same session in parallel — the
+results cross-contaminate and error messages become misleading.

--- a/tools/query-logs/references/indexed-sources.md
+++ b/tools/query-logs/references/indexed-sources.md
@@ -1,0 +1,60 @@
+# What Antithesis indexes and what it does not
+
+The triage report's Logs Explorer covers **container stdout only** for
+cardano-foundation tenant testnets. Anything that goes to a file inside
+a container, or to a shared docker volume, is invisible — even if it is
+later read by another container.
+
+| Source | Goes where | Captured? |
+|---|---|---|
+| `cardano-node` stdout | docker logs (~16-18 lines: startup banner + one-off `Reflection.TracerInfo` / `Reflection.TracerConfigInfo` JSON) | **Yes** — indexed as `general.output_text`, `source=pN` |
+| `cardano-node` tracer stream | forwarded over the tracer socket to `cardano-tracer`, which writes ForMachine JSON to `/opt/cardano-tracer/logs/<host>_3001/node-*.json` on the shared `tracer` docker volume | **No** — volume files are not archived |
+| `cardano-tracer` stdout | docker logs | Yes |
+| sidecars (`tracer-sidecar`, `sidecar`, `configurator`) | docker logs | Yes — this is where Antithesis SDK assertions are emitted |
+| `log-tailer` sidecar | docker logs (after workaround) | Yes — see below |
+
+## Empirical confirmation
+
+Run `s=4a229d0363682145d1831acdf28952a7-50-7`:
+
+| Needle | Match count | Interpretation |
+|---|---:|---|
+| `TracerMeta` | 7,415 | Indexed — startup reflection JSON |
+| `AddedBlockToVolatileDB` | 7,467 | Indexed — but only inside the startup `TracerConfigInfo` JSON that happens to list namespace names; no actual block events |
+| `TraceAddBlockEvent` | 0 | **Not** indexed — steady-state block trace |
+| `ForgedBlock` | 0 | **Not** indexed — forge event |
+| `ConnectionHandler` | 0 | **Not** indexed — mux/connection trace |
+
+So the rich per-node trace stream (1-2 MB per host after 30 minutes,
+locally verified) exists on disk in the `tracer` volume but never
+reaches triage.
+
+## The log-tailer workaround
+
+Added in `cardano-foundation/antithesis-tx-gen-and-ogmios` PR #44. A
+tiny Alpine sidecar mounts the `tracer` volume read-only, polls the
+log directory, and `tail -F`s every `node-*.json` file to its own
+stdout — filtered to `sev ∈ {Warning, Error, Critical}` so we do not
+bury the stream in routine noise.
+
+Each emitted line becomes an indexed `general.output_text` event under
+`source=log-tailer`. To verify it is working on a specific run:
+
+```bash
+./scripts/open-search.sh <session_id> '"sev":"Warning"'
+```
+
+Zero matches during steady-state operation is a valid result — the
+testnet may simply not have hit any Warnings. To prove the sidecar is
+connected regardless, search for something it always emits at startup
+(e.g. a tracer namespace that appears on boot).
+
+## Do not trust apparent matches on config-echo JSON
+
+`AddedBlockToVolatileDB` returns thousands of hits but every one is
+inside the same startup `TracerConfigInfo` event that lists every
+tracer namespace name. It is not evidence that block events are
+indexed. Any string that appears in the namespace catalogue will
+match this way. When checking if a specific trace type is captured,
+search for a value that would only appear at runtime (e.g. a slot
+number, a hash, a severity field) rather than a namespace label.

--- a/tools/query-logs/references/search-url-format.md
+++ b/tools/query-logs/references/search-url-format.md
@@ -1,0 +1,84 @@
+# Logs Explorer /search URL format
+
+The Logs Explorer encodes its entire query state into a single URL
+parameter so that any search can be reproduced just by sharing the link.
+
+## Overall URL
+
+```
+https://<tenant>.antithesis.com/search?search=v5v<base64url(json)>&report_name=&get_logs=false&get_logs_event_desc=
+```
+
+- `v5v` is a literal schema marker — **not** part of the base64.
+- The base64 is url-safe (`+`→`-`, `/`→`_`) with padding stripped.
+- `report_name`, `get_logs`, `get_logs_event_desc` are always present
+  but typically empty for ad-hoc queries.
+
+## JSON shape
+
+```json
+{
+  "q": {
+    "n": {
+      "r": {
+        "h": [
+          {
+            "h": [
+              {
+                "c": false,
+                "f": "general.output_text",
+                "o": "contains",
+                "v": "<needle>"
+              }
+            ],
+            "o": "or"
+          }
+        ],
+        "o": "and"
+      },
+      "t": {"g": false, "m": ""},
+      "y": "none"
+    }
+  },
+  "s": "<session_id>"
+}
+```
+
+### Field by field
+
+| Path | Meaning |
+|---|---|
+| `q.n` | The query tree |
+| `q.n.r` | Root clause — an AND of OR groups |
+| `q.n.r.h[]` | AND-joined groups |
+| `q.n.r.h[].h[]` | Leaves within one OR group |
+| `q.n.r.h[].h[].c` | Case-sensitive flag (bool) |
+| `q.n.r.h[].h[].f` | Field name, e.g. `general.output_text` |
+| `q.n.r.h[].h[].o` | Operator: `contains` / `equals` / `regex` |
+| `q.n.r.h[].h[].v` | Value |
+| `q.n.r.h[].o` | How leaves combine: `or` / `and` |
+| `q.n.r.o` | How groups combine: `and` / `or` |
+| `q.n.t` | Time filter (`g` = has-range bool, `m` = mode) |
+| `q.n.y` | Correlation type (`none`, `event`, ...) |
+| `s` | Session id `<hex32>-<major>-<minor>` (the run) |
+
+### Known fields to filter on
+
+- `general.output_text` — stdout content of any container
+- `general.source` — emitter name (e.g. `p1`, `log-tailer`)
+- `general.container` — docker container name
+- `general.virtual_time` — simulated wall-clock
+
+You can usually get away with adding a clause to filter by
+`general.source = log-tailer` to isolate one sidecar's output.
+
+## Why the indirection
+
+The app is a SPA with a Monaco-based query builder. Every edit of the
+builder re-serialises to this JSON and pushes a new URL. The backend
+renders the same query from the URL on first load, so URLs are
+reproducible and shareable.
+
+If the `s` is stale/invalid the page loads but returns zero results
+silently — there is no 4xx response. Always cross-check against
+pangolin's `kv_table/runs` that the session_id exists.

--- a/tools/query-logs/scripts/build-search-url.bb
+++ b/tools/query-logs/scripts/build-search-url.bb
@@ -1,0 +1,57 @@
+#!/usr/bin/env bb
+
+;; Build a Logs Explorer /search URL for a given run session_id and needle.
+;;
+;; Usage:
+;;   build-search-url.bb <session_id> <needle> [--op contains|equals|regex]
+;;                                             [--source <name>]
+;;
+;; The session_id is the Logs Explorer "s" identifier (format
+;; <hex32>-<major>-<minor>), NOT the testRunId.
+
+(require '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+(def tenant (or (System/getenv "ANTITHESIS_TENANT") "cardano"))
+
+(defn parse-args [argv]
+  (loop [args argv
+         out  {:op "contains" :source nil :positional []}]
+    (if (empty? args)
+      out
+      (case (first args)
+        "--op"     (recur (drop 2 args) (assoc out :op (second args)))
+        "--source" (recur (drop 2 args) (assoc out :source (second args)))
+        (recur (rest args)
+               (update out :positional conj (first args)))))))
+
+(defn b64url-nopad [s]
+  (-> (.encodeToString (java.util.Base64/getUrlEncoder) (.getBytes s "UTF-8"))
+      (str/replace #"=+$" "")))
+
+(defn build-query-json
+  "Each leaf goes into its own inner group (h[].h[] of length 1, inner o=\"or\"),
+   and the groups are joined by the outer AND. The Monaco query builder
+   serialises to this shape; collapsing both leaves into a single inner group
+   is rejected silently (the SPA falls back to the empty builder)."
+  [{:keys [sid needle op source]}]
+  (let [needle-group {:h [{:c false :f "general.output_text" :o op :v needle}] :o "or"}
+        source-group (when source
+                       {:h [{:c false :f "general.source" :o "equals" :v source}] :o "or"})
+        groups       (cond-> [needle-group]
+                       source-group (conj source-group))]
+    {:q {:n {:r {:h groups :o "and"}
+             :t {:g false :m ""}
+             :y "none"}}
+     :s sid}))
+
+(let [{:keys [op source positional]} (parse-args *command-line-args*)
+      [sid needle] positional]
+  (when (or (nil? sid) (nil? needle))
+    (binding [*out* *err*]
+      (println "usage: build-search-url.bb <session_id> <needle> [--op OP] [--source NAME]"))
+    (System/exit 2))
+  (let [json-str (json/generate-string (build-query-json {:sid sid :needle needle :op op :source source}))
+        b64 (b64url-nopad json-str)]
+    (println (str "https://" tenant ".antithesis.com/search?search=v5v" b64
+                  "&report_name=&get_logs=false&get_logs_event_desc="))))

--- a/tools/query-logs/scripts/login.bb
+++ b/tools/query-logs/scripts/login.bb
@@ -1,0 +1,163 @@
+#!/usr/bin/env bb
+
+;; One-time interactive login. Launches a real chromium window on the
+;; persistent profile, lets you complete Google SSO by hand, then pulls
+;; __Host-antithesis_sso_session out over CDP and writes it to the same
+;; $ANTITHESIS_COOKIE_FILE set-cookie.sh uses. No DevTools, no paste.
+;;
+;; Usage:
+;;
+;;   scripts/login.bb
+;;
+;; Re-run whenever the cookie expires (~8–9h). The persistent profile
+;; keeps Google session state between runs, so subsequent logins are
+;; often a single click.
+;;
+;; If you invoke this from inside an agent harness that captures tool
+;; stdout into a transcript, invoke it via the harness's shell-passthrough
+;; prefix so the interactive Enter prompt reads from your terminal.
+
+(require '[babashka.process :refer [shell process]]
+         '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+(def tenant (or (System/getenv "ANTITHESIS_TENANT") "cardano"))
+(def cookie-file (or (System/getenv "ANTITHESIS_COOKIE_FILE") "/tmp/antithesis-cookie.txt"))
+(def profile (or (System/getenv "AGENT_BROWSER_PROFILE")
+                 (str (System/getProperty "user.home") "/.cache/agent-browser-triage/profile")))
+(def session (str "antithesis-login-" (.pid (java.lang.ProcessHandle/current))))
+(def cookie-name "__Host-antithesis_sso_session")
+
+(defn die [msg & {:keys [code] :or {code 1}}]
+  (binding [*out* *err*] (println msg))
+  (System/exit code))
+
+(defn npm-path-prepended []
+  (str (System/getProperty "user.home") "/.local/npm-global/bin:" (System/getenv "PATH")))
+
+(defn resolve-bin [bin]
+  (let [res (shell {:out :string :err :string :continue true
+                    :extra-env {"PATH" (npm-path-prepended)}}
+                   "which" bin)]
+    (when (zero? (:exit res)) (str/trim (:out res)))))
+
+(def agent-browser-bin (delay (or (resolve-bin "agent-browser")
+                                  (die "error: agent-browser not in PATH"))))
+(def chromium-bin      (delay (or (resolve-bin "chromium")
+                                  (die "error: chromium not in PATH"))))
+
+(defn ab [& args]
+  (apply shell {:out :string :err :string :continue true}
+         @agent-browser-bin (concat args ["--session" session])))
+
+(defn wait-for-port [port attempts]
+  (loop [n attempts]
+    (let [res (shell {:out :string :err :string :continue true}
+                     "curl" "-s" (str "http://localhost:" port "/json/version"))]
+      (cond
+        (zero? (:exit res)) true
+        (zero? n) false
+        :else (do (Thread/sleep 250) (recur (dec n)))))))
+
+(defn decode-paseto-payload
+  "v2.public layout is 'v2.public.' + base64url(payload_json || ed25519_sig[64]).
+   Returns the JSON string."
+  [paseto]
+  (let [b64   (subs paseto (count "v2.public."))
+        pad   (mod (- 4 (mod (count b64) 4)) 4)
+        b64p  (str b64 (apply str (repeat pad \=)))
+        raw-b (.decode (java.util.Base64/getUrlDecoder) b64p)
+        n     (alength raw-b)
+        json-b (byte-array (take (- n 64) raw-b))]
+    (String. json-b "UTF-8")))
+
+(defn sanity-check [cookie]
+  (let [root (shell {:out :string :err :string :continue true}
+                    "curl" "-s" "-o" "/dev/null" "-w" "%{http_code}"
+                    "-b" (str cookie-name "=" cookie)
+                    (str "https://" tenant ".antithesis.com/"))
+        home (shell {:out :string :err :string :continue true}
+                    "curl" "-sL" "-o" "/dev/null" "-w" "%{http_code}"
+                    "-b" (str cookie-name "=" cookie)
+                    (str "https://" tenant ".antithesis.com/"))]
+    [(:out root) (:out home)]))
+
+(defn prompt-enter! []
+  (binding [*out* *err*]
+    (println)
+    (println "A chromium window is open. Complete the Google login flow.")
+    (println "When you see the tenant dashboard, come back here and press Enter.")
+    (print "> ")
+    (flush))
+  (.readLine (java.io.BufferedReader. (java.io.InputStreamReader. System/in))))
+
+;; ---- main ----
+@agent-browser-bin
+@chromium-bin
+
+(when (and (str/blank? (System/getenv "DISPLAY"))
+           (str/blank? (System/getenv "WAYLAND_DISPLAY")))
+  (die (str "error: no display available — login.bb needs a graphical session.\n"
+            "On a headless machine, do the login in your laptop's browser and\n"
+            "pipe the cookie over with set-cookie.sh:\n"
+            "\n"
+            "  1. In your laptop's DevTools Network tab, right-click any\n"
+            "     <tenant>.antithesis.com request → Copy → Copy as cURL.\n"
+            "  2. ssh to this machine and run:\n"
+            "       scripts/set-cookie.sh\n"
+            "  3. Paste the whole curl blob and press Enter. The script greps\n"
+            "     __Host-antithesis_sso_session out for you.")
+       :code 4))
+
+(.mkdirs (java.io.File. profile))
+(doseq [f (.listFiles (java.io.File. profile))]
+  (when (str/starts-with? (.getName f) "Singleton") (.delete f)))
+
+(let [port     (+ 9222 (rand-int 1000))
+      log-file (java.io.File. "/tmp/chromium-login.log")
+      chrome   (process [@chromium-bin
+                         (str "--remote-debugging-port=" port)
+                         (str "--user-data-dir=" profile)
+                         "--no-first-run" "--no-default-browser-check"
+                         (str "https://" tenant ".antithesis.com/")]
+                        {:out log-file :err log-file})]
+  (try
+    (when-not (wait-for-port port 80)
+      (die "chromium did not open CDP port"))
+    (ab "connect" (str port))
+
+    (prompt-enter!)
+
+    (let [{:keys [exit out err]} (ab "cookies" "get" "--json")]
+      (when-not (zero? exit)
+        (die (str "cookies get failed: " err)))
+      (let [entries (try (json/parse-string out true)
+                         (catch Exception _ (die (str "could not parse cookies JSON"))))
+            hit (->> entries
+                     (filter #(= cookie-name (:name %)))
+                     (filter #(str/starts-with? (or (:value %) "") "v2.public."))
+                     first)]
+        (when-not hit
+          (die (str "no " cookie-name " cookie found — did the login finish?")))
+        (let [value (:value hit)
+              payload (try (decode-paseto-payload value) (catch Exception _ ""))
+              nickname (second (re-find #"\"nickname\":\"([^\"]+)\"" payload))
+              expiry   (second (re-find #"\"exp\":\"([^\"]+)\"" payload))]
+          (spit cookie-file value)
+          (.setReadable (java.io.File. cookie-file) false false)
+          (.setReadable (java.io.File. cookie-file) true true)
+          (.setWritable (java.io.File. cookie-file) false false)
+          (.setWritable (java.io.File. cookie-file) true true)
+          (println (str "wrote " cookie-file " (len=" (count value) ")"))
+          (when nickname (println (str "user:    " nickname)))
+          (when expiry   (println (str "expires: " expiry)))
+          (let [[root home] (sanity-check value)]
+            (println (str "tenant:  " tenant ".antithesis.com  root=" root "  follow=" home))
+            (when-not (and (= "302" root) (= "200" home))
+              (binding [*out* *err*]
+                (println "warn: unexpected HTTP codes — cookie may be invalid or tenant wrong"))
+              (System/exit 2))))))
+
+    (finally
+      (ab "close")
+      (.destroy (:proc chrome)))))

--- a/tools/query-logs/scripts/open-search.bb
+++ b/tools/query-logs/scripts/open-search.bb
@@ -1,0 +1,181 @@
+#!/usr/bin/env bb
+
+;; Drive the Logs Explorer /search page through a CDP-attached chromium and
+;; dump the rendered results.
+;;
+;; Usage:
+;;   open-search.bb <session_id> <needle> [--op OP] [--source NAME]
+;;                                        [--wait-seconds N]
+
+(require '[babashka.process :refer [shell process]]
+         '[clojure.string :as str])
+
+(def here (-> *file* java.io.File. .getAbsoluteFile .getParent))
+(def tenant (or (System/getenv "ANTITHESIS_TENANT") "cardano"))
+(def cookie-file (or (System/getenv "ANTITHESIS_COOKIE_FILE") "/tmp/antithesis-cookie.txt"))
+(def profile (or (System/getenv "AGENT_BROWSER_PROFILE")
+                 (str (System/getProperty "user.home") "/.cache/agent-browser-triage/profile")))
+(def session (or (System/getenv "SESSION")
+                 (str "antithesis-query-" (.pid (java.lang.ProcessHandle/current)))))
+
+(defn die [msg & {:keys [code] :or {code 1}}]
+  (binding [*out* *err*] (println msg))
+  (System/exit code))
+
+(defn parse-args [argv]
+  (loop [args argv
+         out  {:wait-seconds 30 :forward [] :positional []}]
+    (if (empty? args)
+      out
+      (case (first args)
+        "--wait-seconds" (recur (drop 2 args) (assoc out :wait-seconds (Long/parseLong (second args))))
+        ("--op" "--source") (recur (drop 2 args) (update out :forward into [(first args) (second args)]))
+        (recur (rest args) (update out :positional conj (first args)))))))
+
+(defn npm-path-prepended []
+  (str (System/getProperty "user.home") "/.local/npm-global/bin:" (System/getenv "PATH")))
+
+(defn resolve-bin
+  "Find an executable on the augmented PATH. Java's Runtime.exec resolves
+   the program name against the PARENT process's PATH, ignoring :extra-env,
+   so we have to hand it an absolute path."
+  [bin]
+  (let [res (shell {:out :string :err :string :continue true
+                    :extra-env {"PATH" (npm-path-prepended)}}
+                   "which" bin)]
+    (when (zero? (:exit res))
+      (str/trim (:out res)))))
+
+(def agent-browser-bin (delay (or (resolve-bin "agent-browser")
+                                  (die "error: agent-browser not in PATH"))))
+(def chromium-bin      (delay (or (resolve-bin "chromium")
+                                  (die "error: chromium not in PATH"))))
+
+(defn build-url [sid needle forward]
+  (let [res (apply shell {:out :string :err :string :continue true}
+                   (str here "/build-search-url.bb") sid needle forward)]
+    (when-not (zero? (:exit res))
+      (die (str "build-search-url failed: " (:err res))))
+    (str/trim (:out res))))
+
+(defn wait-for-port [port attempts]
+  (loop [n attempts]
+    (let [res (shell {:out :string :err :string :continue true}
+                     "curl" "-s" (str "http://localhost:" port "/json/version"))]
+      (cond
+        (zero? (:exit res)) true
+        (zero? n) false
+        :else (do (Thread/sleep 250) (recur (dec n)))))))
+
+(defn ab [session-name & args]
+  (apply shell {:out :string :err :string :continue true}
+         @agent-browser-bin (concat args ["--session" session-name])))
+
+(defn saw-results? [body]
+  ;; The results pane has rendered — either a real count, or any of the
+  ;; placeholder/loading phrases the SPA shows while the query runs.
+  (and (not (str/blank? body))
+       (or (re-find #"[0-9,]+ matching events" body)
+           (re-find #"No matching events found" body)
+           (re-find #"No results found" body)
+           (re-find #"Initializing query" body)
+           (re-find #"Loading results" body))))
+
+(defn load-finished? [body]
+  ;; A final state is either a concrete count or a definitive empty result.
+  ;; "No matching events found yet" with "Initializing query..." still on
+  ;; screen is NOT final — the SPA hasn't produced its first count yet.
+  (and (not (str/blank? body))
+       (not (re-find #"Initializing query" body))
+       (not (re-find #"Loading results" body))
+       (or (re-find #"[0-9,]+ matching events" body)
+           (re-find #"No results found" body))))
+
+(defn poll-body
+  "Two-phase wait:
+   (1) block until the results pane has rendered (spinner or count line
+       visible), capped at wait-seconds/2,
+   (2) then wait for 'Loading results' to disappear, capped at remaining
+       budget. Returns the last body regardless of whether the deadline
+       was hit, so the caller can still dump what's there for debugging."
+  [wait-seconds]
+  (let [deadline (+ (System/currentTimeMillis) (* wait-seconds 1000))
+        phase1-deadline (+ (System/currentTimeMillis) (* (quot wait-seconds 2) 1000))]
+    ;; Phase 1: wait for the results pane to appear.
+    (loop [last-body ""]
+      (let [res (ab session "get" "text" "body")
+            body (if (zero? (:exit res)) (:out res) last-body)]
+        (cond
+          (saw-results? body)
+          ;; Phase 2: wait for loading to finish.
+          (loop [b body]
+            (cond
+              (load-finished? b) b
+              (>= (System/currentTimeMillis) deadline) b
+              :else
+              (do (Thread/sleep 1000)
+                  (let [r2 (ab session "get" "text" "body")]
+                    (recur (if (zero? (:exit r2)) (:out r2) b))))))
+
+          (>= (System/currentTimeMillis) phase1-deadline) body
+          :else (do (Thread/sleep 1000) (recur body)))))))
+
+(let [{:keys [wait-seconds forward positional]} (parse-args *command-line-args*)
+      [sid needle] positional]
+  (when (or (nil? sid) (nil? needle))
+    (die "usage: open-search.bb <session_id> <needle> [--op OP] [--source NAME] [--wait-seconds N]" :code 2))
+  (when-not (.canRead (java.io.File. cookie-file))
+    (die (str "error: " cookie-file " missing — run set-cookie.sh")))
+  @agent-browser-bin
+  @chromium-bin
+
+  (let [cookie (str/trim (slurp cookie-file))
+        url    (build-url sid needle forward)
+        port   (+ 9222 (rand-int 1000))]
+
+    (.mkdirs (java.io.File. profile))
+    ;; Clear stale SingletonLocks from prior runs.
+    (doseq [f (.listFiles (java.io.File. profile))]
+      (when (str/starts-with? (.getName f) "Singleton")
+        (.delete f)))
+
+    (let [log-file (java.io.File. "/tmp/chromium-query-logs.log")
+          chrome  (process [@chromium-bin
+                            (str "--remote-debugging-port=" port)
+                            (str "--user-data-dir=" profile)
+                            "--no-first-run" "--no-default-browser-check"
+                            "--disable-gpu" "--headless=new" "about:blank"]
+                           {:out log-file :err log-file})]
+      (try
+        (when-not (wait-for-port port 40)
+          (die "chromium did not open CDP port"))
+
+        (ab session "connect" (str port))
+        (ab session "open" (str "https://" tenant ".antithesis.com/dashboard/assets/feature_tests.js"))
+        (ab session "cookies" "set" "__Host-antithesis_sso_session" cookie
+            "--url" (str "https://" tenant ".antithesis.com/")
+            "--path" "/" "--secure" "--httpOnly" "--sameSite" "Lax")
+        (ab session "open" url)
+
+        ;; Give the query builder time to parse the URL, then click the primary
+        ;; Search button — the play-icon one stays disabled. Sleep matches the
+        ;; working shell version; 3s was too short for the SPA to materialise
+        ;; the populated clauses before the click fired.
+        (Thread/sleep 6000)
+        (ab session "click" "a-button[variant=\"primary\"][icon=\"search\"]")
+        (Thread/sleep 1000)
+
+        (let [body (poll-body wait-seconds)]
+          ;; Always dump the full body to /tmp so a failed run is inspectable
+          ;; without having to rerun the query.
+          (spit "/tmp/open-search-last.txt" body)
+          (println "=== URL ===")
+          (println url)
+          (println)
+          (println "=== Body ===")
+          (let [m (re-find #"(?s)Search results.*?Explore your logs" body)]
+            (println (or m body))))
+
+        (finally
+          (ab session "close")
+          (.destroy (:proc chrome)))))))

--- a/tools/query-logs/scripts/pangolin-runs.bb
+++ b/tools/query-logs/scripts/pangolin-runs.bb
@@ -1,0 +1,128 @@
+#!/usr/bin/env bb
+
+;; Stream the tenant's kv_table/runs SSE endpoint and emit run records.
+;;
+;; Usage:
+;;   pangolin-runs.bb                   # JSONL: one run per line
+;;   pangolin-runs.bb --session-ids     # table: submission_time session_id status findings_new
+;;   pangolin-runs.bb --latest-completed   # single session_id of most recent Completed run
+;;   pangolin-runs.bb --by-commit <sha>    # JSONL filtered to runs mentioning <sha>
+;;
+;; Env:
+;;   ANTITHESIS_COOKIE_FILE   defaults to /tmp/antithesis-cookie.txt
+;;   ANTITHESIS_TENANT        defaults to cardano
+;;
+;; Why the magic headers: /api/pangolin/v1/WYATT/kv_table/runs returns 403
+;; unless the request carries all three of X-Antithesis-Allow-Effects: 1,
+;; a browser User-Agent, and content-type: application/json.
+
+(require '[babashka.process :refer [shell]]
+         '[cheshire.core :as json]
+         '[clojure.string :as str])
+
+(def tenant (or (System/getenv "ANTITHESIS_TENANT") "cardano"))
+(def cookie-file (or (System/getenv "ANTITHESIS_COOKIE_FILE") "/tmp/antithesis-cookie.txt"))
+(def user-agent
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36")
+
+(defn die [msg & {:keys [code] :or {code 1}}]
+  (binding [*out* *err*] (println msg))
+  (System/exit code))
+
+(defn load-cookie []
+  (let [f (java.io.File. cookie-file)]
+    (when-not (.canRead f)
+      (die (str "error: " cookie-file " missing — run set-cookie.sh")))
+    (str/trim (slurp f))))
+
+(defn fetch-runs []
+  ;; The SSE endpoint streams indefinitely; curl exits 28 when --max-time
+  ;; trips. That's expected and the buffered body is still usable, so we
+  ;; only fail if stdout is empty.
+  (let [cookie (load-cookie)
+        res (shell {:out :string :err :string :continue true}
+                   "curl" "-sN" "--max-time" "15"
+                   "-b" (str "__Host-antithesis_sso_session=" cookie)
+                   "-H" "X-Antithesis-Allow-Effects: 1"
+                   "-H" "Cache-Control: no-store"
+                   "-H" "Referer;"
+                   "-H" (str "User-Agent: " user-agent)
+                   "-H" "content-type: application/json"
+                   (str "https://" tenant ".antithesis.com/api/pangolin/v1/WYATT/kv_table/runs"))]
+    (when (str/blank? (:out res))
+      (die (str "curl returned empty body (exit=" (:exit res) " err=" (:err res) ")")))
+    (:out res)))
+
+(defn parse-sse [sse-text]
+  ;; Each frame is "data:{...}\n". Body is {Initial|Added: {key,value}}.
+  (->> (str/split-lines sse-text)
+       (filter #(str/starts-with? % "data:"))
+       (map #(subs % 5))
+       (keep (fn [line]
+               (try
+                 (let [obj (json/parse-string line true)]
+                   (or (:Initial obj) (:Added obj)))
+                 (catch Exception _ nil))))))
+
+(defn emit-session-ids [runs]
+  (let [rows (->> runs
+                  (map (fn [{:keys [value]}]
+                         [(or (:submission_time value) "")
+                          (or (:session_id value) "")
+                          (or (:status value) "")
+                          (or (:findings_new value) 0)]))
+                  (sort-by first #(compare %2 %1)))]
+    (printf "%-22s  %-38s  %-20s  %s%n"
+            "submission_time" "session_id" "status" "findings_new")
+    (doseq [[t sid st fn_] rows]
+      (printf "%-22s  %-38s  %-20s  %s%n" t sid st fn_))))
+
+(def session-id-pattern #"^[0-9a-f]{32}-\d+-\d+$")
+
+(defn testnet-run? [run]
+  ;; Webhook aggregator runs (e.g. tenant_data_aggregator.nb2) carry
+  ;; synthetic session_ids like "OTIS" that won't open in Logs Explorer.
+  ;; Real testnet runs have a <hex32>-<major>-<minor> session_id.
+  (some->> (get-in run [:value :session_id])
+           (re-matches session-id-pattern)))
+
+(defn latest-completed-sid [runs]
+  (->> runs
+       (filter testnet-run?)
+       (filter #(= "Completed" (get-in % [:value :status])))
+       (sort-by #(get-in % [:value :submission_time]) #(compare %2 %1))
+       first
+       :value
+       :session_id))
+
+(defn by-commit [runs sha]
+  ;; A run references its commit in params["antithesis.commit_id"] or
+  ;; params["antithesis.description"] depending on launcher.
+  (filter (fn [{:keys [value]}]
+            (let [params (:params value)
+                  cid    (str (get params (keyword "antithesis.commit_id")) (get params "antithesis.commit_id"))
+                  desc   (str (get params (keyword "antithesis.description")) (get params "antithesis.description"))]
+              (or (str/starts-with? (or cid "") sha)
+                  (str/includes?    (or desc "") sha))))
+          runs))
+
+(let [args *command-line-args*
+      runs (parse-sse (fetch-runs))]
+  (case (first args)
+    "--session-ids"
+    (emit-session-ids runs)
+
+    "--latest-completed"
+    (if-let [sid (latest-completed-sid runs)]
+      (println sid)
+      (die "no completed run found" :code 3))
+
+    "--by-commit"
+    (let [sha (second args)]
+      (when (str/blank? sha) (die "usage: pangolin-runs.bb --by-commit <sha>" :code 2))
+      (doseq [r (by-commit runs sha)]
+        (println (json/generate-string r))))
+
+    ;; default: JSONL
+    (doseq [r runs]
+      (println (json/generate-string r)))))

--- a/tools/query-logs/scripts/query.bb
+++ b/tools/query-logs/scripts/query.bb
@@ -1,0 +1,160 @@
+#!/usr/bin/env bb
+
+;; One-shot Antithesis Logs Explorer query: resolve the run, fire the
+;; search, parse the rendered body, emit a structured summary.
+;;
+;; Usage:
+;;   query.bb [selector] [options] <needle>
+;;
+;; Run selector (default --latest):
+;;   --latest                most recent Completed run on this tenant
+;;   --commit <sha>          run matching <sha> in params
+;;   --session <id>          use this session_id directly
+;;
+;; Query options:
+;;   --op contains|equals|regex   (default contains)
+;;   --source <name>              filter events to source=<name>
+;;   --count-only                 emit just the match count
+;;   --raw                        emit the raw body dump (no parsing)
+;;   --wait-seconds N             max seconds to wait (default 30)
+
+(require '[babashka.process :refer [shell]]
+         '[clojure.string :as str])
+
+(def here (-> *file* java.io.File. .getAbsoluteFile .getParent))
+
+(defn die [msg & {:keys [code] :or {code 1}}]
+  (binding [*out* *err*] (println msg))
+  (System/exit code))
+
+(defn parse-args [argv]
+  (loop [args argv
+         out  {:mode :latest :forward [] :count-only? false :raw? false
+               :from-dump nil :commit nil :session nil :needle nil}]
+    (if (empty? args)
+      out
+      (case (first args)
+        "--latest"       (recur (rest args) (assoc out :mode :latest))
+        "--commit"       (recur (drop 2 args) (assoc out :mode :commit :commit (second args)))
+        "--session"      (recur (drop 2 args) (assoc out :mode :session :session (second args)))
+        "--op"           (recur (drop 2 args) (update out :forward into ["--op" (second args)]))
+        "--source"       (recur (drop 2 args) (update out :forward into ["--source" (second args)]))
+        "--wait-seconds" (recur (drop 2 args) (update out :forward into ["--wait-seconds" (second args)]))
+        "--count-only"   (recur (rest args) (assoc out :count-only? true))
+        "--raw"          (recur (rest args) (assoc out :raw? true))
+        "--from-dump"    (recur (drop 2 args) (assoc out :from-dump (second args)))
+        ("-h" "--help")  (do (shell "sed" "-n" "2,22p" *file*) (System/exit 0))
+        (if (str/starts-with? (first args) "--")
+          (die (str "unknown flag: " (first args)) :code 2)
+          (recur (rest args) (assoc out :needle (first args))))))))
+
+(defn resolve-session-id [{:keys [mode commit session]}]
+  (let [runs (str here "/pangolin-runs.bb")]
+    (case mode
+      :session session
+      :latest  (let [{:keys [out exit err]}
+                     (shell {:out :string :err :string :continue true} runs "--latest-completed")]
+                 (when-not (zero? exit) (die (str "resolver failed: " err) :code 3))
+                 (str/trim out))
+      :commit  (let [{:keys [out exit err]}
+                     (shell {:out :string :err :string :continue true} runs "--by-commit" commit)]
+                 (when-not (zero? exit) (die (str "resolver failed: " err) :code 3))
+                 ;; pick newest match
+                 (->> (str/split-lines out)
+                      (remove str/blank?)
+                      (map #(cheshire.core/parse-string % true))
+                      (sort-by #(get-in % [:value :submission_time]) #(compare %2 %1))
+                      first
+                      (#(get-in % [:value :session_id])))))))
+
+(defn run-search [sid needle forward]
+  (let [res (apply shell {:out :string :err :string :continue true}
+                   (str here "/open-search.bb") sid needle forward)]
+    (when-not (zero? (:exit res))
+      (die (str "open-search failed: " (:err res)) :code 4))
+    (:out res)))
+
+(defn extract-body [dump]
+  (or (second (re-find #"(?s)=== Body ===\n(.*)" dump)) ""))
+
+(defn extract-count [body]
+  (when-let [m (re-find #"([0-9,]+) matching events" body)]
+    (Long/parseLong (str/replace (second m) #"," ""))))
+
+(defn parse-events
+  "Each rendered row is 4 contiguous lines: <vtime> <source> <host> <json>.
+   The JSON payload can wrap across lines; we greedily accumulate until the
+   next decimal virtual-time line."
+  [body]
+  (let [lines (->> (str/split-lines body)
+                   (remove #(re-matches #"^\s*$" %))
+                   (remove #(#{"Search results" "Share search" "List" "Map"
+                               "Download logs" "Explore your logs"} %))
+                   (remove #(re-matches #".*matching events$" %))
+                   (remove #(re-matches #"Loading results.*" %)))
+        vtime? (fn [s] (re-matches #"^\d+\.\d+$" s))]
+    (loop [ls lines state :vtime row {} out []]
+      (if (empty? ls)
+        (if (and (= state :json) (seq (:json row))) (conj out row) out)
+        (let [l (first ls)]
+          (case state
+            :vtime  (if (vtime? l)
+                      (recur (rest ls) :source {:vtime l :json ""} out)
+                      (recur (rest ls) :vtime row out))
+            :source (recur (rest ls) :host (assoc row :source l) out)
+            :host   (recur (rest ls) :json (assoc row :host l) out)
+            :json   (if (vtime? l)
+                      (recur ls :vtime {} (conj out row))
+                      (recur (rest ls) :json (update row :json str l) out))))))))
+
+(defn extract-ns-sev [json-line]
+  {:ns  (second (re-find #"\"ns\":\"([^\"]+)\"" json-line))
+   :sev (second (re-find #"\"sev\":\"([^\"]+)\"" json-line))})
+
+(defn summarise [sid needle match-count events]
+  (let [enriched (map #(merge % (extract-ns-sev (:json %))) events)
+        unique   (->> enriched
+                      (map #(select-keys % [:vtime :source :host :ns :sev]))
+                      distinct)
+        by-src   (->> unique
+                      (group-by :source)
+                      (map (fn [[k vs]] [k (count vs)]))
+                      (sort-by second >))
+        by-triple (->> unique
+                       (group-by (juxt :source :ns :sev))
+                       (map (fn [[k vs]] [k (count vs)]))
+                       (sort-by second >)
+                       (take 30))]
+    (println "session_id:" sid)
+    (println "needle:    " needle)
+    (println "matches:   " (or match-count "?"))
+    (println "distinct rows rendered:" (count unique))
+    (println)
+    (println "By source:")
+    (doseq [[s n] by-src] (printf "  %5d  %s%n" n (or s "")))
+    (println)
+    (println "By (source, ns, sev):")
+    (doseq [[[s ns sev] n] by-triple]
+      (printf "  %5d  %-14s  %-40s  %s%n" n (or s "") (or ns "") (or sev "")))
+    (println)
+    (println "First 10 distinct events:")
+    (doseq [{:keys [vtime source host ns sev]} (take 10 unique)]
+      (printf "  %-8s  %-14s  %-14s  %-40s  %s%n"
+              (or vtime "") (or source "") (or host "") (or ns "") (or sev "")))))
+
+(let [{:keys [count-only? raw? forward needle from-dump] :as opts} (parse-args *command-line-args*)]
+  (when (str/blank? needle)
+    (die "error: needle required. See --help." :code 2))
+  (let [sid (if from-dump
+              (or (:session opts) "<from-dump>")
+              (resolve-session-id opts))]
+    (when (str/blank? sid) (die "error: could not resolve session_id" :code 3))
+    (let [dump (if from-dump (slurp from-dump) (run-search sid needle forward))]
+      (cond
+        raw? (println dump)
+        :else
+        (let [body (if from-dump dump (extract-body dump))
+              cnt  (extract-count body)]
+          (if count-only?
+            (println (or cnt 0))
+            (summarise sid needle cnt (parse-events body))))))))

--- a/tools/query-logs/scripts/set-cookie.sh
+++ b/tools/query-logs/scripts/set-cookie.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Prompt the user interactively for the Antithesis SSO PASETO cookie and
+# write it to /tmp/antithesis-cookie.txt with 0600 perms.
+#
+# The read prompt is silent (-s) so the value does NOT land in shell history
+# or terminal scrollback. Only this script's stdout is ever visible — the
+# cookie value itself is never printed, only its length, the user's nickname,
+# and expiry.
+#
+# Usage:
+#
+#   scripts/set-cookie.sh
+#
+# Then paste either the bare __Host-antithesis_sso_session value
+# (v2.public....) or the full 'Copy as cURL' blob from DevTools, and
+# press Enter. The value is stored at $ANTITHESIS_COOKIE_FILE (default
+# /tmp/antithesis-cookie.txt) for subsequent calls.
+#
+# If you invoke this from inside an agent harness that captures tool
+# stdout into a transcript, invoke it via the harness's shell-passthrough
+# prefix so the silent read happens in your terminal and the pasted
+# value never reaches the transcript.
+
+set -euo pipefail
+
+COOKIE_FILE="${ANTITHESIS_COOKIE_FILE:-/tmp/antithesis-cookie.txt}"
+
+printf "Paste the Antithesis cookie — either the bare v2.public.… value or\n"
+printf "the full 'Copy as cURL' blob from DevTools — then Enter (hidden): "
+read -rs RAW_INPUT
+printf '\n'
+
+if [[ -z "$RAW_INPUT" ]]; then
+  echo "error: empty input" >&2
+  exit 1
+fi
+
+# Accept two shapes:
+#   1. a bare PASETO starting with v2.public.
+#   2. a full 'Copy as cURL' blob — pull the cookie out of -b/--cookie or
+#      the Cookie: header. The Cookie header can carry several name=value
+#      pairs joined by '; '; we only want __Host-antithesis_sso_session.
+if [[ "$RAW_INPUT" == v2.public.* && "$RAW_INPUT" != *$'\n'* && "$RAW_INPUT" != *" "* ]]; then
+  COOKIE="$RAW_INPUT"
+else
+  COOKIE="$(printf '%s' "$RAW_INPUT" \
+    | grep -oE '__Host-antithesis_sso_session=v2\.public\.[A-Za-z0-9_-]+' \
+    | head -1 \
+    | sed 's/^__Host-antithesis_sso_session=//')"
+fi
+
+if [[ -z "$COOKIE" ]]; then
+  echo "error: could not find __Host-antithesis_sso_session=v2.public.… in input" >&2
+  exit 1
+fi
+if [[ "$COOKIE" != v2.public.* ]]; then
+  echo "error: expected value starting with v2.public." >&2
+  exit 1
+fi
+
+umask 077
+printf '%s' "$COOKIE" > "$COOKIE_FILE"
+
+# Decode the payload (middle segment of PASETO v2.public) to extract expiry.
+# v2.public layout: "v2.public." + base64url( payload_json || ed25519_sig[64] ).
+# So after decoding, trim the last 64 bytes to recover the JSON.
+B64="${COOKIE#v2.public.}"
+PAD=$(( (4 - ${#B64} % 4) % 4 ))
+for _ in $(seq 1 "$PAD"); do B64="${B64}="; done
+RAW="$(printf '%s' "$B64" | tr '_-' '/+' | base64 -d 2>/dev/null || true)"
+JSON="${RAW%????????????????????????????????????????????????????????????????}"
+EXP="$(printf '%s' "$JSON" | grep -oE '"exp":"[^"]+"' | head -1 | sed 's/.*:"//; s/"$//')"
+NICKNAME="$(printf '%s' "$JSON" | grep -oE '"nickname":"[^"]+"' | head -1 | sed 's/.*:"//; s/"$//')"
+
+echo "wrote $COOKIE_FILE (len=${#COOKIE})"
+[[ -n "$NICKNAME" ]] && echo "user:    $NICKNAME"
+[[ -n "$EXP" ]]      && echo "expires: $EXP"
+
+# Quick sanity check against the tenant dashboard — expect root redirect (302)
+# and /home load (200). If this fails the cookie is wrong or expired.
+TENANT="${ANTITHESIS_TENANT:-cardano}"
+ROOT_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -b "__Host-antithesis_sso_session=$COOKIE" \
+  "https://${TENANT}.antithesis.com/")
+HOME_CODE=$(curl -sL -o /dev/null -w "%{http_code}" \
+  -b "__Host-antithesis_sso_session=$COOKIE" \
+  "https://${TENANT}.antithesis.com/")
+echo "tenant:  ${TENANT}.antithesis.com  root=$ROOT_CODE  follow=$HOME_CODE"
+if [[ "$ROOT_CODE" != "302" || "$HOME_CODE" != "200" ]]; then
+  echo "warn: unexpected HTTP codes — cookie may be invalid or tenant wrong" >&2
+  exit 2
+fi


### PR DESCRIPTION
## Summary

Adds `tools/query-logs/` — a reverse-engineered CLI we've been using in triage to pull matches out of Antithesis Logs Explorer over CDP — and wires it into the mkdocs site.

### Tool (`tools/query-logs/`)

- `scripts/query.bb` — one-shot entry point: resolves `session_id`, fires the search, parses the body, emits a structured summary (match count, breakdown by `source` / `(source, ns, sev)`, first 10 distinct rows).
- `scripts/login.bb` — interactive cookie intake on a display host: opens chromium for Google SSO, pulls the cookie out over CDP. Fails fast with a helpful message on headless hosts.
- `scripts/set-cookie.sh` — headless cookie intake: accepts either a bare PASETO or a whole `Copy as cURL` blob from DevTools; greps `__Host-antithesis_sso_session=v2.public.…` out itself.
- `scripts/pangolin-runs.bb` — resolves runs from `kv_table/runs` with the mandatory `X-Antithesis-Allow-Effects` / UA / content-type triad; filters out `OTIS` synthetic ids.
- `scripts/build-search-url.bb` — `v5v<base64url(json)>` encoder, one group per clause (the SPA rejects collapsed groups silently).
- `scripts/open-search.bb` — CDP-attached chromium driver with two-phase polling (wait for results pane, then clear `Initializing query…` / `Loading results`). Body spat to `/tmp/open-search-last.txt` for debugging.
- `references/` — `search-url-format.md`, `indexed-sources.md`, `driver-troubleshooting.md`.
- `README.md` — self-contained recipe with prerequisites, selector modes, failure table.

### Docs

- New site page `docs/query-logs.md` — framed as the companion to `docs/triage.md`: triage parses the report HTML (assertions, findings), query-logs searches the indexed stdout.
- Nav entry `Querying logs` added to `mkdocs.yml` between *Triage* and *Contributing*.
- Cross-link added in `triage.md` so a reader starting from triage finds the stdout-search tool.

## Status: workaround

Flagged at the top of both the tool README and the new docs page: this is a stopgap pending an official Antithesis API. Everything here is observable from a logged-in browser session; nothing is privileged. Delete the day a real API lands.

## Verified end-to-end

Live query against `session 37aa2da344c6d749811cfa24e983be97-50-7` with `needle='"sev":"Warning"' --source log-tailer` returns **116,858 matching events**, confirming the log-tailer sidecar from #44 is emitting.

## Test plan

- [x] `set-cookie.sh` accepts bare PASETO and full `Copy as cURL` blob; value never hits scrollback
- [x] `login.bb` fails fast with a helpful message when `DISPLAY` and `WAYLAND_DISPLAY` are both unset
- [x] `pangolin-runs.bb --latest-completed` returns real testnet session_ids (OTIS filtered)
- [x] `query.bb` end-to-end against a real session
- [ ] `mkdocs build` is clean (local verification recommended before merge)