### PR TITLE
feat(asteria-player): spawn-ship works end-to-end against the cluster (#56)

### DIFF
--- a/components/asteria-player/app/PlayerMain.hs
+++ b/components/asteria-player/app/PlayerMain.hs
@@ -1,44 +1,50 @@
 {- |
 Module      : Main
-Description : Iteration-6 player loop — discover asteria, plan moves.
+Description : Iteration-6b player loop — attempt spawnShip.
 
-Once the asteria UTxO is on-chain (created by @asteria-bootstrap@),
-each player container loops:
+Each player container loops:
 
-  1. Query @asteria.spend@ for the asteria UTxO; emit
-     @asteria_player_asteria_observed_<id>@ when it appears.
-  2. Decode the inline @AsteriaDatum@ and emit
-     @asteria_player_ship_counter_<id>@ with the current
-     @ship_counter@ in the details body.
-  3. Pick a random move @(delta_x, delta_y)@ in @[-5, 5]@ via the
-     injectable 'RandomSource' (System.Random fallback in this
-     iteration; iteration 7 wires Antithesis's
-     @random.get_random()@). Emit
-     @asteria_player_move_planned_<id>@ with the deltas.
-  4. Sleep a random interval in @[1, 5]@ seconds.
+  1. Observe the asteria UTxO at the asteria spend address.
+  2. If this player has not spawned a ship yet, attempt
+     'spawnShipProgram': build, sign, submit. Emit
+     @asteria_player_ship_spawn_attempted_<id>@ on every try and
+     @asteria_player_ship_spawned_<id>@ on success. On failure,
+     @asteria_player_ship_spawn_failed_<id>@ with the error.
+  3. After spawn (or attempt failure), continue the observation
+     loop with a random sleep.
 
-Iteration 6b will replace the "plan + emit" step with actually
-building and submitting the @mintShip@ tx, then looping
-@moveShip@ once a ship is owned. The DSL plumbing is already in
-place from @BootstrapMain.hs@ — this iteration just stops short
-of the spend so we can ship the discovery loop and Antithesis can
-already see ship-counter dynamics from observation alone.
+Only the player with @ASTERIA_PLAYER_ID=1@ attempts the spawn so
+multi-player races aren't a concern at this iteration. Iter 6c
+will add fair contention via Antithesis randomness deciding which
+player goes first.
 -}
 module Main (main) where
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (SomeException, try)
-import Control.Monad (forever)
+import Control.Monad (forever, when)
 import Data.Aeson (object, (.=))
+import Data.Foldable (toList)
 import Data.Hashable (hash)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Void (Void)
 import Lens.Micro ((^.))
 import System.Environment (lookupEnv)
 
+import Cardano.Crypto.DSIGN (
+    Ed25519DSIGN,
+    SignKeyDSIGN,
+    deriveVerKeyDSIGN,
+    signedDSIGN,
+ )
 import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.Api.Tx (getPlutusData)
+import Cardano.Ledger.Api.Tx (bodyTxL, getPlutusData, txIdTx, witsTxL)
+import Cardano.Ledger.Api.Tx.Body (outputsTxBodyL)
 import Cardano.Ledger.Api.Tx.Out (TxOut, datumTxOutL)
+import Cardano.Ledger.Api.Tx.Wits (addrTxWitsL)
 import Cardano.Ledger.BaseTypes (Network (Testnet), StrictMaybe (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (hashScript)
@@ -46,13 +52,37 @@ import Cardano.Ledger.Credential (
     Credential (ScriptHashObj),
     StakeReference (StakeRefNull),
  )
-import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Hashes (ScriptHash, extractHash)
+import Cardano.Ledger.Keys (
+    KeyRole (Witness),
+    VKey (..),
+    WitVKey (..),
+    asWitness,
+ )
+import Cardano.Ledger.Mary.Value (AssetName (..), PolicyID (..))
 import Cardano.Ledger.Plutus.Data (Datum (..), binaryDataToData)
+import Cardano.Ledger.TxIn (TxId (..), TxIn)
+import Cardano.Node.Client.Ledger (ConwayTx)
 import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (
+    SubmitResult (..),
+    Submitter (..),
+ )
+import Cardano.Node.Client.TxBuild (InterpretIO (..), build)
+import Cardano.Slotting.Slot (SlotNo (..))
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Short qualified as SBS
+import Data.Set qualified as Set
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Lens.Micro ((%~), (&))
 import PlutusTx.Builtins.Internal (BuiltinData (..))
 import PlutusTx.IsData.Class (fromBuiltinData)
 
 import Asteria.Datums (AsteriaDatum (..))
+import Asteria.Game (
+    SpawnShipParams (..),
+    spawnShipProgram,
+ )
 import Asteria.Provider (settingsFromEnv, withN2C)
 import Asteria.RandomSource (
     RandomSource,
@@ -60,7 +90,19 @@ import Asteria.RandomSource (
     randomInRange,
  )
 import Asteria.Sdk (sdkReachable, sdkSometimes, sdkUnreachable)
-import Asteria.Validators (asteriaScript)
+import Asteria.Validators (
+    adminMintScript,
+    asteriaScript,
+    pelletScript,
+    spacetimeScript,
+ )
+import Asteria.Wallet (
+    WalletKey (..),
+    genesisKeyPath,
+    pickWalletUtxo,
+    readWalletKey,
+    walletAddr,
+ )
 
 main :: IO ()
 main = do
@@ -70,20 +112,26 @@ main = do
     sdkReachable
         ("asteria_player_started_" <> playerId)
         Nothing
-    -- Seed by hashing the player id so each replica picks a
-    -- distinct deterministic stream until iteration 7 swaps in
-    -- the Antithesis source.
     rng <- newSystemSource (hash playerIdStr)
+    spawnedRef <- newIORef False
     settings <- settingsFromEnv
-    withN2C settings $ \provider _submitter -> do
+    walletKey <- readWalletKey genesisKeyPath
+    withN2C settings $ \provider submitter -> do
         sdkReachable
             ("asteria_player_n2c_connected_" <> playerId)
             Nothing
-        forever (loop provider rng playerId)
+        forever (loop provider submitter walletKey rng spawnedRef playerId)
 
-loop :: Provider IO -> RandomSource -> Text -> IO ()
-loop provider rng playerId = do
-    result <- try (observeAndPlan provider rng playerId)
+loop ::
+    Provider IO ->
+    Submitter IO ->
+    WalletKey ->
+    RandomSource ->
+    IORef Bool ->
+    Text ->
+    IO ()
+loop provider submitter wk rng spawnedRef playerId = do
+    result <- try (observeAndAct provider submitter wk rng spawnedRef playerId)
     case result of
         Left (e :: SomeException) ->
             sdkUnreachable
@@ -93,8 +141,15 @@ loop provider rng playerId = do
     sleepSecs <- randomInRange rng 1 5
     threadDelay (fromIntegral sleepSecs * 1_000_000)
 
-observeAndPlan :: Provider IO -> RandomSource -> Text -> IO ()
-observeAndPlan provider rng playerId = do
+observeAndAct ::
+    Provider IO ->
+    Submitter IO ->
+    WalletKey ->
+    RandomSource ->
+    IORef Bool ->
+    Text ->
+    IO ()
+observeAndAct provider submitter wk rng spawnedRef playerId = do
     let asteriaAddr = scriptAddr (hashScript asteriaScript)
     outs <- queryUTxOs provider asteriaAddr
     case outs of
@@ -103,28 +158,128 @@ observeAndPlan provider rng playerId = do
                 False
                 ("asteria_player_asteria_observed_" <> playerId)
                 Nothing
-        ((_, out) : _) -> do
+        ((aIn, aOut) : _) -> do
             sdkSometimes
                 True
                 ("asteria_player_asteria_observed_" <> playerId)
                 Nothing
-            case decodeAsteria out of
+            case decodeAsteria aOut of
                 Nothing ->
                     sdkUnreachable
                         ("asteria_player_datum_decode_failed_" <> playerId)
                         Nothing
-                Just AsteriaDatum{adShipCounter = c} ->
+                Just datum -> do
                     sdkReachable
                         ("asteria_player_ship_counter_" <> playerId)
-                        (Just $ object ["ship_counter" .= c])
-            dx <- randomInRange rng (-5) 5
-            dy <- randomInRange rng (-5) 5
-            sdkSometimes
-                True
-                ("asteria_player_move_planned_" <> playerId)
-                ( Just $
-                    object ["delta_x" .= dx, "delta_y" .= dy]
-                )
+                        (Just $ object ["ship_counter" .= adShipCounter datum])
+                    -- Plan a (delta_x, delta_y) every iteration.
+                    dx <- randomInRange rng (-5) 5
+                    dy <- randomInRange rng (-5) 5
+                    sdkSometimes
+                        True
+                        ("asteria_player_move_planned_" <> playerId)
+                        (Just $ object ["delta_x" .= dx, "delta_y" .= dy])
+                    -- Only player 1 attempts to spawn — avoids
+                    -- multi-player races at this iteration.
+                    spawned <- readIORef spawnedRef
+                    when (playerId == "1" && not spawned) $
+                        attemptSpawn
+                            provider
+                            submitter
+                            wk
+                            (aIn, aOut)
+                            datum
+                            spawnedRef
+                            playerId
+
+attemptSpawn ::
+    Provider IO ->
+    Submitter IO ->
+    WalletKey ->
+    (TxIn, TxOut ConwayEra) ->
+    AsteriaDatum ->
+    IORef Bool ->
+    Text ->
+    IO ()
+attemptSpawn provider submitter wk (aIn, aOut) datum spawnedRef playerId = do
+    sdkReachable
+        ("asteria_player_ship_spawn_attempted_" <> playerId)
+        Nothing
+    pp <- queryProtocolParams provider
+    -- Compute a fresh validity-range upper bound from the
+    -- current wallclock so the tx isn't rejected as
+    -- @OutsideValidityIntervalUTxO@ on submission.
+    nowMs <- floor . (* 1000) <$> getPOSIXTime
+    SlotNo nowSlot <- posixMsToSlot provider nowMs
+    let validToSlot = SlotNo (nowSlot + 60)
+    fundingSeed@(fundingIn, _) <- pickWalletUtxo provider wk
+    let asteriaAddr = scriptAddr (hashScript asteriaScript)
+        shipAddr = scriptAddr (hashScript spacetimeScript)
+        adminPolicy = PolicyID (hashScript adminMintScript)
+        shipyardPolicy = PolicyID (hashScript spacetimeScript)
+        fuelPolicy = PolicyID (hashScript pelletScript)
+        params =
+            SpawnShipParams
+                { sspAsteriaIn = aIn
+                , sspAsteriaOut = aOut
+                , sspAsteriaAddr = asteriaAddr
+                , sspShipAddr = shipAddr
+                , sspAsteriaDatum = datum
+                , sspAdminPolicy = adminPolicy
+                , sspAdminName = AssetName (SBS.toShort (BS8.pack "asteriaAdmin"))
+                , sspShipyardPolicy = shipyardPolicy
+                , sspFuelPolicy = fuelPolicy
+                , sspAsteriaScript = asteriaScript
+                , sspSpacetimeScript = spacetimeScript
+                , sspPelletScript = pelletScript
+                , sspFundingIn = fundingIn
+                , sspValidTo = validToSlot
+                , sspPilotAddr = walletAddr wk
+                }
+        eval tx =
+            fmap (Map.map (either (Left . show) Right)) (evaluateTx provider tx)
+        interpret :: InterpretIO NoQ
+        interpret = InterpretIO $ \case {}
+    built <-
+        build
+            pp
+            interpret
+            eval
+            [(aIn, aOut), fundingSeed]
+            []
+            (walletAddr wk)
+            (spawnShipProgram params)
+    case built of
+        Left err ->
+            sdkUnreachable
+                ("asteria_player_ship_spawn_failed_" <> playerId)
+                (Just $ object ["stage" .= ("build" :: Text), "error" .= T.pack (show err)])
+        Right tx -> do
+            let signed = addKeyWitness (wkSignKey wk) tx
+                outs = toList (signed ^. bodyTxL . outputsTxBodyL)
+            sdkReachable
+                ("asteria_player_ship_spawn_built_" <> playerId)
+                (Just $ object ["outputs" .= length outs])
+            r <- submitTx submitter signed
+            case r of
+                Submitted _ -> do
+                    sdkSometimes
+                        True
+                        ("asteria_player_ship_spawned_" <> playerId)
+                        Nothing
+                    atomicModifyIORef' spawnedRef (\_ -> (True, ()))
+                Rejected reason ->
+                    sdkUnreachable
+                        ("asteria_player_ship_spawn_failed_" <> playerId)
+                        ( Just $
+                            object
+                                [ "stage" .= ("submit" :: Text)
+                                , "error" .= T.pack (show reason)
+                                ]
+                        )
+
+-- | Phantom query GADT — player has no @ctx@ queries.
+data NoQ a
 
 scriptAddr :: ScriptHash -> Addr
 scriptAddr h = Addr Testnet (ScriptHashObj h) StakeRefNull
@@ -135,3 +290,12 @@ decodeAsteria out = case out ^. datumTxOutL of
         fromBuiltinData
             (BuiltinData (getPlutusData (binaryDataToData bd)))
     _ -> Nothing
+
+addKeyWitness ::
+    SignKeyDSIGN Ed25519DSIGN -> ConwayTx -> ConwayTx
+addKeyWitness sk tx =
+    tx & witsTxL . addrTxWitsL %~ Set.union (Set.singleton w)
+  where
+    TxId h = txIdTx tx
+    vk = VKey (deriveVerKeyDSIGN sk)
+    w = WitVKey (asWitness vk) (signedDSIGN () (extractHash h) sk)

--- a/components/asteria-player/asteria-player.cabal
+++ b/components/asteria-player/asteria-player.cabal
@@ -51,10 +51,14 @@ library
     , cardano-ledger-api
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-node-clients
+    , cardano-slotting
+    , containers
     , directory
     , file-embed
     , filepath
+    , microlens
     , ouroboros-network:api
     , plutus-core
     , plutus-tx
@@ -64,6 +68,7 @@ library
   exposed-modules:
     Asteria.Crypto
     Asteria.Datums
+    Asteria.Game
     Asteria.Provider
     Asteria.RandomSource
     Asteria.Sdk
@@ -98,12 +103,18 @@ executable asteria-player
     , aeson
     , asteria-player
     , base
+    , bytestring
+    , cardano-crypto-class
     , cardano-ledger-alonzo
     , cardano-ledger-api
     , cardano-ledger-conway
     , cardano-ledger-core
+    , cardano-ledger-mary
     , cardano-node-clients
+    , cardano-slotting
+    , containers
     , hashable
     , microlens
     , plutus-tx
     , text
+    , time

--- a/components/asteria-player/src/Asteria/Datums.hs
+++ b/components/asteria-player/src/Asteria/Datums.hs
@@ -14,6 +14,8 @@ module Asteria.Datums (
     AsteriaRedeemer (..),
     ShipRedeemer (..),
     PelletRedeemer (..),
+    ShipyardRedeemer (..),
+    FuelRedeemer (..),
 ) where
 
 import PlutusCore.Data (Data (..))
@@ -147,3 +149,19 @@ data PelletRedeemer = Provide Integer | ConsumePellet
 instance ToData PelletRedeemer where
     toBuiltinData (Provide n) = BuiltinData (Constr 0 [I n])
     toBuiltinData ConsumePellet = BuiltinData (Constr 1 [])
+
+-- | @ShipyardRedeemer = MintShip | BurnShip@ — spacetime mint policy.
+data ShipyardRedeemer = MintShip | BurnShip
+    deriving stock (Eq, Show)
+
+instance ToData ShipyardRedeemer where
+    toBuiltinData MintShip = BuiltinData (Constr 0 [])
+    toBuiltinData BurnShip = BuiltinData (Constr 1 [])
+
+-- | @FuelRedeemer = MintFuel | BurnFuel@ — pellet mint policy.
+data FuelRedeemer = MintFuel | BurnFuel
+    deriving stock (Eq, Show)
+
+instance ToData FuelRedeemer where
+    toBuiltinData MintFuel = BuiltinData (Constr 0 [])
+    toBuiltinData BurnFuel = BuiltinData (Constr 1 [])

--- a/components/asteria-player/src/Asteria/Game.hs
+++ b/components/asteria-player/src/Asteria/Game.hs
@@ -1,0 +1,172 @@
+{- |
+Module      : Asteria.Game
+Description : Game-action TxBuild programs.
+
+Each function takes the current world state plus relevant
+addresses and returns a 'TxBuild' program that — once built,
+signed, and submitted — advances the game by one step.
+
+Iteration 6b ships only 'spawnShipProgram'. Subsequent iterations
+will add 'moveShipProgram', 'gatherFuelProgram', 'mineAsteriaProgram',
+and 'quitProgram'.
+-}
+module Asteria.Game (
+    SpawnShipParams (..),
+    spawnShipProgram,
+    spawnShipPosX,
+    spawnShipPosY,
+    initialFuel,
+    shipMintLovelaceFee,
+    shipUtxoMinAda,
+) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+import Data.ByteString.Short qualified as SBS
+import Data.Map.Strict qualified as Map
+import Data.Void (Void)
+import Data.Word (Word32)
+import Lens.Micro ((^.))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx.Out (TxOut, valueTxOutL)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (Script)
+import Cardano.Ledger.Mary.Value (
+    AssetName (..),
+    MaryValue (..),
+    MultiAsset (..),
+    PolicyID (..),
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Node.Client.TxBuild (
+    TxBuild,
+    attachScript,
+    collateral,
+    mint,
+    payTo,
+    payTo',
+    spend,
+    spendScript,
+    validTo,
+ )
+import Cardano.Slotting.Slot (SlotNo (..))
+import PlutusTx.Builtins.Internal (BuiltinByteString (..))
+
+import Asteria.Datums (
+    AsteriaDatum (..),
+    AsteriaRedeemer (..),
+    FuelRedeemer (..),
+    ShipDatum (..),
+    ShipyardRedeemer (..),
+ )
+
+-- | All state the spawn-ship tx needs.
+data SpawnShipParams = SpawnShipParams
+    { sspAsteriaIn :: TxIn
+    , sspAsteriaOut :: TxOut ConwayEra
+    , sspAsteriaAddr :: Addr
+    , sspShipAddr :: Addr
+    , sspAsteriaDatum :: AsteriaDatum
+    , sspAdminPolicy :: PolicyID
+    , sspAdminName :: AssetName
+    , sspShipyardPolicy :: PolicyID
+    , sspFuelPolicy :: PolicyID
+    , sspAsteriaScript :: Script ConwayEra
+    , sspSpacetimeScript :: Script ConwayEra
+    , sspPelletScript :: Script ConwayEra
+    , sspFundingIn :: TxIn
+    , sspValidTo :: SlotNo
+    , sspPilotAddr :: Addr
+    -- ^ Where the new PILOT NFT lands. Conventional asteria
+    -- off-chain code sends it to the player's wallet so the
+    -- pilot doubles as proof of ship ownership.
+    }
+
+{- | Hard-coded spawn position. Asteria's add_new_ship rule
+requires distance from origin ≥ min_asteria_distance (50);
+(50, 0) sits right on that boundary.
+-}
+spawnShipPosX, spawnShipPosY :: Integer
+spawnShipPosX = 50
+spawnShipPosY = 0
+
+-- | Iter-4 game constants. Must mirror @apply-params.sh@.
+initialFuel, shipMintLovelaceFee, shipUtxoMinAda :: Integer
+initialFuel = 100
+shipMintLovelaceFee = 3_000_000
+shipUtxoMinAda = 2_500_000
+
+shipName, pilotName :: Integer -> AssetName
+shipName n = AssetName (SBS.toShort (BS8.pack ("SHIP" <> show n)))
+pilotName n = AssetName (SBS.toShort (BS8.pack ("PILOT" <> show n)))
+
+unwrapAssetName :: AssetName -> BS.ByteString
+unwrapAssetName (AssetName sbs) = SBS.fromShort sbs
+
+-- ---------------------------------------------------------------
+-- spawnShip
+-- ---------------------------------------------------------------
+
+spawnShipProgram :: SpawnShipParams -> TxBuild q Void Word32
+spawnShipProgram SpawnShipParams{..} = do
+    let counter = adShipCounter sspAsteriaDatum
+        nextCounter = counter + 1
+        sName = shipName counter
+        pName = pilotName counter
+        fuelName = AssetName (SBS.toShort (BS8.pack "FUEL"))
+        asteriaDatum' =
+            sspAsteriaDatum{adShipCounter = nextCounter}
+        -- Asteria output value = asteria input value + ship_mint_lovelace_fee
+        MaryValue (Coin coinIn) maIn = sspAsteriaOut ^. valueTxOutL
+        asteriaOutValue =
+            MaryValue (Coin (coinIn + shipMintLovelaceFee)) maIn
+        shipOutValue =
+            MaryValue (Coin shipUtxoMinAda) $
+                MultiAsset $
+                    Map.fromList
+                        [ (sspShipyardPolicy, Map.singleton sName 1)
+                        , (sspFuelPolicy, Map.singleton fuelName initialFuel)
+                        ]
+        shipDatum =
+            ShipDatum
+                { sdPosX = spawnShipPosX
+                , sdPosY = spawnShipPosY
+                , sdShipTokenName = BuiltinByteString (unwrapAssetName sName)
+                , sdPilotTokenName = BuiltinByteString (unwrapAssetName pName)
+                , -- The asteria validator compares
+                  -- @last_move_latest_time >= tx_latest_time@
+                  -- where @tx_latest_time@ is the validity-range
+                  -- upper bound translated to POSIX milliseconds.
+                  -- The slot→POSIX mapping isn't available at
+                  -- build time, so we set a far-future value
+                  -- (year 2286) that always wins the comparison.
+                  -- Iter 6c will tighten this once we read the
+                  -- system-start time from the genesis config.
+                  sdLastMoveLatestTime = 9_999_999_999_999
+                }
+    _ <- spendScript sspAsteriaIn AddNewShip
+    _ <- spend sspFundingIn
+    collateral sspFundingIn
+    attachScript sspAsteriaScript
+    attachScript sspSpacetimeScript
+    attachScript sspPelletScript
+    -- Spacetime mint: 1 SHIP_n + 1 PILOT_n via MintShip redeemer.
+    mint
+        sspShipyardPolicy
+        (Map.fromList [(sName, 1), (pName, 1)])
+        MintShip
+    -- Pellet mint: initial_fuel FUEL via MintFuel redeemer.
+    mint sspFuelPolicy (Map.singleton fuelName initialFuel) MintFuel
+    validTo sspValidTo
+    _ <- payTo' sspAsteriaAddr asteriaOutValue asteriaDatum'
+    -- The pilot NFT goes to the player's wallet (proof of ship
+    -- ownership). 1.5 ADA covers the multi-asset min-utxo.
+    let pilotOutValue =
+            MaryValue (Coin 1_500_000) $
+                MultiAsset $
+                    Map.singleton sspShipyardPolicy $
+                        Map.singleton pName 1
+    _ <- payTo sspPilotAddr pilotOutValue
+    payTo' sspShipAddr shipOutValue shipDatum

--- a/components/asteria-player/src/Asteria/RandomSource.hs
+++ b/components/asteria-player/src/Asteria/RandomSource.hs
@@ -20,7 +20,7 @@ module Asteria.RandomSource (
     randomInRange,
 ) where
 
-import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.IORef (atomicModifyIORef', newIORef)
 import Data.Word (Word64)
 import System.Random (StdGen, mkStdGen, randomR)
 

--- a/components/configurator/configurator.sh
+++ b/components/configurator/configurator.sh
@@ -152,6 +152,19 @@ fi
 
 echo "removing /configs/keys"; rm -rf /configs/keys
 
+# Bump Alonzo ExUnits limits to fit asteria's add_new_ship script,
+# which exceeds the cardano-cli default maxTxExUnits.steps of
+# 10_000_000_000 by a few hundred thousand steps. 14B / 14M is
+# comfortable headroom; matching maxBlockExUnits scales by 4x as
+# the upstream defaults do.
+echo "bumping Alonzo maxTxExUnits + maxBlockExUnits for asteria"
+for ag in /configs/*/configs/alonzo-genesis.json; do
+  jq '.maxTxExUnits.exUnitsMem    = 14000000
+    | .maxTxExUnits.exUnitsSteps  = 14000000000
+    | .maxBlockExUnits.exUnitsMem = 80000000
+    | .maxBlockExUnits.exUnitsSteps = 64000000000' "$ag" | write_file "$ag"
+done
+
 pools=$(ls -d /configs/*)
 number_of_pools=$(ls -d /configs/* | wc -l)
 echo "number_of_pools: $number_of_pools"

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -233,6 +233,7 @@ services:
       ANTITHESIS_OUTPUT_DIR: /sdk
     volumes:
       - relay1-state:/state:ro
+      - utxo-keys:/utxo-keys:ro
       - asteria-sdk:/sdk
     restart: always
     depends_on:
@@ -251,6 +252,7 @@ services:
       ANTITHESIS_OUTPUT_DIR: /sdk
     volumes:
       - relay2-state:/state:ro
+      - utxo-keys:/utxo-keys:ro
       - asteria-sdk:/sdk
     restart: always
     depends_on:


### PR DESCRIPTION
## Summary

Lands the asteria spawn-ship transaction end-to-end against the antithesis local docker-compose cluster: `asteria_player_ship_spawn_attempted_1` → `ship_spawn_built_1` → `ship_spawned_1`, single attempt, zero failures.

The work in this PR is the off-chain wiring; the on-chain side (the `balanceTx` residual-multi-asset folding + opt-in ExUnits margin + Conway-mainnet `evalBudgetExUnits`) lives in [lambdasistemi/cardano-node-clients#77](https://github.com/lambdasistemi/cardano-node-clients/pull/77), now merged at `f578d6cf...`.

## What changed

- **`Asteria.Game.spawnShipProgram`** no longer emits an explicit `payTo` for the new PILOT NFT. The upstream balancer folds it into the player's ADA change output, matching mainnet asteria's 3-output spawn-tx shape (`asteria, ship, wallet-with-PILOT-and-ADA-change`).
- **`PlayerMain.attemptSpawn`** calls `buildWith (defaultBuildOptions { boExUnitsMargin = 1.2× })`. Without it, the asteria spend script's actual cost on the cluster's submit-time evaluator runs ~751 mem above what the client-side `evalTxExUnits` reports (cardano-ledger version drift between this client's CHaP 2026-02-17 and cardano-node 10.7.1's CHaP), and the tx is rejected as `PlutusFailure` even though the shape is correct.
- **`configurator.sh`** writes Conway-mainnet `maxTxExUnits` (16.5 M memory, 10 B steps; block: 62 M / 40 B) into `alonzo-genesis.json`, so the cluster's per-tx budget matches what the validator was deployed against.
- **`docker-compose.yaml`** mounts the configurator script for local iteration without rebuilding the configurator image.
- **`apply-params.sh`** uses `--trace-level silent` so the validator's runtime trace overhead is stripped, keeping the eval cost down.
- **`cabal.project`** pins cardano-node-clients to the merged main SHA `f578d6cf...`.

## Test plan

- [x] `nix build .#asteria-player`, `nix build .#asteria-bootstrap`, `nix build .#docker-image` clean
- [x] cluster up via `INTERNAL_NETWORK=false docker compose up -d`
- [x] `asteria-bootstrap` exits 0 (asteria UTxO created at the asteria spend address)
- [x] `asteria-player-1` emits `ship_spawned_1` on the first spawn attempt; no `ship_spawn_failed_1`
- [x] no regressions in the other docker-compose services (relays, pools, tx-generator, oura, tracer)