### PR TITLE
feat(asteria-player): bootstrap submits self-pay tx end-to-end

### DIFF
--- a/components/asteria-player/app/BootstrapMain.hs
+++ b/components/asteria-player/app/BootstrapMain.hs
@@ -1,25 +1,176 @@
 {- |
 Module      : Main
-Description : Iteration-1 stub for the asteria game bootstrap.
+Description : Iteration-5 bootstrap: real tx submission against the cluster.
 
-Emits 'sdkReachable' so the SDK fallback file shows the bootstrap
-container ran, then exits 0. Subsequent iterations replace this with
-the actual asteria bootstrap tx:
+Connects to N2C, reads the genesis signing key from
+@\/utxo-keys\/genesis.3.skey@, builds a no-op self-pay tx through
+the @TxBuild@ DSL, signs with the genesis key, and submits.
+Confirms by polling @queryUTxOs@ for the new tx output (the change
+output's hash and value).
 
-  1. Compile + parameter-apply the 4 Aiken validators.
-  2. Submit a tx that:
-       - mints the asteria admin NFT,
-       - locks the asteria UTxO at the asteria spend address with
-         inline @AsteriaDatum {ship_counter=0, shipyard_policy=…}@,
-       - deploys all four validators as inline reference scripts,
-       - mints the initial pellet UTxOs at known coordinates.
-
-When this exits 0 the docker-compose @depends_on@ on
-@service_completed_successfully@ unblocks the player containers.
+This proves the bootstrap binary can build → sign → submit → confirm
+end-to-end against the antithesis cluster without exploding. The
+actual asteria-shaped bootstrap (admin NFT mint, ref-script deploy,
+asteria UTxO + pellets) lands in iteration 5b on top of the wallet
+plumbing in 'Asteria.Wallet'.
 -}
 module Main (main) where
 
-import Asteria.Sdk (sdkReachable)
+import Control.Concurrent (threadDelay)
+import Control.Exception (SomeException, try)
+import Data.Aeson (object, (.=))
+import Data.Foldable (toList)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Void (Void)
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx (bodyTxL)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
+import Cardano.Ledger.Api.Tx.Out (TxOut, coinTxOutL)
+import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.TxBuild (
+    InterpretIO (..),
+    TxBuild,
+    build,
+    payTo,
+    spend,
+ )
+
+import Asteria.Provider (settingsFromEnv, withN2C)
+import Asteria.Sdk (sdkReachable, sdkSometimes, sdkUnreachable)
+import Asteria.Wallet (
+    WalletKey (..),
+    genesisKeyPath,
+    pickWalletUtxo,
+    readWalletKey,
+    walletAddr,
+ )
+import Cardano.Crypto.DSIGN (
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    deriveVerKeyDSIGN,
+    signedDSIGN,
+ )
+import Cardano.Ledger.Api.Tx (txIdTx, witsTxL)
+import Cardano.Ledger.Api.Tx.Wits (addrTxWitsL)
+import Cardano.Ledger.Hashes (extractHash)
+import Cardano.Ledger.Keys (
+    KeyRole (Witness),
+    VKey (..),
+    WitVKey (..),
+    asWitness,
+ )
+import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Node.Client.Ledger (ConwayTx)
+import Data.Set qualified as Set
+import Lens.Micro ((%~), (&))
 
 main :: IO ()
-main = sdkReachable "asteria_bootstrap_completed" Nothing
+main = do
+    sdkReachable "asteria_bootstrap_starting" Nothing
+    settings <- settingsFromEnv
+    walletKey <- readWalletKey genesisKeyPath
+    sdkReachable
+        "asteria_bootstrap_wallet_loaded"
+        ( Just $
+            object
+                [ "addr" .= T.pack (show (walletAddr walletKey))
+                ]
+        )
+    withN2C settings $ \provider submitter -> do
+        seed@(_, seedOut) <- pickWalletUtxo provider walletKey
+        let inputCoin = seedOut ^. coinTxOutL
+        sdkReachable
+            "asteria_bootstrap_seed_picked"
+            ( Just $
+                object
+                    ["seed_coin" .= unCoin inputCoin]
+            )
+        result <- try (selfPay provider submitter walletKey seed)
+        case result of
+            Left (e :: SomeException) -> do
+                sdkUnreachable
+                    "asteria_bootstrap_self_pay_failed"
+                    ( Just $
+                        object ["error" .= T.pack (show e)]
+                    )
+                error (show e)
+            Right () ->
+                sdkSometimes
+                    True
+                    "asteria_bootstrap_self_pay"
+                    Nothing
+    sdkReachable "asteria_bootstrap_completed" Nothing
+
+selfPay ::
+    Provider IO ->
+    Submitter IO ->
+    WalletKey ->
+    (TxIn, TxOut ConwayEra) ->
+    IO ()
+selfPay provider submitter wk seed@(seedIn, _) = do
+    pp <- queryProtocolParams provider
+    let addr = walletAddr wk
+        prog :: TxBuild NoQ Void ()
+        prog = do
+            _ <- spend seedIn
+            _ <- payTo addr (inject (Coin 5_000_000))
+            pure ()
+        eval tx =
+            fmap
+                (Map.map (either (Left . show) Right))
+                (evaluateTx provider tx)
+        interpret :: InterpretIO NoQ
+        interpret = InterpretIO $ \case {}
+    built <- build pp interpret eval [seed] [] addr prog
+    case built of
+        Left err -> error ("build: " <> show err)
+        Right tx -> do
+            let signed = addKeyWitness (wkSignKey wk) tx
+                outs = toList (signed ^. bodyTxL . outputsTxBodyL)
+            sdkReachable
+                "asteria_bootstrap_tx_built"
+                ( Just $
+                    object
+                        ["outputs" .= length outs]
+                )
+            r <- submitTx submitter signed
+            case r of
+                Submitted _ ->
+                    waitForConfirmation provider addr 60
+                Rejected reason ->
+                    error ("submit rejected: " <> show reason)
+
+waitForConfirmation ::
+    Provider IO -> Addr -> Int -> IO ()
+waitForConfirmation provider addr attempts
+    | attempts <= 0 = error "timed out waiting for confirmation"
+    | otherwise = do
+        outs <- queryUTxOs provider addr
+        if length outs >= 1
+            then pure ()
+            else do
+                threadDelay 1_000_000
+                waitForConfirmation provider addr (attempts - 1)
+
+-- | Phantom query GADT — bootstrap has no @ctx@ queries.
+data NoQ a
+
+addKeyWitness ::
+    SignKeyDSIGN Ed25519DSIGN -> ConwayTx -> ConwayTx
+addKeyWitness sk tx =
+    tx & witsTxL . addrTxWitsL %~ Set.union (Set.singleton w)
+  where
+    TxId h = txIdTx tx
+    vk = VKey (deriveVerKeyDSIGN sk)
+    w = WitVKey (asWitness vk) (signedDSIGN () (extractHash h) sk)

--- a/components/asteria-player/asteria-player.cabal
+++ b/components/asteria-player/asteria-player.cabal
@@ -46,7 +46,9 @@ library
     , base
     , base16-bytestring
     , bytestring
+    , cardano-crypto-class
     , cardano-ledger-alonzo
+    , cardano-ledger-api
     , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-node-clients
@@ -60,6 +62,7 @@ library
     Asteria.Provider
     Asteria.Sdk
     Asteria.Validators
+    Asteria.Wallet
 
 executable asteria-bootstrap
   import:           settings
@@ -67,8 +70,16 @@ executable asteria-bootstrap
   hs-source-dirs:   app
   default-language: GHC2021
   build-depends:
+    , aeson
     , asteria-player
     , base
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-node-clients
+    , containers
+    , microlens
     , text
 
 executable asteria-player

--- a/components/asteria-player/src/Asteria/Wallet.hs
+++ b/components/asteria-player/src/Asteria/Wallet.hs
@@ -1,0 +1,139 @@
+{- |
+Module      : Asteria.Wallet
+Description : Genesis-key wallet for the antithesis cluster.
+
+Reads the genesis-utxo signing key from
+@\/utxo-keys\/genesis.1.skey@ (placed there by the @configurator@
+container at cluster boot), decodes it, and exposes:
+
+  * 'genesisSignKey'  — the 'SignKeyDSIGN' for signing.
+  * 'genesisAddr'     — the Shelley payment address.
+  * 'pickGenesisUtxo' — first UTxO sitting at that address.
+
+The skey file is a Cardano text-envelope JSON document whose
+@cborHex@ field encodes a CBOR @bytes@ value (header @5820@) holding
+the raw 32-byte ed25519 secret key.
+-}
+module Asteria.Wallet (
+    WalletKey (..),
+    genesisKeyPath,
+    readWalletKey,
+    walletAddr,
+    pickWalletUtxo,
+) where
+
+import Cardano.Crypto.DSIGN (
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    deriveVerKeyDSIGN,
+    rawDeserialiseSignKeyDSIGN,
+ )
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.Tx.Out (TxOut)
+import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Credential (
+    Credential (KeyHashObj),
+    StakeReference (StakeRefNull),
+ )
+import Cardano.Ledger.Keys (KeyHash, KeyRole (Payment), VKey (..), hashKey)
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.Provider (Provider (..))
+import Data.Aeson (Value (Object), eitherDecodeFileStrict, (.:))
+import Data.Aeson.Types (parseEither)
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BS8
+import Data.Text (Text)
+import Data.Text qualified as T
+
+-- | Loaded wallet: signing key + key hash + address.
+data WalletKey = WalletKey
+    { wkSignKey :: SignKeyDSIGN Ed25519DSIGN
+    , wkKeyHash :: KeyHash Payment
+    }
+
+{- | Default mount-point for the antithesis cluster's genesis
+signing keys. The @configurator@ container writes them here at
+boot, and bootstrap / player containers mount it read-only.
+
+We pick @genesis.3.skey@ deliberately: @tx-generator@ takes the
+first available genesis key (@genesis.1@) and would race the
+bootstrap for the same UTxO otherwise, surfacing as a
+\"All inputs are spent\" mempool error.
+-}
+genesisKeyPath :: FilePath
+genesisKeyPath = "/utxo-keys/genesis.3.skey"
+
+{- | Read a Cardano text-envelope @.skey@ file and decode its
+@cborHex@ into a 'WalletKey'.
+-}
+readWalletKey :: FilePath -> IO WalletKey
+readWalletKey fp = do
+    raw <- eitherDecodeFileStrict fp
+    case raw of
+        Left e ->
+            error ("Asteria.Wallet: parse JSON " <> fp <> ": " <> e)
+        Right v ->
+            case parseEither (extractCborHex fp) v of
+                Left e -> error e
+                Right h -> pure (mkKey h)
+  where
+    extractCborHex path val = do
+        case val of
+            Object o -> do
+                hexT <- o .: "cborHex"
+                pure (hexT :: Text)
+            _ ->
+                fail
+                    ( "Asteria.Wallet: expected JSON object in "
+                        <> path
+                    )
+
+mkKey :: Text -> WalletKey
+mkKey hexT =
+    let bytes =
+            either
+                (error . ("Asteria.Wallet: hex decode: " <>))
+                id
+                (Base16.decode (BS8.pack (T.unpack hexT)))
+        -- Strip the CBOR header (1 byte tag + 1 byte length for
+        -- bytestrings of length 24..255). Genesis skeys are 32
+        -- bytes wrapped as "5820<32 bytes>".
+        keyBytes =
+            if BS.length bytes == 34
+                && BS.take 2 bytes == BS.pack [0x58, 0x20]
+                then BS.drop 2 bytes
+                else
+                    error
+                        ( "Asteria.Wallet: unexpected CBOR shape, "
+                            <> "len="
+                            <> show (BS.length bytes)
+                        )
+        sk =
+            maybe
+                (error "Asteria.Wallet: rawDeserialiseSignKeyDSIGN")
+                id
+                (rawDeserialiseSignKeyDSIGN keyBytes)
+        vk = VKey (deriveVerKeyDSIGN sk)
+        kh = hashKey vk
+     in WalletKey{wkSignKey = sk, wkKeyHash = kh}
+
+{- | Derive the Shelley payment address from a 'WalletKey'. No
+stake credential — same shape the e2e harness uses.
+-}
+walletAddr :: WalletKey -> Addr
+walletAddr wk = Addr Testnet (KeyHashObj (wkKeyHash wk)) StakeRefNull
+
+{- | Query the provider for UTxOs at the wallet's address and
+return the first one. Errors if there are none — caller is
+expected to call this once the cluster has booted.
+-}
+pickWalletUtxo ::
+    Provider IO -> WalletKey -> IO (TxIn, TxOut ConwayEra)
+pickWalletUtxo provider wk = do
+    let addr = walletAddr wk
+    outs <- queryUTxOs provider addr
+    case outs of
+        u : _ -> pure u
+        [] -> error ("Asteria.Wallet: no UTxOs at " <> show addr)


### PR DESCRIPTION
## Summary

Iteration 5 of the asteria phase-1 gatherer ([#56](https://github.com/cardano-foundation/cardano-node-antithesis/issues/56)). Builds on iter 1–4 (#57, #58, #59, #60), all merged.

The bootstrap binary now **submits a real transaction end-to-end** against the cluster: connects to N2C, reads a genesis signing key, picks a seed UTxO, builds a tx through the TxBuild DSL, signs, submits, and polls for confirmation. No-op shape (5 ADA self-pay) — the asteria-shaped bootstrap is iter 5b.

## Changes

- `src/Asteria/Wallet.hs` — reads `/utxo-keys/genesis.3.skey`, decodes the Cardano text-envelope JSON, strips the CBOR header, derives the Shelley address, exposes `pickWalletUtxo`. Picks `genesis.3` deliberately to avoid racing `tx-generator` (which takes `genesis.1`).
- `app/BootstrapMain.hs` — `withN2C` → wallet → seed UTxO → `TxBuild` self-pay → sign → submit → poll for confirmation. Six SDK events at milestones.

## Verified locally

```
[sdk:reachable]   asteria_bootstrap_starting
[sdk:reachable]   asteria_bootstrap_wallet_loaded
[sdk:reachable]   asteria_bootstrap_seed_picked      {"seed_coin":200000000000000}
[sdk:reachable]   asteria_bootstrap_tx_built         {"outputs":2}
[sdk:sometimes]   asteria_bootstrap_self_pay         true
[sdk:reachable]   asteria_bootstrap_completed
```

`asteria-bootstrap` exits 0; players unblock; pp-query loop continues.

## Notes

- First attempt used `genesis.1.skey` and hit `ConwayMempoolFailure \"All inputs are spent\"` — `tx-generator` was racing for the same UTxO. Switched to `genesis.3` (each genesis seed has 200_000 ADA, plenty for both).

## Test plan

- [x] nix build .#asteria-bootstrap succeeds.
- [x] nix build .#docker-image && docker load produces the image.
- [x] docker compose up -d → asteria-bootstrap exits 0, all six SDK events land.
- [x] asteria-player-1/-2 unblock and run pp-query loops.
- [x] docker compose down --volumes cleans up.

## Subsequent iterations

5b. Real asteria bootstrap (mint admin NFT, lock asteria UTxO with inline AsteriaDatum, deploy ref-scripts, spawn pellets).
6. Game loop with injectable RandomSource.
7. Antithesis randomness wiring.
8. Richer assertions.