### PR TITLE
tracer-sidecar: rescan parent dir for late-arriving node subdirs

### DIFF
--- a/components/tracer-sidecar/src/App.hs
+++ b/components/tracer-sidecar/src/App.hs
@@ -26,24 +26,23 @@ import Control.Concurrent
     , newMVar
     , threadDelay
     )
-import Control.Concurrent.Async (async, link, wait)
+import Control.Concurrent.Async (async, link)
 import Control.Exception (SomeException, try)
 import Control.Monad
-    ( forM
-    , forM_
+    ( forM_
     , forever
     , guard
+    , unless
     , when
     , (<=<)
     )
-import Control.Monad.Fix (fix)
 import Data.Aeson
     ( FromJSON
     , eitherDecode
     )
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
-import Data.Foldable (traverse_)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (isPrefixOf)
 import Data.Maybe (isJust)
 import Data.Set (Set)
@@ -88,33 +87,42 @@ main = do
 
     writeSdkJsonl $ sometimesTracesDeclaration "find log files"
 
-    nodeDirs <- fix $ \loop -> do
-        mls <- try $ listDirectory dir
-        case mls of
-            Left (e :: SomeException) -> do
-                putStrLn $ "Error listing directory " <> dir <> ": " <> show e
-                threadDelay 1000000
-                loop
-            Right _ -> do
-                nodeDirs' <- fmap (dir </>) <$> listDirectory dir
-                if null nodeDirs'
-                    then do
-                        putStrLn "No node log directories found, waiting..."
-                        threadDelay 1000000
-                        loop
-                    else return nodeDirs'
     let spec = mkSpec nPools
-
-    writeSdkJsonl $ sometimesTracesReached "find log files"
-
     mvar <- newMVar =<< initialStateIO spec
-    threads <- forM nodeDirs $ \nodeDir ->
-        async
-            $ tailJsonLinesFromTracerLogDir
-                True
-                nodeDir
-                (modifyMVar_ mvar . flip (processMessageIO spec))
-    traverse_ wait threads
+
+    -- Each cardano-node process gets its own subdirectory under `dir` once it
+    -- handshakes with cardano-tracer. Those subdirectories appear over time
+    -- and may also appear *after* sidecar startup (e.g. slow-starting pool
+    -- containers, or node restarts via fault injection). Scan in a loop,
+    -- spawning a file-tailing watcher the first time we see each subdir.
+    seenRef <- newIORef (Set.empty :: Set FilePath)
+    sdkReachedRef <- newIORef False
+    forever $ do
+        esubs <- try (listDirectory dir)
+        case esubs of
+            Left (e :: SomeException) ->
+                putStrLn
+                    $ "Error listing directory " <> dir <> ": " <> show e
+            Right subs -> do
+                seen <- readIORef seenRef
+                let current = Set.fromList $ fmap (dir </>) subs
+                    new = current `Set.difference` seen
+                unless (null new) $ do
+                    reached <- readIORef sdkReachedRef
+                    unless reached $ do
+                        writeSdkJsonl $ sometimesTracesReached "find log files"
+                        writeIORef sdkReachedRef True
+                    forM_ new $ \nodeDir -> do
+                        putStrLn $ "Tailing node log dir: " <> nodeDir
+                        link
+                            =<< async
+                                ( tailJsonLinesFromTracerLogDir
+                                    True
+                                    nodeDir
+                                    (modifyMVar_ mvar . flip (processMessageIO spec))
+                                )
+                    writeIORef seenRef (seen <> new)
+        threadDelay 1000000
 
 -- | Tails json lines from each file in a directory,
 -- one at a time respecting their lexical order

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -181,7 +181,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:4da4d4e
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:ff408d6
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     command:


### PR DESCRIPTION
## Summary
Fixes #50. Every `cardano-node-master` Antithesis run was tripping `Sometimes: Any p{1,2,3} log` because `tracer-sidecar/src/App.hs` snapshotted `/opt/cardano-tracer/logs` once at startup — only the subdirs that existed at that instant were watched. Producers whose subdirs appeared slightly later (or any node restarted by fault injection mid-run) were invisible for the rest of the test, so their LogMessages never reached the Spec rules.

Evidence from run `4631aac7d48a4381989da64f48e8ecb5-50-7` (commit `e86f3a1`):
| subdir | `Tailing file` events |
|---|---:|
| `relay2.example_3001/` | 1,146 |
| `p1 / p2 / p3 / relay1` | 0 |

Meanwhile `source=log-tailer` (independent poll-based tailer) saw 7,131 `"host":"p1.example"` lines from the *same* run, proving the tracer was writing those subdirs to disk.

## Change
Replace the one-shot `listDirectory` + `forM nodeDirs` + `traverse_ wait` in `App.hs:91-117` with a `forever`-poll loop that:
- maintains a `Set FilePath` of known subdirs
- each tick lists the parent dir, diffs against the set, spawns a watcher for every new subdir
- emits `Tailing node log dir: <path>` as each watcher starts
- fires the SDK `sometimesTracesReached "find log files"` event on the first non-empty diff, preserving existing semantics for that assertion

Single-file diff: `components/tracer-sidecar/src/App.hs`, +38/-30.

Then bumps the compose image tag to the new commit so `publish-images` builds and pushes it.

## Local verification
Started the sidecar against an empty `logs/` dir, created subdirs one at a time:
```
t=2s (no subdirs)   → starting tracer-sidecar...
t=4s (add relay2)   → + Tailing node log dir: .../relay2.example_3001
t=6s (add p1 late)  → + Tailing node log dir: .../p1.example_3001
t=8s (add p2 + p3)  → + Tailing node log dir: .../p2.example_3001
                     + Tailing node log dir: .../p3.example_3001
```

All three existing hspec tests pass (`processMessages` golden, `decodes all test data`, `tailJsonLinesFromTracerLogDir 10×10`).

## Not included
The 4th unrelated finding on the same run — `No unexpected container exits → ogmios, exit code: 255` — is tracked separately in #49.

## Test plan
- [x] Local: `nix build .#tracer-sidecar-tests && ./test` — 3/3 pass
- [x] Local: manual subdir-late reproduction above
- [ ] CI `publish-images` — builds and pushes `tracer-sidecar:ff408d6`
- [ ] Post-merge Antithesis run — confirm `Sometimes: Any p{1,2,3} log` findings disappear from the run report