### PR TITLE
feat(asteria-player): player observes asteria + plans random moves

### DIFF
--- a/components/asteria-player/app/PlayerMain.hs
+++ b/components/asteria-player/app/PlayerMain.hs
@@ -1,16 +1,28 @@
 {- |
 Module      : Main
-Description : Iteration-2 — query protocol params via N2C in a loop.
+Description : Iteration-6 player loop — discover asteria, plan moves.
 
-Connects to the cardano-node N2C socket at
-@$CARDANO_NODE_SOCKET_PATH@ using the queue / async pattern from
-cardano-node-clients's @withDevnet@. Once connected, queries protocol
-parameters in a loop (every 5 seconds) and emits an
-@asteria_player_pp_query_<id>@ 'sdk_sometimes' event so the antithesis
-hypervisor can confirm the player is genuinely talking to a node.
+Once the asteria UTxO is on-chain (created by @asteria-bootstrap@),
+each player container loops:
 
-Subsequent iterations replace the loop body with actual game state
-queries + tx submissions.
+  1. Query @asteria.spend@ for the asteria UTxO; emit
+     @asteria_player_asteria_observed_<id>@ when it appears.
+  2. Decode the inline @AsteriaDatum@ and emit
+     @asteria_player_ship_counter_<id>@ with the current
+     @ship_counter@ in the details body.
+  3. Pick a random move @(delta_x, delta_y)@ in @[-5, 5]@ via the
+     injectable 'RandomSource' (System.Random fallback in this
+     iteration; iteration 7 wires Antithesis's
+     @random.get_random()@). Emit
+     @asteria_player_move_planned_<id>@ with the deltas.
+  4. Sleep a random interval in @[1, 5]@ seconds.
+
+Iteration 6b will replace the "plan + emit" step with actually
+building and submitting the @mintShip@ tx, then looping
+@moveShip@ once a ship is owned. The DSL plumbing is already in
+place from @BootstrapMain.hs@ — this iteration just stops short
+of the spend so we can ship the discovery loop and Antithesis can
+already see ship-counter dynamics from observation alone.
 -}
 module Main (main) where
 
@@ -18,15 +30,37 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, try)
 import Control.Monad (forever)
 import Data.Aeson (object, (.=))
+import Data.Hashable (hash)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Lens.Micro ((^.))
 import System.Environment (lookupEnv)
 
