### PR TITLE
feat(asteria-player): pin cardano-node-clients + N2C provider

### DIFF
--- a/components/asteria-player/app/PlayerMain.hs
+++ b/components/asteria-player/app/PlayerMain.hs
@@ -1,33 +1,58 @@
 {- |
 Module      : Main
-Description : Iteration-1 stub for the asteria-player long-running loop.
+Description : Iteration-2 — query protocol params via N2C in a loop.
 
-Emits 'sdkReachable' to the JSONL fallback, then sleeps forever so
-the container stays alive for inspection. Subsequent iterations
-replace this body with the actual game loop:
+Connects to the cardano-node N2C socket at
+@$CARDANO_NODE_SOCKET_PATH@ using the queue / async pattern from
+cardano-node-clients's @withDevnet@. Once connected, queries protocol
+parameters in a loop (every 5 seconds) and emits an
+@asteria_player_pp_query_<id>@ 'sdk_sometimes' event so the antithesis
+hypervisor can confirm the player is genuinely talking to a node.
 
-  1. Resolve the N2C socket path from @CARDANO_NODE_SOCKET_PATH@.
-  2. Build a 'Provider' + 'Submitter' against it.
-  3. Loop:
-        state <- queryGameState provider
-        action <- pickAction antithesisRandom state
-        signed <- buildAndSign action
-        Submitted _ <- submitTx submitter signed
-        threadDelay (waitFor antithesisRandom)
+Subsequent iterations replace the loop body with actual game state
+queries + tx submissions.
 -}
 module Main (main) where
 
 import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, try)
 import Control.Monad (forever)
+import Data.Aeson (object, (.=))
+import Data.Text (Text)
 import Data.Text qualified as T
 import System.Environment (lookupEnv)
 
-import Asteria.Sdk (sdkReachable)
+import Asteria.Provider (settingsFromEnv, withN2C)
+import Asteria.Sdk (sdkReachable, sdkSometimes, sdkUnreachable)
+import Cardano.Node.Client.Provider (Provider (..))
 
 main :: IO ()
 main = do
-    playerId <- maybe "asteria-player" id <$> lookupEnv "ASTERIA_PLAYER_ID"
+    playerIdStr <-
+        maybe "unknown" id <$> lookupEnv "ASTERIA_PLAYER_ID"
+    let playerId = T.pack playerIdStr
     sdkReachable
-        ("asteria_player_started_" <> T.pack playerId)
+        ("asteria_player_started_" <> playerId)
         Nothing
-    forever (threadDelay 60_000_000) -- 60s
+    settings <- settingsFromEnv
+    withN2C settings $ \provider _submitter -> do
+        sdkReachable
+            ("asteria_player_n2c_connected_" <> playerId)
+            Nothing
+        forever (loop provider playerId)
+  where
+    loop provider playerId = do
+        result <- try (queryProtocolParams provider)
+        case result of
+            Left (e :: SomeException) ->
+                sdkUnreachable
+                    ("asteria_player_pp_query_failed_" <> playerId)
+                    ( Just $
+                        object ["error" .= T.pack (show e)]
+                    )
+            Right _pp ->
+                sdkSometimes
+                    True
+                    ("asteria_player_pp_query_" <> playerId)
+                    Nothing
+        threadDelay 5_000_000

--- a/components/asteria-player/asteria-player.cabal
+++ b/components/asteria-player/asteria-player.cabal
@@ -41,13 +41,20 @@ library
   default-language: GHC2021
   build-depends:
     , aeson
+    , async
     , base
     , bytestring
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-node-clients
     , directory
     , filepath
+    , ouroboros-network:api
     , text
 
-  exposed-modules:  Asteria.Sdk
+  exposed-modules:
+    Asteria.Provider
+    Asteria.Sdk
 
 executable asteria-bootstrap
   import:           settings
@@ -65,6 +72,8 @@ executable asteria-player
   hs-source-dirs:   app
   default-language: GHC2021
   build-depends:
+    , aeson
     , asteria-player
     , base
+    , cardano-node-clients
     , text

