### PR TITLE
Re-add ogmios with stop_signal: SIGKILL (#49 workaround)

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -125,6 +125,34 @@ services:
       relay1:
         condition: service_started
 
+  # Ogmios exits with code 255 on SIGINT/SIGTERM — see
+  # CardanoSolutions/ogmios#459 and #49. Antithesis's "No unexpected
+  # container exits" property excludes 137/143 but flags 255, so every
+  # fault-injected stop triggers a finding. Until the upstream fix
+  # lands, send SIGKILL directly: ogmios is stateless (chain-sync'd
+  # JSON-RPC adapter, no on-disk state to flush) so graceful shutdown
+  # isn't needed here, and 137 is excluded by the property.
+  ogmios:
+    image: docker.io/cardanosolutions/ogmios:v6.14.0
+    container_name: ogmios
+    hostname: ogmios.example
+    command:
+      - "--node-socket"
+      - "/state/node.socket"
+      - "--node-config"
+      - "/configs/configs/config.json"
+      - "--host"
+      - "0.0.0.0"
+    volumes:
+      - relay2-state:/state:ro
+      - p1-configs:/configs:ro
+    restart: always
+    stop_signal: SIGKILL
+    stop_grace_period: 0s
+    depends_on:
+      relay2:
+        condition: service_started
+
   tx-generator:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:tx-gen-v1
     container_name: tx-generator


### PR DESCRIPTION
Re-introduces ogmios into the `cardano_node_master` testnet with a `stop_signal: SIGKILL` + `stop_grace_period: 0s` workaround for the upstream bug tracked in #49 and filed upstream as [CardanoSolutions/ogmios#459](https://github.com/CardanoSolutions/ogmios/issues/459).

## Context
Ogmios v6.14.0 returns exit code **255** on any graceful signal-driven shutdown (SIGINT or SIGTERM). Antithesis's built-in "No unexpected container exits" property excludes 137 (SIGKILL) and 143 (SIGTERM default action), but flags 255 as unclean. That means every fault-injected stop cycle of ogmios would trip the property and a clean run would be impossible.

Root cause, from ogmios source (`server/src/Ogmios.hs:140`): a SIGTERM handler re-raises SIGINT hoping the GHC runtime will cleanup; the `UserInterrupt` that GHC raises inside `concurrently_` doesn't reach a user-level exit handler and the RTS exits 255.

## Workaround

```yaml
ogmios:
  ...
  stop_signal: SIGKILL
  stop_grace_period: 0s
```

Docker stop sends SIGKILL directly → kernel kills the process → exit code **137**, which the Antithesis property explicitly excludes. Ogmios is a stateless JSON-RPC adapter (no on-disk state, all state is derived from the node socket) so losing graceful shutdown is not a correctness concern.

Once CardanoSolutions/ogmios#459 ships, drop `stop_signal` and `stop_grace_period` and rely on the image's default `STOPSIGNAL SIGINT`.

## Verified locally

```
$ docker compose stop ogmios
 Container ogmios Stopping
 Container ogmios Stopped
real    0m0.651s
$ docker inspect ogmios --format '{{.State.ExitCode}}'
137
```

## Test plan
- [x] Local smoke: `stop_signal: SIGKILL` yields exit 137 in <1s
- [ ] Antithesis duration=1h run on this branch — expect `findings_new: 0` (nothing to trip now)
- [ ] Merge

Closes #49.