### PR TITLE
testnet: strip asteria-player from compose to unblock scheduled runs

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -188,77 +188,6 @@ services:
       tracer:
         condition: service_started
 
-  # ----------------------------------------------
-  # Asteria game (issue #56). Bootstrap is a
-  # one-shot service that deploys validators +
-  # creates the asteria UTxO + spawns pellets.
-  # Players are long-running services that loop
-  # the game decisions, with their RNG sourced
-  # from Antithesis instrumentation so the
-  # hypervisor can drive game state-space
-  # exploration. Iteration 1 wires the pipeline
-  # only — bootstrap and player binaries are
-  # placeholders that emit sdk_reachable.
-  # ----------------------------------------------
-
-  asteria-bootstrap:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-player:dev
-    container_name: asteria-bootstrap
-    hostname: asteria-bootstrap.example
-    # Override the image's `sleep-forever` entrypoint so the
-    # composer driver actually runs and the container exits 0
-    # once the bootstrap is complete.
-    entrypoint: ["/bin/parallel_driver_asteria_bootstrap"]
-    environment:
-      CARDANO_NODE_SOCKET_PATH: /state/node.socket
-      NETWORK_MAGIC: "42"
-      ANTITHESIS_OUTPUT_DIR: /sdk
-    volumes:
-      - relay1-state:/state:ro
-      - utxo-keys:/utxo-keys:ro
-      - asteria-sdk:/sdk
-    depends_on:
-      relay1:
-        condition: service_started
-
-  asteria-player-1:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-player:dev
-    container_name: asteria-player-1
-    hostname: asteria-player-1.example
-    entrypoint: ["/bin/parallel_driver_asteria_player"]
-    environment:
-      ASTERIA_PLAYER_ID: "1"
-      CARDANO_NODE_SOCKET_PATH: /state/node.socket
-      NETWORK_MAGIC: "42"
-      ANTITHESIS_OUTPUT_DIR: /sdk
-    volumes:
-      - relay1-state:/state:ro
-      - utxo-keys:/utxo-keys:ro
-      - asteria-sdk:/sdk
-    restart: always
-    depends_on:
-      asteria-bootstrap:
-        condition: service_completed_successfully
-
-  asteria-player-2:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-player:dev
-    container_name: asteria-player-2
-    hostname: asteria-player-2.example
-    entrypoint: ["/bin/parallel_driver_asteria_player"]
-    environment:
-      ASTERIA_PLAYER_ID: "2"
-      CARDANO_NODE_SOCKET_PATH: /state/node.socket
-      NETWORK_MAGIC: "42"
-      ANTITHESIS_OUTPUT_DIR: /sdk
-    volumes:
-      - relay2-state:/state:ro
-      - utxo-keys:/utxo-keys:ro
-      - asteria-sdk:/sdk
-    restart: always
-    depends_on:
-      asteria-bootstrap:
-        condition: service_completed_successfully
-
 volumes:
   tracer:
   p1-configs:
@@ -267,7 +196,6 @@ volumes:
   relay1-state:
   relay2-state:
   utxo-keys:
-  asteria-sdk:
 
 networks:
   default:


### PR DESCRIPTION
## Why

Every scheduled `cfhal` run on `testnets/cardano_node_master` since 2026-04-25 19:28 UTC has come back **Incomplete** with zero container stdout — the SUT never started.

Root cause: compose references `ghcr.io/.../asteria-player:dev`. The publish-images script ([`scripts/push-cardano_node_master_images.sh`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/scripts/push-cardano_node_master_images.sh)) resolves each compose tag via `git rev-list -n 1 "$TAG"`; `dev` resolves to nothing, so the image is never built/pushed and Antithesis can't pull it.

Latest publish-images run confirms: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/24960399181

> `Processing: asteria-player (tag: dev)`
> `Error: Tag 'dev' not found in repo. Skipping asteria-player.`

## What

Remove the `asteria-bootstrap` / `asteria-player-1` / `asteria-player-2` services and the `asteria-sdk` volume from `testnets/cardano_node_master/docker-compose.yaml`. Nothing else changes — `oura:latest`, `sidecar:1362c5b`, every other component-tag stay exactly as they were on the green-on-day-24 baseline (commit 7e0f8f5c).

`components/asteria-player/` and the composer scripts stay — PR #67 will re-add the compose block with a real image tag.

Ogmios is already absent from main (removed in 7e0f8f5 pending #49).

## After merge

The next scheduled `cfhal` run should boot the SUT and complete normally with the same probabilistic findings profile as the pre-asteria scheduled runs.