--- a/components/asteria-player/cabal.project
+++ b/components/asteria-player/cabal.project
@@ -1,8 +1,18 @@
-index-state: 2025-08-07T00:00:00Z
+-- Pinned to match cardano-node-clients's cabal.project exactly,
+-- because we depend on its TxBuild DSL + Provider/Submitter
+-- interface and need every transitive source-repository-package
+-- pin available so cabal can resolve the build plan.
+--
+-- When bumping the cardano-node-clients tag below, copy the
+-- updated index-state + SRP block + constraints from
+-- https://github.com/lambdasistemi/cardano-node-clients/blob/<rev>/cabal.project
+-- in the same commit.
+
+index-state: 2026-02-17T10:15:41Z
 
 index-state:
-  , hackage.haskell.org 2025-08-07T00:00:00Z
-  , cardano-haskell-packages 2025-08-07T00:00:00Z
+  , hackage.haskell.org 2026-02-17T10:15:41Z
+  , cardano-haskell-packages 2026-03-23T18:21:55Z
 
 packages: .
 
@@ -16,3 +26,80 @@ repository cardano-haskell-packages
     bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/cardano-node-clients
+  tag: f6a31ca6c169810a46e45648a0868d7a48eb1f02
+  --sha256: 0fcblvcqdhlj3kjq7jyarj169grmi6csvmrhpja4sc80ann3nihr
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/chain-follower
+  tag: 371b5930976ac3bb4e8a4ef576d5098d706984ee
+  --sha256: 1rks78zmgmxz5cg4v82vnc6hwib8vrylwk2m7y82iqaymmnskdvf
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/rocksdb-kv-transactions
+  tag: e2e77579888ebbd832ea750ebf2635dfc3307025
+  --sha256: 0nd1yz6k3xh1p7nlswp2jbw74bzqr7bvz11kcfyhhimqmjhkqvwm
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdasistemi/rocksdb-haskell.git
+  tag: a3e86b39f9510fea54abf734ee84aec33d0d683f
+  --sha256: 1gjzqhf81fy3bpc79ndmx3s77x3s1gf0lsk762acbfnpfh6g1hd0
+
+source-repository-package
+  type: git
+  location: https://github.com/cardano-foundation/cardano-ledger-read
+  tag: 34d0767bd5c3648ab77ecbc00db0ad0a2a5316a5
+  --sha256: 0v357pbw2s22lsizxidq67pn4dcjkajips6mlcskd1zna35nyyv6
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/typed-protocols
+  tag: typed-protocols-1.2.0.0
+  --sha256: 0v9rjf0q8wbhscfyvbwbwpzjq078l4il3i4vyyghqxahy293whwq
+  subdir: typed-protocols
+
+source-repository-package
+  type: git
+  location: https://github.com/stevana/quickcheck-state-machine
+  tag: v0.10.3
+  --sha256: 1v7pk509ysbfkbkvf8sppf0pgp866vyviah5gsihlsvlb08lnrfg
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cuddle
+  tag: cuddle-1.1.1.0
+  --sha256: 1f4wk3kgb68bg97gfb9wycv5zkv0dsghlkf9pj64z0bpcr0wkxrc
+
+-- Pin Cardano and Ouroboros packages for the cardano-node 10.7.0 line
+constraints:
+    cardano-ledger-allegra == 1.9.0.0
+  , cardano-ledger-alonzo == 1.15.0.0
+  , cardano-ledger-api == 1.13.0.0
+  , cardano-ledger-babbage == 1.13.0.0
+  , cardano-ledger-byron == 1.3.0.0
+  , cardano-ledger-conway == 1.21.0.0
+  , cardano-ledger-core == 1.19.0.0
+  , cardano-ledger-mary == 1.10.0.0
+  , cardano-ledger-shelley == 1.18.0.0
+  , cardano-crypto-class == 2.3.1.0
+  , cardano-crypto-praos == 2.2.2.0
+  , cardano-protocol-tpraos == 1.5.0.0
+  , cuddle == 1.1.1.0
+  , quickcheck-state-machine == 0.10.3
+  , ouroboros-consensus == 1.0.0.0
+  , ouroboros-network == 1.1.0.0
+  , typed-protocols == 1.2.0.0
+
+package ouroboros-consensus
+  tests: False
+  benchmarks: False
+
+package ouroboros-network
+  tests: False
+  benchmarks: False