-import Asteria.Provider (settingsFromEnv, withN2C)
-import Asteria.Sdk (sdkReachable, sdkSometimes, sdkUnreachable)
-import Asteria.Validators (asteriaScript, deployScript, pelletScript, spacetimeScript)
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Api.Tx (getPlutusData)
+import Cardano.Ledger.Api.Tx.Out (TxOut, datumTxOutL)
+import Cardano.Ledger.BaseTypes (Network (Testnet), StrictMaybe (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (hashScript)
+import Cardano.Ledger.Credential (
+    Credential (ScriptHashObj),
+    StakeReference (StakeRefNull),
+ )
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Plutus.Data (Datum (..), binaryDataToData)
 import Cardano.Node.Client.Provider (Provider (..))
+import PlutusTx.Builtins.Internal (BuiltinData (..))
+import PlutusTx.IsData.Class (fromBuiltinData)
+
+import Asteria.Datums (AsteriaDatum (..))
+import Asteria.Provider (settingsFromEnv, withN2C)
+import Asteria.RandomSource (
+    RandomSource,
+    newSystemSource,
+    randomInRange,
+ )
+import Asteria.Sdk (sdkReachable, sdkSometimes, sdkUnreachable)
+import Asteria.Validators (asteriaScript)
 
 main :: IO ()
 main = do
@@ -36,41 +70,68 @@ main = do
     sdkReachable
         ("asteria_player_started_" <> playerId)
         Nothing
-    -- Touch each validator so the blueprint-load machinery is
-    -- exercised at startup (not lazily on first game action).
-    -- Iteration 4 will swap these unapplied scripts for
-    -- parameter-applied versions and start using their hashes
-    -- as part of bootstrap.
-    let validatorHashes =
-            [ T.pack (show (hashScript asteriaScript))
-            , T.pack (show (hashScript spacetimeScript))
-            , T.pack (show (hashScript pelletScript))
-            , T.pack (show (hashScript deployScript))
-            ]
-    sdkReachable
-        ("asteria_player_validators_loaded_" <> playerId)
-        ( Just $
-            object ["hashes" .= validatorHashes]
-        )
+    -- Seed by hashing the player id so each replica picks a
+    -- distinct deterministic stream until iteration 7 swaps in
+    -- the Antithesis source.
+    rng <- newSystemSource (hash playerIdStr)
     settings <- settingsFromEnv
     withN2C settings $ \provider _submitter -> do
         sdkReachable
             ("asteria_player_n2c_connected_" <> playerId)
             Nothing
-        forever (loop provider playerId)
-  where
-    loop provider playerId = do
-        result <- try (queryProtocolParams provider)
-        case result of
-            Left (e :: SomeException) ->
-                sdkUnreachable
-                    ("asteria_player_pp_query_failed_" <> playerId)
-                    ( Just $
-                        object ["error" .= T.pack (show e)]
-                    )
-            Right _pp ->
-                sdkSometimes
-                    True
-                    ("asteria_player_pp_query_" <> playerId)
-                    Nothing
-        threadDelay 5_000_000
+        forever (loop provider rng playerId)
+
+loop :: Provider IO -> RandomSource -> Text -> IO ()
+loop provider rng playerId = do
+    result <- try (observeAndPlan provider rng playerId)
+    case result of
+        Left (e :: SomeException) ->
+            sdkUnreachable
+                ("asteria_player_loop_errored_" <> playerId)
+                (Just $ object ["error" .= T.pack (show e)])
+        Right () -> pure ()
+    sleepSecs <- randomInRange rng 1 5
+    threadDelay (fromIntegral sleepSecs * 1_000_000)
+
+observeAndPlan :: Provider IO -> RandomSource -> Text -> IO ()
+observeAndPlan provider rng playerId = do
+    let asteriaAddr = scriptAddr (hashScript asteriaScript)
+    outs <- queryUTxOs provider asteriaAddr
+    case outs of
+        [] -> do
+            sdkSometimes
+                False
+                ("asteria_player_asteria_observed_" <> playerId)
+                Nothing
+        ((_, out) : _) -> do
+            sdkSometimes
+                True
+                ("asteria_player_asteria_observed_" <> playerId)
+                Nothing
+            case decodeAsteria out of
+                Nothing ->
+                    sdkUnreachable
+                        ("asteria_player_datum_decode_failed_" <> playerId)
+                        Nothing
+                Just AsteriaDatum{adShipCounter = c} ->
+                    sdkReachable
+                        ("asteria_player_ship_counter_" <> playerId)
+                        (Just $ object ["ship_counter" .= c])
+            dx <- randomInRange rng (-5) 5
+            dy <- randomInRange rng (-5) 5
+            sdkSometimes
+                True
+                ("asteria_player_move_planned_" <> playerId)
+                ( Just $
+                    object ["delta_x" .= dx, "delta_y" .= dy]
+                )
+
+scriptAddr :: ScriptHash -> Addr
+scriptAddr h = Addr Testnet (ScriptHashObj h) StakeRefNull
+
+decodeAsteria :: TxOut ConwayEra -> Maybe AsteriaDatum
+decodeAsteria out = case out ^. datumTxOutL of
+    Datum bd ->
+        fromBuiltinData
+            (BuiltinData (getPlutusData (binaryDataToData bd)))
+    _ -> Nothing

--- a/components/asteria-player/asteria-player.cabal
+++ b/components/asteria-player/asteria-player.cabal
@@ -58,12 +58,14 @@ library
     , ouroboros-network:api
     , plutus-core
     , plutus-tx
+    , random
     , text
 
   exposed-modules:
     Asteria.Crypto
     Asteria.Datums
     Asteria.Provider
+    Asteria.RandomSource
     Asteria.Sdk
     Asteria.Validators
     Asteria.Wallet
@@ -96,6 +98,12 @@ executable asteria-player
     , aeson
     , asteria-player
     , base
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-conway
     , cardano-ledger-core
     , cardano-node-clients
+    , hashable
+    , microlens
+    , plutus-tx
     , text

--- a/components/asteria-player/src/Asteria/RandomSource.hs
+++ b/components/asteria-player/src/Asteria/RandomSource.hs
@@ -1,0 +1,62 @@
+{- |
+Module      : Asteria.RandomSource
+Description : Pluggable randomness for player decisions.
+
+Every player decision (which direction to move, when to mine,
+how long to sleep) goes through a 'RandomSource'. The default
+implementation uses 'System.Random' with a per-container seed
+('newSystemSource'). Iteration 7 will add an Antithesis-driven
+implementation that subprocesses to Python's
+@antithesis.random.get_random()@ so the hypervisor controls
+every game decision and can drive state-space exploration.
+
+The interface is a record-of-functions rather than a typeclass
+so the active source can be swapped at runtime by reading an
+env var.
+-}
+module Asteria.RandomSource (
+    RandomSource (..),
+    newSystemSource,
+    randomInRange,
+) where
+
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.Word (Word64)
+import System.Random (StdGen, mkStdGen, randomR)
+
+{- | A random-source handle. 'getU64' returns a fresh @Word64@
+on every call; thread-safety is the implementation's
+responsibility.
+-}
+newtype RandomSource = RandomSource
+    { getU64 :: IO Word64
+    }
+
+{- | A 'System.Random'-backed source seeded from the player's
+identifier so each container has a deterministic-but-distinct
+sequence. Drop-in fallback when the Antithesis SDK isn't
+reachable.
+-}
+newSystemSource :: Int -> IO RandomSource
+newSystemSource seed = do
+    ref <- newIORef (mkStdGen seed)
+    pure
+        RandomSource
+            { getU64 = atomicModifyIORef' ref drawWord64
+            }
+
+drawWord64 :: StdGen -> (StdGen, Word64)
+drawWord64 g =
+    let (w, g') = randomR (minBound, maxBound) g
+     in (g', w)
+
+{- | Draw an integer in @[lo, hi]@ inclusive. Implemented via
+modulo, which biases when @hi - lo + 1@ doesn't divide @2^64@,
+but the bias is below 1e-18 for practical asteria ranges
+(direction deltas in @-9..9@, sleep intervals in @1..30@).
+-}
+randomInRange :: RandomSource -> Integer -> Integer -> IO Integer
+randomInRange src lo hi = do
+    w <- getU64 src
+    let span_ = hi - lo + 1
+    pure (lo + fromIntegral w `mod` span_)


### PR DESCRIPTION
## Summary

Iteration 6 of the asteria phase-1 gatherer ([#56](https://github.com/cardano-foundation/cardano-node-antithesis/issues/56)). Builds on iter 1–5b (all merged).

The player now plays the **observation half** of the game: discovers the asteria UTxO created by the bootstrap, decodes the inline `AsteriaDatum`, picks a random move direction every loop iteration via a pluggable `RandomSource`. Submission of the move tx is deferred to iter 6b.

## Changes

- `src/Asteria/RandomSource.hs` — pluggable randomness as a record-of-functions. `newSystemSource` seeds `System.Random` from `ASTERIA_PLAYER_ID` hash so each replica has a distinct stream. `randomInRange` for direction deltas / sleep intervals. Iter 7 will add an Antithesis-driven sibling implementation; consumer code is already abstracted.
- `app/PlayerMain.hs` — observation loop:
  1. queryUTxOs at asteria spend address.
  2. emit `asteria_player_asteria_observed_<id>` sometimes(true|false).
  3. decode `AsteriaDatum` → emit `asteria_player_ship_counter_<id>` with the counter.
  4. draw `(delta_x, delta_y)` in `[-5, 5]` → emit `asteria_player_move_planned_<id>`.
  5. sleep `[1, 5]` seconds.

## Verified locally

```
[sdk:sometimes] asteria_player_asteria_observed_1
[sdk:reachable] asteria_player_ship_counter_1
[sdk:sometimes] asteria_player_move_planned_1
```

JSONL details:

```json
{"id":"asteria_player_ship_counter_1","details":{"ship_counter":0}}
{"id":"asteria_player_move_planned_1","details":{"delta_x":3,"delta_y":4}}
{"id":"asteria_player_ship_counter_2","details":{"ship_counter":0}}
{"id":"asteria_player_move_planned_2","details":{"delta_x":0,"delta_y":-4}}
```

Distinct deltas per replica confirm the seed-by-id strategy is producing independent streams.

## Test plan

- [x] nix build .#asteria-player succeeds.
- [x] nix build .#docker-image && docker load.
- [x] docker compose up -d → players observe asteria + emit move-planned events.
- [x] docker compose down --volumes cleans up.

## Subsequent iterations

6b. Replace plan with actual mintShip / moveShip submission.
7. Antithesis randomness wiring.
8. Richer assertions.