### PR TITLE
docs: add Querying Logs page for tools/query-logs

### DIFF
--- a/docs/query-logs.md
+++ b/docs/query-logs.md
@@ -1,0 +1,85 @@
+# Querying the Logs Explorer
+
+Complement to [Triaging Antithesis reports](triage.md). The triage
+flow uses `antithesis-triage` to parse a single test-run's **HTML
+report** (assertion findings, bug listings). This page covers the
+companion task: searching the **indexed stdout** of every container
+in a run — i.e. driving the Antithesis Logs Explorer `/search` page
+from a script.
+
+The tool lives at [`tools/query-logs/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/tools/query-logs)
+in this repo. Its [README](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/query-logs/README.md)
+is the detailed reference; this page summarises the shape of the
+problem and when to reach for it.
+
+!!! warning "Workaround, not a supported API"
+    Antithesis does not currently publish a programmatic interface for
+    their Logs Explorer. `tools/query-logs/` is a reverse-engineered
+    CLI: it drives a real chromium over CDP, injects an SSO cookie,
+    and scrapes the rendered DOM. Everything it does is observable
+    from a logged-in browser session — nothing is privileged. The day
+    Antithesis ship an API this tool should be deleted.
+
+## When to use query-logs vs triage
+
+| Question | Tool |
+|---|---|
+| "Why did this assertion fail?" | `antithesis-triage` — parses the report HTML |
+| "Did the log-tailer sidecar emit anything during run X?" | `tools/query-logs/` — searches indexed stdout |
+| "How many `sev:Warning` events came from source=p1?" | `tools/query-logs/` |
+| "What was the value of `k` right before the bug was armed?" | `tools/query-logs/` with a `regex` matcher |
+| "Was the run Completed, and what's its `session_id`?" | `tools/query-logs/scripts/pangolin-runs.bb --session-ids` |
+
+## Fast path
+
+Once the cookie is in `$ANTITHESIS_COOKIE_FILE`:
+
+```bash
+tools/query-logs/scripts/query.bb --latest '"sev":"Warning"' --source log-tailer
+```
+
+Produces a structured summary: total match count, breakdown by source,
+by `(source, ns, sev)`, and the first 10 distinct rendered rows.
+
+## Cookie intake
+
+Two paths depending on where you're running:
+
+- **Headed host** — `scripts/login.bb` opens a chromium window, waits
+  for you to complete Google SSO, and pulls the cookie out over CDP.
+- **Headless host** (CI, remote VM) — `scripts/set-cookie.sh` accepts
+  either a bare PASETO or a whole `Copy as cURL` blob from your
+  laptop's DevTools Network tab. It greps the cookie out itself.
+
+Both paths are silent: only nickname, expiry, and a `root=302 follow=200`
+sanity code are ever printed. The cookie value never hits scrollback.
+
+## What Antithesis actually indexes
+
+**Container stdout only.** If a log stream lives inside a docker
+volume (for example the cardano-tracer `ForMachine` stream) it is
+**not** captured by Antithesis. The workaround is the
+[log-tailer sidecar](components/sidecar.md): it tails the JSON files
+to its own stdout under `source=log-tailer`, making them searchable.
+See also [references/indexed-sources.md](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/query-logs/references/indexed-sources.md)
+in the tool folder.
+
+## Finding a run
+
+```bash
+tools/query-logs/scripts/pangolin-runs.bb --session-ids        # time + session_id table
+tools/query-logs/scripts/pangolin-runs.bb --latest-completed   # single session_id
+tools/query-logs/scripts/pangolin-runs.bb --by-commit <sha>    # JSONL, filtered
+```
+
+The `session_id` used by Logs Explorer is **not** the `testRunId`
+moog exposes; it's `value.session_id` from a pangolin run record, of
+the form `<hex32>-<major>-<minor>`.
+
+## Failure modes
+
+See [references/driver-troubleshooting.md](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/query-logs/references/driver-troubleshooting.md).
+Common traps: stale cookie (`root=302 follow=302`), the play-icon
+button staying disabled, synthetic `OTIS` session ids from webhook
+aggregator runs, and the SPA silently rejecting collapsed multi-clause
+query JSON.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -74,6 +74,15 @@ When prompted, paste the decrypted Antithesis URL from `moog facts test-runs` or
 
 The skill walks through the report, extracts failing Sometimes/Always assertions and bug findings, and can download logs for a specific run.
 
+## Searching indexed stdout
+
+Triage covers the report (assertion findings, bug listings). For the
+complementary task — searching the **indexed stdout** of every
+container in a run (e.g. "did the log-tailer sidecar emit anything
+during run X?") — see [Querying the Logs Explorer](query-logs.md).
+That tool lives at [`tools/query-logs/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/tools/query-logs)
+and drives a headless chromium against Logs Explorer.
+
 ## What is not available
 
 - **No structured JSON report export.** Only the in-container SDK log (`ANTITHESIS_SDK_LOCAL_OUTPUT`) is structured; the triage report itself is HTML behind PASETO.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,4 +32,5 @@ nav:
       - testnets/index.md
       - Cardano Node Master: testnets/cardano-node-master.md
   - Triage: triage.md
+  - Querying logs: query-logs.md
   - Contributing: contributing.md


### PR DESCRIPTION
Follow-up to #45 — the squash-merge of the tool dropped the docs commit, so re-landing just the docs bits here.

## Summary

- New page `docs/query-logs.md` framed as the companion to `docs/triage.md`: triage parses the report HTML (assertions, findings); query-logs searches the indexed stdout.
- Nav entry `Querying logs` added to `mkdocs.yml` between *Triage* and *Contributing*.
- Cross-link added in `triage.md` so readers starting from triage find the stdout-search tool.
- Workaround-not-API status flagged up top on the new page, matching the tool's README.

## Test plan

- [ ] `mkdocs build` clean (no broken link / missing-page warnings)
- [ ] Rendered nav shows *Querying logs* between *Triage* and *Contributing*