--- a/components/asteria-player/flake.lock
+++ b/components/asteria-player/flake.lock
@@ -3,17 +3,17 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1777036826,
-        "narHash": "sha256-c9oScWEa0q5X0VF7G6mSsOrh+glHfwnUGdbHnPTVPVQ=",
+        "lastModified": 1774292745,
+        "narHash": "sha256-m/+P0W4C6tYojUPSq8tY4Dwan14bDA2aXbkctWTonj8=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3932849518c1c50018ee3dfba06b391f93a33f76",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       },
       "original": {
         "owner": "intersectmbo",
-        "ref": "repo",
         "repo": "cardano-haskell-packages",
+        "rev": "887d73ce434831e3a67df48e070f4f979b3ac5a6",
         "type": "github"
       }
     },
@@ -40,13 +40,30 @@
         "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.15",
+        "ref": "v0.3.14",
         "repo": "blst",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
         "type": "github"
       }
     },
@@ -135,30 +152,14 @@
         "type": "github"
       }
     },
-    "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1777077665,
-        "narHash": "sha256-vWdSmhs5cv3VpK0suIh/WubQfUCPUgZx6pYyWFTsfIo=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "39467ede37e08e2ee3d361dafdc6065a0090a8f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1777077654,
-        "narHash": "sha256-+4hPhljk4/S7DbMvDLrvUB50NUGaW67tjHN1q0G64/M=",
+        "lastModified": 1762302430,
+        "narHash": "sha256-thtGuIGrodKEfZPh+Sv22m1BR2zxNQY8RCsGlBWroj4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c32368d9ff0fa43a335cbca6a199e69dab8dee8c",
+        "rev": "c5dc9e01d45948892915b5394f23986277fb0ccb",
         "type": "github"
       },
       "original": {
@@ -184,14 +185,34 @@
         "type": "github"
       }
     },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776252609,
+        "narHash": "sha256-oUeHwNUXIAG89EihLIoUKSKolFOPwT+q4pPd8IogkJE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04",
+        "type": "github"
+      }
+    },
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "hackage": "hackage",
+        "hackage": [
+          "hackageNix"
+        ],
         "hackage-for-stackage": "hackage-for-stackage",
         "hackage-internal": "hackage-internal",
         "hls": "hls",
@@ -199,7 +220,6 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
-        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -219,22 +239,22 @@
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
-        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1777079111,
-        "narHash": "sha256-b72oLR9qo9r/jgTcraH94uDLvYpuToMyA2UjR8QGGgY=",
+        "lastModified": 1762315551,
+        "narHash": "sha256-7uaB/UpiFn/+gf7s5NMpSTTUv5Ws30DjsmmqZry+1cY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3328b9aff5de3b50cd90cafe68d55aa701ca1fc3",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "ef52c36b9835c77a255befe2a20075ba71e3bfab",
         "type": "github"
       }
     },
@@ -318,23 +338,6 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.12": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1758709460,
-        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -501,27 +504,28 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1776426337,
-        "narHash": "sha256-hkfKwhbhCiDVBwDeeKKXQiBg9VAI3KMM1GZ3yhO6cT8=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "fdfc53bc51c684fe086117de651f36572b26655a",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "iohk-nix",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       }
     },
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1775620557,
-        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
         "type": "github"
       },
       "original": {
@@ -581,11 +585,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1751290243,
-        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
         "type": "github"
       },
       "original": {
@@ -597,32 +601,16 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1764560356,
-        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "lastModified": 1757716134,
+        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-25.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2511": {
-      "locked": {
-        "lastModified": 1775749320,
-        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -644,11 +632,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
         "type": "github"
       },
       "original": {
@@ -679,6 +667,7 @@
       "inputs": {
         "CHaP": "CHaP",
         "flake-parts": "flake-parts",
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
         "iohkNix": "iohkNix",
         "nixpkgs": [
@@ -724,11 +713,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1777076716,
-        "narHash": "sha256-pnXfUJ5T/ZWM4TsRsMjeWcBcomeXxb7FGDWxCcdzN2w=",
+        "lastModified": 1762301584,
+        "narHash": "sha256-yLihKEbngbLV1EhuLJSencMCtrDM2sYGsVZkX8xlSK8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "422f16979778c83180782c86e8ffd5aa26cf0e91",
+        "rev": "ce12bd44df0b5488bdbbe8762d79379e2bc76d62",
         "type": "github"
       },
       "original": {

--- a/components/asteria-player/flake.nix
+++ b/components/asteria-player/flake.nix
@@ -5,21 +5,36 @@
     extra-trusted-public-keys =
       [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
+  # Pinned to match cardano-node-clients's flake inputs so the
+  # haskell.nix project plan resolves identically. Bumping
+  # cardano-node-clients's tag in cabal.project should be
+  # accompanied by a refresh of these revisions.
   inputs = {
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix = {
+      url =
+        "github:input-output-hk/haskell.nix/ef52c36b9835c77a255befe2a20075ba71e3bfab";
+      inputs.hackage.follows = "hackageNix";
+    };
+    hackageNix = {
+      url =
+        "github:input-output-hk/hackage.nix/55ba0ca4bcc9690f2ea45335cb2b9e95d8219a04";
+      flake = false;
+    };
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     iohkNix = {
-      url = "github:input-output-hk/iohk-nix";
+      url =
+        "github:input-output-hk/iohk-nix/f444d972c301ddd9f23eac4325ffcc8b5766eee9";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     CHaP = {
-      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
+      url =
+        "github:intersectmbo/cardano-haskell-packages/887d73ce434831e3a67df48e070f4f979b3ac5a6";
       flake = false;
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-parts, haskellNix, CHaP, iohkNix, ... }:
+  outputs = inputs@{ self, nixpkgs, flake-parts, haskellNix, hackageNix, CHaP, iohkNix, ... }:
     let
       version = self.dirtyShortRev or self.shortRev or "dev";
       parts = flake-parts.lib.mkFlake { inherit inputs; } {
@@ -36,7 +51,7 @@
               inherit system;
             };
             project = import ./nix/project.nix {
-              indexState = "2025-08-07T00:00:00Z";
+              indexState = "2026-02-17T10:15:41Z";
               inherit CHaP;
               inherit pkgs;
             };

--- a/components/asteria-player/nix/project.nix
+++ b/components/asteria-player/nix/project.nix
@@ -2,10 +2,35 @@
 
 let
   indexTool = { index-state = indexState; };
-  mkProject = ctx@{ lib, pkgs, ... }: {
+
+  # Mirror cardano-node-clients's fix-libs to make sure
+  # cardano-crypto-praos, cardano-crypto-class, cardano-lmdb,
+  # blockio-uring resolve their pkgconfig deps and the heavy
+  # packages skip Haddock to keep build time sane.
+  fix-libs = { lib, pkgs, ... }: {
+    packages.cardano-crypto-praos.components.library.pkgconfig =
+      lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+    packages.cardano-crypto-class.components.library.pkgconfig =
+      lib.mkForce [ [ pkgs.libsodium-vrf pkgs.secp256k1 pkgs.libblst ] ];
+    packages.cardano-lmdb.components.library.pkgconfig =
+      lib.mkForce [ [ pkgs.lmdb ] ];
+    packages.blockio-uring.components.library.pkgconfig =
+      lib.mkForce [ [ pkgs.liburing ] ];
+    packages.cardano-ledger-binary.components.library.doHaddock =
+      lib.mkForce false;
+    packages.plutus-core.components.library.doHaddock =
+      lib.mkForce false;
+    packages.plutus-ledger-api.components.library.doHaddock =
+      lib.mkForce false;
+    packages.plutus-tx.components.library.doHaddock =
+      lib.mkForce false;
+  };
+
+  mkProject = { lib, pkgs, ... }: {
     name = "asteria-player";
     src = ./..;
-    compiler-nix-name = "ghc984";
+    compiler-nix-name = "ghc9122";
+    modules = [ fix-libs ];
     inputMap = { "https://chap.intersectmbo.org/" = CHaP; };
   };
   project = pkgs.haskell-nix.cabalProject' mkProject;
@@ -18,21 +43,18 @@ let
       fourmolu = indexTool;
       hlint = indexTool;
     };
-    withHoogle = true;
+    withHoogle = false;
     buildInputs = [
       pkgs.git
       pkgs.just
       pkgs.nixfmt-classic
+      pkgs.lmdb
+      pkgs.liburing
     ];
-    shellHook = ''
-      echo "Entering shell for asteria-player development"
-    '';
   };
 
 in {
-  devShells = {
-    default = project.shellFor shell;
-  };
+  devShells.default = project.shellFor shell;
   packages.asteria-player =
     project.hsPkgs.asteria-player.components.exes.asteria-player;
   packages.asteria-bootstrap =

--- a/components/asteria-player/src/Asteria/Provider.hs
+++ b/components/asteria-player/src/Asteria/Provider.hs
@@ -1,0 +1,109 @@
+{- |
+Module      : Asteria.Provider
+Description : Connect to a running Cardano node via N2C.
+
+Stands up the same channel + 'runNodeClient' plumbing that
+@withDevnet@ uses in cardano-node-clients's e2e harness, but
+against an *existing* socket instead of spawning its own
+@cardano-node@. This is the right shape for both the
+docker-compose cluster and the antithesis sandbox.
+
+Usage:
+
+@
+withN2C magic socketPath $ \\provider submitter -> do
+    pp <- queryProtocolParams provider
+    ...
+@
+-}
+module Asteria.Provider (
+    withN2C,
+    N2CSettings (..),
+    settingsFromEnv,
+) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (async, poll)
+import Control.Exception (SomeException, throwIO)
+import Data.Word (Word32)
+import Text.Read (readMaybe)
+
+import Cardano.Node.Client.N2C.Connection (
+    newLSQChannel,
+    newLTxSChannel,
+    runNodeClient,
+ )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.Provider (Provider)
+import Cardano.Node.Client.Submitter (Submitter)
+import Ouroboros.Network.Magic (NetworkMagic (..))
+import System.Environment (lookupEnv)
+
+-- | Connection settings resolved from the environment.
+data N2CSettings = N2CSettings
+    { n2cSocketPath :: FilePath
+    , n2cNetworkMagic :: NetworkMagic
+    }
+    deriving (Eq, Show)
+
+-- | Read 'CARDANO_NODE_SOCKET_PATH' and 'NETWORK_MAGIC'.
+settingsFromEnv :: IO N2CSettings
+settingsFromEnv = do
+    sock <-
+        maybe
+            (error "CARDANO_NODE_SOCKET_PATH not set")
+            id
+            <$> lookupEnv "CARDANO_NODE_SOCKET_PATH"
+    magicStr <-
+        maybe "42" id <$> lookupEnv "NETWORK_MAGIC"
+    let magic = case readMaybe magicStr :: Maybe Word32 of
+            Just m -> NetworkMagic m
+            Nothing ->
+                error
+                    ( "NETWORK_MAGIC is not a number: "
+                        <> magicStr
+                    )
+    pure
+        N2CSettings
+            { n2cSocketPath = sock
+            , n2cNetworkMagic = magic
+            }
+
+{- | Stand up an N2C connection to an existing
+@cardano-node@ socket and run an action with a
+'Provider' + 'Submitter'.
+
+Mirrors the channel-and-async dance from
+@withDevnet@ in @cardano-node-clients@'s e2e
+harness, sized for one player loop (queue capacity
+16 for both channels).
+-}
+withN2C ::
+    N2CSettings ->
+    (Provider IO -> Submitter IO -> IO a) ->
+    IO a
+withN2C N2CSettings{..} action = do
+    lsqCh <- newLSQChannel 16
+    ltxsCh <- newLTxSChannel 16
+    nodeThread <-
+        async $
+            runNodeClient
+                n2cNetworkMagic
+                n2cSocketPath
+                lsqCh
+                ltxsCh
+    -- Same 3-second grace period as @withDevnet@.
+    threadDelay 3_000_000
+    status <- poll nodeThread
+    case status of
+        Just (Left e) ->
+            throwIO (e :: SomeException)
+        Just (Right (Left e)) ->
+            throwIO e
+        Just (Right (Right ())) ->
+            error "asteria-player: N2C closed unexpectedly"
+        Nothing -> pure ()
+    let provider = mkN2CProvider lsqCh
+        submitter = mkN2CSubmitter ltxsCh
+    action provider submitter


### PR DESCRIPTION
## Summary

Iteration 2 of the asteria phase-1 gatherer ([#56](https://github.com/cardano-foundation/cardano-node-antithesis/issues/56)). Builds on iteration 1 ([#57](https://github.com/cardano-foundation/cardano-node-antithesis/pull/57), already merged).

The player now actually connects to a Cardano node via the N2C local socket and queries protocol parameters in a loop, emitting `sdk_sometimes(true)` per successful query. No game logic yet — that's iteration 3 onwards.

## Changes

- `cabal.project`: pin [`cardano-node-clients@f6a31ca`](https://github.com/lambdasistemi/cardano-node-clients/commit/f6a31ca6c169810a46e45648a0868d7a48eb1f02) via `source-repository-package` along with all transitive SRPs (chain-follower, rocksdb-kv-transactions, rocksdb-haskell, cardano-ledger-read, typed-protocols, quickcheck-state-machine, cuddle) and matching ledger / ouroboros constraints. Mirrors cardano-node-clients's own cabal.project — when its tag bumps, this file gets refreshed in the same commit.
- `flake.nix` + `nix/project.nix`: pin haskell.nix, hackage.nix, iohkNix, and CHaP to the same revisions as cardano-node-clients; bump the compiler to ghc9122; add the `fix-libs` module covering libsodium-vrf, secp256k1, libblst, lmdb, liburing plus `doHaddock = false` for the heavy ledger/plutus packages.
- `src/Asteria/Provider.hs`: thin `withN2C` wrapper around `runNodeClient` + `mkN2CProvider` / `mkN2CSubmitter`. Reads `CARDANO_NODE_SOCKET_PATH` and `NETWORK_MAGIC` from the environment.
- `app/PlayerMain.hs`: connects via `withN2C`, then loops `queryProtocolParams` + `sdkSometimes` every 5s, with `sdkUnreachable` on exception.

## Verified locally

```
docker compose -f testnets/cardano_node_master/docker-compose.yaml up -d
docker logs asteria-player-1
```

```
[sdk:reachable] asteria_player_started_1
[sdk:reachable] asteria_player_n2c_connected_1
[sdk:sometimes] asteria_player_pp_query_1
[sdk:sometimes] asteria_player_pp_query_1
[sdk:sometimes] asteria_player_pp_query_1
...
```

`sdk.jsonl` accumulates one `asteria_player_pp_query_<N>` event per player per ~5s. Both player containers pull from their respective relay's N2C socket without contention.

## Test plan

- [x] nix build .#asteria-player succeeds.
- [x] nix build .#docker-image && docker load < result produces a 158 MB image.
- [x] Bring up the local cluster; players connect and emit sdk_sometimes events steadily.
- [x] docker compose down --volumes --remove-orphans cleans up.

## Subsequent iterations

3. Compile [txpipe/asteria](https://github.com/txpipe/asteria/tree/main/onchain) Aiken validators with parameter application.
4. Real bootstrap (deploy ref-scripts, mint admin NFT, lock asteria UTxO, spawn pellets).
5. Game loop with injectable RandomSource.
6. Antithesis randomness wiring.
7. Richer assertions.