### PR TITLE
docs(spec): indexer-backed read side for test workloads (003, refs #69)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# cardano-node-antithesis-issue-69 Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-27
+
+## Active Technologies
+
+- (003-indexer-read-side)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+# Add commands for 
+
+## Code Style
+
+: Follow standard conventions
+
+## Recent Changes
+
+- 003-indexer-read-side: Added
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/specs/003-indexer-read-side/checklists/requirements.md
+++ b/specs/003-indexer-read-side/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Indexer-Backed Read Side for Test Workloads
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-26
+**Feature**: [spec.md](../spec.md)
+**Parent issue**: [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Upstream dependency: [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) — minimal address→UTxO indexer daemon (Unix socket, NDJSON, in-memory, two read primitives). Named in FR-011, FR-012, and Assumptions; the compose wiring lands once that ships.
+- Rejected upstream candidate: [`cardano-utxo-csmt`](https://github.com/lambdasistemi/cardano-utxo-csmt) (closed transport ticket [`#233`](https://github.com/lambdasistemi/cardano-utxo-csmt/issues/233)). Its CSMT + dual-mode backend + journal-replay structure exists for inclusion proofs, which this spec does not need; stripping CSMT leaves nothing reusable.
+- `cardano-cli query utxo --address` is named in FRs as the failing pattern to remove, per [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69).
+- Compose file paths (`testnets/cardano_node_master/docker-compose.yaml`) and component directory names (`components/tx-generator`, `components/asteria-player`) are referenced because they bound the integration surface; the spec does not prescribe code structure inside those components.
+- `MUST` / `MUST NOT` language is used in functional requirements to make each requirement directly checkable.
+- Items marked incomplete would require spec updates before `/speckit.clarify` or `/speckit.plan`. None remain.

--- a/specs/003-indexer-read-side/contracts/compose-topology.md
+++ b/specs/003-indexer-read-side/contracts/compose-topology.md
@@ -1,0 +1,115 @@
+# Contract: Compose Topology
+
+**Feature**: 003-indexer-read-side
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Data Model**: [../data-model.md](../data-model.md)
+**File touched**: [`testnets/cardano_node_master/docker-compose.yaml`](../../../testnets/cardano_node_master/docker-compose.yaml)
+
+This is the YAML diff this PR introduces. The shape (not the literal bytes) is the contract: a follow-up to a sibling testnet that wants the same indexer follows the same shape.
+
+## Adds
+
+### A new `indexer` service
+
+```yaml
+  indexer:
+    image: ghcr.io/lambdasistemi/cardano-utxo-indexer:<tag>   # final image name from #78
+    container_name: indexer
+    hostname: indexer.example
+    command: >
+      --relay-socket /state/node.socket
+      --listen /sock/indexer.sock
+    volumes:
+      - relay1-state:/state:ro
+      - indexer-sock:/sock
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - 'echo ''{"ready":null}'' | socat - UNIX-CONNECT:/sock/indexer.sock | jq -e .ready'
+      interval: 5s
+      timeout: 3s
+      retries: 60
+      start_period: 10s
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+```
+
+Notes:
+- Mounts the same `relay1-state` volume that today's `tx-generator` and `oura` mount. Same N2C socket, read-only.
+- Owns the new `indexer-sock` volume read-write. Consumers mount it read-only.
+- The healthcheck uses the wire from [contracts/indexer-client.md](./indexer-client.md) REQ-3. `socat` and `jq` are expected in the daemon image (the daemon is allowed to ship a small amount of tooling for self-healthcheck — constitution's "minimal sidecar image" rule applies to *sidecar* composer-command containers, not to service containers like this one).
+
+### A new `indexer-sock` volume
+
+```yaml
+volumes:
+  # ... existing ...
+  indexer-sock:
+```
+
+Ephemeral. Holds exactly one file: `indexer.sock`. Cleared on `docker compose down -v`.
+
+## Modifies
+
+### `tx-generator` service
+
+```yaml
+  tx-generator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:<commit-sha-from-this-branch>   # bumped per constitution VII
+    # ... existing fields ...
+    environment:
+      # existing:
+      CARDANO_NODE_SOCKET_PATH: /state/node.socket
+      NETWORK_MAGIC: "42"
+      # added:
+      INDEXER_SOCKET_PATH: /sock/indexer.sock
+      REFUND_THRESHOLD_LOVELACE: "5000000"
+      REFUND_TOPUP_LOVELACE: "100000000"
+      TX_GENERATOR_PACING: "none"
+      INDEXER_RETRY_BACKOFF: "5"
+    volumes:
+      # existing:
+      - relay1-state:/state:ro
+      - p1-configs:/configs:ro
+      - utxo-keys:/utxo-keys:ro
+      # added:
+      - indexer-sock:/sock:ro
+    depends_on:
+      # existing:
+      relay1:
+        condition: service_started
+      # added:
+      indexer:
+        condition: service_healthy
+```
+
+Notes:
+- Image tag bump is mandatory per constitution principle VII. The actual SHA is filled in by the final commit of the branch (vertical commit 4 in [plan.md](../plan.md)).
+- `relay1-state` mount stays read-only — submission still uses `cardano-cli transaction submit` over the relay's Unix socket (FR-009). Only the read side moves.
+- Refund threshold + top-up env vars expose the invariants from [research.md R-002](../research.md). Defaults match the data model.
+
+### Asteria services (`asteria-bootstrap`, `asteria-player-1`, `asteria-player-2`)
+
+Identical mount + env additions as tx-generator (the `INDEXER_SOCKET_PATH` env, the `indexer-sock:/sock:ro` volume, the `depends_on: indexer: service_healthy`). Image tag for asteria-player is **not** bumped in this PR — the asteria-player binary's actual port to the indexer happens in [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67); this PR only wires the volume + env so PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) inherits them on rebase.
+
+## Does not change
+
+- Existing volumes (`p1-configs`, `p2-configs`, `p3-configs`, `relay1-state`, `relay2-state`, `utxo-keys`, `tracer`, `asteria-sdk`).
+- Existing services other than tx-generator / asteria-* (`configurator`, `tracer`, `p1`, `p2`, `p3`, `relay1`, `relay2`, `oura`, `sidecar`, `tracer-sidecar`, `log-tailer`).
+- The `networks.default` block (`internal: ${INTERNAL_NETWORK}` toggle untouched). The indexer never exposes a TCP port; the only inter-container channel is the shared `indexer-sock` volume.
+
+## Acceptance against this contract
+
+A docker compose `config` (lint) + `up -d` smoke run on a clean machine MUST:
+
+1. Start `indexer` after `relay1` is up.
+2. Reach `indexer` healthy within `start_period + retries × interval = 10 + 60×5 = 5m10s` worst case (target [SC-006](../spec.md): `ready=true` within 1 minute on devnet).
+3. Start `tx-generator` only after `indexer` is healthy.
+4. `docker compose exec indexer ls /sock/indexer.sock` shows the socket file.
+5. `docker compose exec tx-generator ls /sock/indexer.sock` shows the same socket file (verifying the shared-volume mount).
+6. `docker logs indexer` shows N2C chain-sync events; `docker logs tx-generator` shows successful `INDEXER_READY` SDK signal followed by tx submissions.
+
+## Image hygiene
+
+Per constitution Principle VII, the tx-generator image tag bump in this PR resolves to a commit on this branch that contains both the rewritten `tx_generator.py` and the new `indexer_client.py`. `publish-images` workflow on push rebuilds and pushes the image; the SHA in compose matches the commit. `merge-guard` enforces this on merge.

--- a/specs/003-indexer-read-side/contracts/indexer-client.md
+++ b/specs/003-indexer-read-side/contracts/indexer-client.md
@@ -1,0 +1,95 @@
+# Contract: Indexer Client (NDJSON over Unix socket)
+
+**Feature**: 003-indexer-read-side
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md) | **Data Model**: [../data-model.md](../data-model.md)
+**Daemon**: [`lambdasistemi/cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) (the producer of this contract)
+
+This is the wire contract consumed by `tx-generator` (Python) and `asteria-player` (Haskell, in PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)). The daemon is the producer; this document is the consumer-side specification of the same wire.
+
+## Transport
+
+- Unix domain socket, `SOCK_STREAM`, default path `/sock/indexer.sock` (configurable per-consumer via env `INDEXER_SOCKET_PATH`).
+- One subscription per connection. Close the socket to cancel. No multiplexing.
+- Wire format: newline-delimited JSON (NDJSON), UTF-8, one JSON object per line. `\n` is the only line terminator.
+
+## Requests
+
+### REQ-1: `utxos_at` — snapshot at address
+
+**Request line**:
+```json
+{"utxos_at": "<bech32-or-base16-address>"}
+```
+
+**Response (one line, then EOF)**:
+```json
+{"utxos": [{"txin": "<txid>#<ix>", "txout": "<base16-cbor>"}, ...]}
+```
+
+- `txid` is hex (64 chars, lowercase). `ix` is a non-negative integer.
+- `txout` is base16-encoded CBOR of the Cardano `TxOut` (era-appropriate). Consumers either deserialize via cardano-cli helpers (Python: shell out is acceptable; Haskell: `cardano-ledger-*` decoder) or, for the address-and-value-only use case in this spec, parse only the lovelace and asset entries from the CBOR.
+- An empty `utxos: []` response means "no UTxOs at this address right now"; this is not an error.
+
+**Error responses**:
+- `{"error": "<message>"}` — daemon failed to serve the request (e.g. address parse failure). Raised as `IndexerUnavailable`.
+
+### REQ-2: `await` — block until `(txid, ix)` appears
+
+**Request line**:
+```json
+{"await": "<txid>#<ix>", "timeout_seconds": <int>}
+```
+
+- `timeout_seconds` is optional; if omitted, the daemon waits indefinitely (until consumer closes the socket).
+
+**Response (one line, then EOF)**:
+- On observation: `{"slot": <int>, "blockHash": "<hex>", "txout": "<base16-cbor>"}`
+- On timeout: `{"timeout": true}`
+
+**Cancellation**: consumer closes the socket. Daemon discards the subscription.
+
+**Rollback semantics** (per [spec.md](../spec.md) wait primitive — final): the daemon emits the response line on the first observation. If the observed block is rolled back before the response line is written, the daemon stays open and waits for the next observation. Once the line is written, the daemon closes the socket; rollback handling after that point is the caller's concern (rediscoverable via `utxos_at`).
+
+### REQ-3: `ready` — readiness probe
+
+**Request line**:
+```json
+{"ready": null}
+```
+
+**Response (one line, then EOF)**:
+```json
+{"ready": <bool>, "tipSlot": <int|null>, "processedSlot": <int|null>, "slotsBehind": <int|null>}
+```
+
+- `ready=true` ⇔ `slotsBehind ≤ K` for a daemon-internal threshold K (consumer doesn't need to know K).
+- All slot fields may be `null` during the very first moments after the daemon starts and before it has observed any chain-sync activity.
+
+This request is also what the docker compose healthcheck uses (per [../research.md R-004](../research.md)).
+
+## Failure model
+
+- **Connection refused / EOF mid-line / unparseable JSON / `{"error": ...}` response**: consumer raises `IndexerUnavailable` (or language-equivalent). One catch site per consumer, in the main loop. Surfacing the error and pausing the workload is the only legal response. Falling back to `cardano-cli query utxo --address` is **forbidden** (FR-006).
+- **Slow daemon** (long catch-up, `slotsBehind > 0`): consumers see `ready=false` from the healthcheck and don't start until the daemon goes ready. After startup, momentary lag is tolerated — `utxos_at` returns the daemon's last-applied set; consumers proceed with the deterministic-chain assumption.
+- **Daemon crash mid-await**: consumer sees EOF on the read; raise `IndexerUnavailable`.
+
+## Antithesis SDK assertions on this contract
+
+Consumers MUST emit at least the following SDK signals during steady-state operation (constitution Principle II):
+
+| Trigger | SDK call | Meaning |
+|---|---|---|
+| First successful `ready=true` after consumer startup | `reachable("indexer_ready")` | Indexer is wired in and reachable. |
+| Refund tx is built | `sometimes("refund_triggered")` | Both this branch and the no-refund branch must be observed under fault injection. |
+| About to build self-pay or refund | `always("active_utxo_above_min", <bool>)` | Invariant — must be true before every build. |
+| Caught a non-`IndexerUnavailable` exception that masked an indexer failure | `unreachable("indexer_silently_unreachable")` | Defensive — the SDK report flags it if the failure model is ever bypassed. |
+
+## Out-of-scope (not in v1)
+
+- Policy/asset-keyed lookups (`utxos_by_policy`). Consumers filter `value` in-process for asset-class discovery.
+- Cancel-message vocabulary (`{"cancel": ...}`). One subscription per connection; close to cancel.
+- Streaming subscriptions returning more than one response line. Every v1 request emits exactly one response line then EOF.
+
+## Versioning
+
+This contract is v1. Future additions (e.g. policy-keyed snapshot, multi-line streams) are additive and gated behind a new request kind, not a wire-level versioning header.

--- a/specs/003-indexer-read-side/data-model.md
+++ b/specs/003-indexer-read-side/data-model.md
@@ -1,0 +1,133 @@
+# Data Model: Indexer-Backed Read Side for Test Workloads
+
+**Feature**: 003-indexer-read-side
+**Date**: 2026-04-27
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Research**: [research.md](./research.md)
+
+This is a workload port + compose change, not a service with persistent data. The "data model" here is (a) the in-process state that tx-generator carries between iterations of its submit loop, and (b) the wire shapes consumed from the indexer daemon (which are also documented as the contract in [contracts/indexer-client.md](./contracts/indexer-client.md)).
+
+## E1 — `TxGenState` (in-memory, single-threaded)
+
+Held as Python attributes on the running tx-generator process. No persistence; on container restart, recovered by re-reading the address from the indexer (per [research.md R-001](./research.md)).
+
+| Field | Type | Source / Invariant |
+|---|---|---|
+| `address` | `str` (bech32) | Picked at startup from `/utxo-keys/genesis.<N>.addr.info`; same key for the entire run. |
+| `skey_path` | `str` (path) | Sibling `genesis.<N>.skey` to `address`. |
+| `active_txin` | `(txid: str, ix: int)` | Initialised at startup from `utxos_at(address)` selecting any UTxO with `lovelace ≥ T`. After each successful self-pay tx, advanced to `(new_txid, 0)`. After each refund tx, advanced to `(refund_txid, 0)`. |
+| `active_lovelace` | `int` | Lovelace value of the active UTxO. Decremented locally by the just-built tx's fee (read from the tx body) so we don't need a re-query. Reset on refund. |
+| `refund_threshold` | `int` (lovelace) | Env `REFUND_THRESHOLD_LOVELACE`, default 5_000_000. Constant for the run. |
+| `refund_topup` | `int` (lovelace) | Env `REFUND_TOPUP_LOVELACE`, default 100_000_000. Constant for the run. |
+| `pacing_mode` | `"none" \| "await"` | Env `TX_GENERATOR_PACING`, default `"none"` (per [research.md R-005](./research.md)). |
+| `await_timeout_seconds` | `int` | Env `TX_GENERATOR_AWAIT_TIMEOUT_SECONDS`, default 60. Used only when `pacing_mode = "await"`. |
+| `tx_count` | `int` | Total submitted (self-pay + refund), exposed in logs. |
+| `error_count` | `int` | Total caught + retried errors, exposed in logs. |
+
+**State invariants**:
+- `active_lovelace ≥ min_utxo + safety_margin` at every loop entry (asserted via SDK `always(active_utxo_above_min)` per plan Constitution Check II).
+- `active_txin` is always the most recently produced self-pay or refund output; never re-fetched mid-chain.
+
+**State transitions**:
+
+```
+[bootstrap]
+  ↓ utxos_at(address)
+  → pick UTxO with lovelace ≥ refund_threshold + safety
+  → active_txin, active_lovelace
+
+[loop: every iteration]
+  if active_lovelace < refund_threshold:
+    [refund]
+      → faucet_txin = pick_faucet(utxos_at(address))      # exclude active_txin
+      → build refund tx: ins=[active_txin, faucet_txin],
+                         outs=[(address, refund_topup)],
+                         change-address=address (drains rest to a faucet-shaped UTxO)
+      → sign, submit, refund_txid
+      → active_txin = (refund_txid, 0)
+      → active_lovelace = refund_topup  (minus fee, computed from tx body)
+  else:
+    [self-pay]
+      → build tx: ins=[active_txin], outs=[], change-address=address
+                  → produces single output at (new_txid, 0)
+      → sign, submit, new_txid
+      → if pacing_mode == "await":
+          await((new_txid, 0), timeout=await_timeout_seconds)
+      → active_txin = (new_txid, 0)
+      → active_lovelace -= fee  (read from tx body)
+```
+
+## E2 — `IndexerClient` (NDJSON over Unix stream socket)
+
+Lives in `components/tx-generator/indexer_client.py`. Stateless — one short-lived connection per request. No connection pooling in v1 (the call rate is `< 1 Hz`).
+
+### Public surface
+
+```python
+class IndexerUnavailable(RuntimeError): ...
+
+class IndexerClient:
+    def __init__(self, socket_path: str): ...
+
+    def utxos_at(self, address: str) -> list[Utxo]:
+        """Snapshot. Raises IndexerUnavailable on any failure."""
+
+    def await_txin(self, txid: str, ix: int, timeout_seconds: int) -> AwaitResult:
+        """Blocks until (txid, ix) is observed, or timeout. Raises IndexerUnavailable on connection failure."""
+
+    def ready(self) -> ReadyStatus:
+        """One-shot readiness check. Raises IndexerUnavailable on failure."""
+```
+
+### Wire conversation
+
+| Method | Request line | Response line(s) |
+|---|---|---|
+| `utxos_at` | `{"utxos_at": "<bech32-or-base16-address>"}` | one line: `{"utxos": [{"txin": "<txid>#<ix>", "txout": "<base16-cbor>"}, ...]}`, then EOF |
+| `await_txin` | `{"await": "<txid>#<ix>", "timeout_seconds": N}` | blocks; one line: `{"slot": <int>, "blockHash": "<hex>", "txout": "<base16-cbor>"}` or `{"timeout": true}`, then EOF |
+| `ready` | `{"ready": null}` | one line: `{"ready": <bool>, "tipSlot": <int|null>, "processedSlot": <int|null>, "slotsBehind": <int|null>}`, then EOF |
+
+Failure responses (errors from the daemon) take the shape `{"error": "<message>"}` and are raised as `IndexerUnavailable`. Connection-level failures (socket refused, EOF before a full line, non-JSON line) are also raised as `IndexerUnavailable`.
+
+### Data shapes
+
+```python
+@dataclass(frozen=True)
+class Utxo:
+    txin: tuple[str, int]   # (txid, output index)
+    txout_cbor_hex: str     # base16-encoded CBOR TxOut
+
+@dataclass(frozen=True)
+class AwaitResult:
+    timed_out: bool
+    slot: int | None
+    block_hash: str | None
+    txout_cbor_hex: str | None
+
+@dataclass(frozen=True)
+class ReadyStatus:
+    ready: bool
+    tip_slot: int | None
+    processed_slot: int | None
+    slots_behind: int | None
+```
+
+## E3 — Compose topology delta
+
+The new entities introduced into `testnets/cardano_node_master/docker-compose.yaml`:
+
+| Entity | Shape | Notes |
+|---|---|---|
+| `indexer` service | new container, image TBD per [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78), mounts `relay1-state:/state:ro` (relay socket source) and `indexer-sock:/sock` (own socket). Runs the daemon binary with `--relay-socket /state/node.socket --listen /sock/indexer.sock`. | Healthcheck per [research.md R-004](./research.md). |
+| `indexer-sock` volume | new top-level docker volume; ephemeral. | Holds exactly one file: `indexer.sock`. |
+| `tx-generator` service edits | add `indexer-sock:/sock:ro` mount; add `INDEXER_SOCKET_PATH=/sock/indexer.sock` env; add `depends_on: indexer: { condition: service_healthy }`. Bump image tag to a commit SHA from this branch. | Submission still uses `relay1-state:/state:ro` for `cardano-cli transaction submit` (FR-009). |
+| `asteria-bootstrap`, `asteria-player-1`, `asteria-player-2` service edits | same `indexer-sock:/sock:ro` mount + same env + same `depends_on`. | Asteria implementation lives in PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67). |
+
+See [contracts/compose-topology.md](./contracts/compose-topology.md) for the exact YAML diff.
+
+## Cross-references
+
+- The single-output / change-only tx shape that makes `(txid, 0)` deterministic: [research.md R-001](./research.md).
+- Refund threshold + top-up defaults: [research.md R-002](./research.md).
+- Failure model `IndexerUnavailable` raised once and caught once: [research.md R-003](./research.md).
+- Pacing modes `"none"` vs `"await"`: [research.md R-005](./research.md).
+- Daemon image-tag handling until [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) publishes: [research.md R-006](./research.md).

--- a/specs/003-indexer-read-side/plan.md
+++ b/specs/003-indexer-read-side/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Indexer-Backed Read Side for Test Workloads
+
+**Branch**: `003-indexer-read-side` | **Date**: 2026-04-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-indexer-read-side/spec.md`
+**Parent issue**: [cardano-foundation/cardano-node-antithesis#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)
+**External dependency**: [lambdasistemi/cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78) — minimal address→UTxO indexer daemon (Unix socket, NDJSON, in-memory)
+
+## Summary
+
+Move the read side of every test workload off `cardano-cli query utxo --address` (LSQ-by-address) onto the small daemon scoped in [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78), and stop tx-generator's dust-and-poll wedge by reshaping its submit loop into a deterministic self-pay chain with a refund actor. This plan covers the **antithesis-side work only**: porting the Python `tx-generator`, wiring the daemon into `testnets/cardano_node_master/docker-compose.yaml`, and giving the asteria-player rebase a clear contract. The daemon itself ships upstream in [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78).
+
+## Technical Context
+
+**Language/Version**:
+- tx-generator: Python 3.11 (current `components/tx-generator/Dockerfile` base; client uses stdlib `socket` + `json`, no new deps).
+- asteria-player: Haskell (rebase guidance only — implementation lives in the [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) worktree).
+- Compose: docker-compose v2 YAML.
+
+**Primary Dependencies**:
+- Existing `cardano-cli` (in tx-generator image — used for `transaction build` / `sign` / `submit` only; query usage removed).
+- Indexer daemon image from [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78), pulled by tag from `ghcr.io/lambdasistemi/...` (final image name + tag picked when daemon ships).
+- Antithesis SDK (already imported in `tx_generator.py:17–27`).
+
+**Storage**: None on the antithesis side. Daemon's in-memory index is its concern.
+
+**Testing**:
+- Local smoke test via `just smoke-test` per constitution (existing recipe must keep passing).
+- New consumer-side unit tests for the NDJSON client (no daemon required — tested against a `socketpair`-mocked server in tests).
+- New compose-level integration test: bring the cluster + daemon up, verify the SC-001/SC-002 acceptance metrics over a 5-minute window.
+
+**Target Platform**: Linux containers, docker compose; same as the rest of `testnets/cardano_node_master/`.
+
+**Project Type**: Workload component port + compose wiring. Single-project, no new top-level service in this repo.
+
+**Performance Goals**:
+- SC-001: zero `Tx failed` / `UTxO still present` / dust lines in 30 minutes (today: 23 in 5 minutes).
+- SC-002: zero `GetUTxOByAddress` LSQ requests from tx-generator and asteria-player containers over a 10-minute window.
+- SC-003: submitted-tx count within ±5% of `elapsed / configured_interval`.
+- SC-006: indexer daemon `ready=true` within 1 minute on local devnet.
+
+**Constraints**:
+- Submission MUST stay on LocalTxSubmission via the existing relay socket (FR-009).
+- Compose pattern is shared-volume Unix sockets — no TCP between containers (clarification 3 in spec).
+- Constitution principle VII: every image tag in compose must resolve to a commit; bumping tx-generator's tag is part of this PR.
+- Constitution principle I (composer-first): tx-generator is a long-running daemon today, not a composer command. This PR preserves that shape; conversion to composer is out of scope for #69. **Documented deviation, see Complexity Tracking.**
+
+**Scale/Scope**:
+- ~250 LoC Python rewrite of `tx_generator.py` (similar size to today, fewer code paths).
+- ~50 LoC new `indexer_client.py` for the NDJSON Unix-socket protocol.
+- ~30 lines of YAML edits in `docker-compose.yaml` (new service + new volume + healthcheck wiring).
+- No new top-level directories.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Note |
+|---|---|---|
+| I. Composer-first workload | **Deviation** | tx-generator is a long-running compose service, not a composer command. Pre-existing structure; this PR ports the read side and the chain shape but does NOT redesign tx-generator into composer commands. Tracked in Complexity Tracking. |
+| II. SDK instrumentation mandatory | PASS | Adds `reachable` on indexer-client init success, `sometimes(refund_triggered)` around the refund branch, `always(active_utxo_above_min)` invariant check before each self-pay tx, `unreachable("indexer_silently_unreachable")` if the client ever falls back to LSQ (defensive — should not fire). |
+| III. Short-running commands | N/A | tx-generator is not a composer command. |
+| IV. Duration-robust | PASS | Deterministic chain + refund pattern is independent of run duration. |
+| V. Realistic workload over synthetic volume | PASS-by-indirection | tx-generator stays synthetic; this PR is the precondition that unblocks the realistic asteria workload (PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)) per User Story 3. |
+| VI. Bisect-safe commits | PASS | Vertical commits planned: (1) NDJSON client lib, (2) tx-generator deterministic chain, (3) tx-generator refund actor, (4) compose wiring + image bump. Each compiles, smoke-test passes. |
+| VII. Image tag hygiene | PASS | tx-generator's tag in `testnets/cardano_node_master/docker-compose.yaml` bumps to a commit SHA from this branch in commit (4). |
+
+**Gate result**: PASS with one documented deviation (composer-first), justified in Complexity Tracking. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-indexer-read-side/
+├── plan.md                 # This file (/speckit.plan output)
+├── research.md             # Phase 0 — decisions on tx shape, refund model, client wire
+├── data-model.md           # Phase 1 — tx-generator state, NDJSON client contract
+├── contracts/
+│   ├── indexer-client.md       # NDJSON request/response shapes consumed
+│   └── compose-topology.md     # New service + volume + healthcheck contract
+├── quickstart.md           # Phase 1 — local bring-up + acceptance verification
+├── checklists/
+│   └── requirements.md     # Existing spec-quality checklist
+└── tasks.md                # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root, files touched by this feature)
+
+```text
+components/
+├── tx-generator/
+│   ├── Dockerfile              # No change (stdlib only)
+│   ├── requirements.txt        # No change
+│   ├── tx_generator.py         # Rewrite: deterministic chain, refund actor, NDJSON client; remove LSQ queries + post-submit poll
+│   └── indexer_client.py       # NEW: ~50 LoC NDJSON-over-Unix-socket client
+└── asteria-player/             # Untouched here; rebase on top of this PR is PR #67's work
+
+testnets/cardano_node_master/
+├── docker-compose.yaml         # Add `indexer` service, `indexer-sock` volume, healthcheck wiring; mount socket read-only into tx-generator + asteria-player services; bump tx-generator image tag
+└── indexer-config.json         # NEW (if needed): daemon config (relay socket path, listen socket path, ready threshold)
+```
+
+**Structure Decision**: Single project, two file additions (`indexer_client.py`, optionally `indexer-config.json`), one significant rewrite (`tx_generator.py`), targeted edits to `docker-compose.yaml`. No new top-level directory. Deliberately minimal.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|---|---|---|
+| Constitution Principle I (composer-first): tx-generator stays a non-composer long-running service | Today's tx-generator is a long-running daemon by design ([cardano-node-antithesis#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69) treats it as such); the issue's scope is fixing the read-side query pattern and the dust wedge, not redesigning tx-generator into composer commands. | "Convert tx-generator to a composer command in the same PR" rejected because it would expand scope significantly and decouples poorly from #69's required-direction. Tracked as a follow-up; not blocking this PR. |
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Resolved decisions: tx-shape (single self-pay output, change-only build), refund actor signal (active-UTxO threshold T as env var), NDJSON client failure model (raise + halt; no node-fallback), compose healthcheck mechanism (`socat` line-write into `ready` request), tx-confirmation pacing (default off; `await` available for stricter modes).
+
+## Phase 1 — Design & Contracts
+
+- [data-model.md](./data-model.md) — tx-generator's running state (active UTxO, threshold, faucet pool, last-built tx body), the NDJSON client's connection model.
+- [contracts/indexer-client.md](./contracts/indexer-client.md) — exact request/response JSON shapes consumed; failure cases.
+- [contracts/compose-topology.md](./contracts/compose-topology.md) — the YAML diff (service shape, volume mounts, healthcheck command).
+- [quickstart.md](./quickstart.md) — `INTERNAL_NETWORK=false docker compose up -d`; verify `ready=true`; observe LSQ trace; check `docker logs tx-generator`.
+
+## Constitution Check (post-design)
+
+Re-evaluating after Phase 1:
+- Principle II (SDK): contracts/indexer-client.md fixes exact assertion sites — PASS.
+- Principle VI (bisect-safe): the vertical-commit list above is preserved by the data-model boundaries (client is a separate file from the rewrite, refund logic is a separate function from the chain logic). PASS.
+- Principle VII (image tag hygiene): contracts/compose-topology.md mandates a tag bump in the same PR. PASS.
+
+No new violations introduced by Phase 1 design.
+
+## Out-of-band
+
+- Daemon delivery: tracked upstream in [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78). This PR carries an empty (placeholder) daemon image tag in compose until the daemon ships; smoke-test gating happens once the upstream image is published.
+- Asteria rebase: tracked in [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67). The contracts in this plan (`indexer-client.md`, `compose-topology.md`) are the integration surface; that PR consumes them in Haskell.

--- a/specs/003-indexer-read-side/quickstart.md
+++ b/specs/003-indexer-read-side/quickstart.md
@@ -1,0 +1,156 @@
+# Quickstart: Indexer-Backed Read Side for Test Workloads
+
+**Feature**: 003-indexer-read-side
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+How to bring up the cluster locally and verify the acceptance metrics for [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69).
+
+## Prerequisites
+
+- This worktree at `/code/cardano-node-antithesis-issue-69/` (branch `003-indexer-read-side`).
+- Daemon image from [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) published to ghcr (or built locally and bind-mounted — see "Daemon not yet published" below).
+- `docker`, `docker compose v2`, `jq`, `socat` on the host (the host needs them for the inspection commands below; the containers ship their own).
+- `INTERNAL_NETWORK=false` in your env so the bridge has external egress for image pulls. Set `=true` to mirror Antithesis's network shape.
+
+## Bring up
+
+```bash
+cd /code/cardano-node-antithesis-issue-69/testnets/cardano_node_master
+INTERNAL_NETWORK=false docker compose up -d
+```
+
+Expected: every service in `docker compose ps` reaches `healthy` (for those with healthchecks) or `Up` within ~2 minutes on a fresh devnet.
+
+## Verify the indexer is wired
+
+```bash
+# 1. Indexer container is healthy
+docker compose ps indexer
+# STATE should be "running (healthy)"
+
+# 2. Socket file is on the shared volume
+docker compose exec indexer ls -la /sock/
+# Expect: indexer.sock (srw-...)
+
+# 3. Same socket visible read-only inside tx-generator
+docker compose exec tx-generator ls -la /sock/
+# Expect: indexer.sock visible
+
+# 4. Direct ready probe from tx-generator's container
+docker compose exec tx-generator sh -c \
+  'echo "{\"ready\":null}" | socat - UNIX-CONNECT:/sock/indexer.sock | jq .'
+# Expect: {"ready":true,"tipSlot":...,"processedSlot":...,"slotsBehind":0}
+
+# 5. Direct snapshot probe for a known funded address
+ADDR="$(docker compose exec tx-generator sh -c \
+  'cat /utxo-keys/genesis.1.addr.info | jq -r .address')"
+docker compose exec tx-generator sh -c \
+  "echo '{\"utxos_at\":\"$ADDR\"}' | socat - UNIX-CONNECT:/sock/indexer.sock | jq ."
+# Expect: {"utxos":[{"txin":"...#0","txout":"<base16>"}, ...]}
+```
+
+## Verify SC-001 (no dust / no Tx failed / no UTxO-still-present)
+
+Let the cluster run for 30 minutes after `tx-generator` has started submitting:
+
+```bash
+# Wait for first tx
+docker compose logs --follow tx-generator | grep -m1 'Submitted tx'
+# Then time 30 minutes from this point
+sleep 1800
+
+docker logs tx-generator 2>&1 | \
+  grep -cE 'Tx failed|UTxO still present|does not meet the minimum UTxO threshold'
+# Expect: 0  (today: ~150+ over 30min)
+```
+
+## Verify SC-002 (no GetUTxOByAddress LSQ from consumers)
+
+The relay's tracer logs LSQ events to the shared `tracer` volume. Consumers are `tx-generator` and `asteria-player-*`.
+
+```bash
+# Sample one minute's worth of relay LSQ events
+docker compose exec tracer-sidecar sh -c \
+  'tail -F /opt/cardano-tracer/logs/relay1.example/*.log' \
+  | grep -E 'GetUTxOByAddress' \
+  | grep -E 'tx-generator|asteria-player' &
+SAMPLER=$!
+sleep 600   # 10 minutes
+kill $SAMPLER
+
+# Expect: no matching lines printed.
+```
+
+## Verify SC-003 (submission rate within ±5%)
+
+```bash
+# Compute target rate from configured interval
+INTERVAL_S=$(docker compose exec tx-generator printenv MIN_SLEEP)   # adjust if you renamed
+# (Default is 5..30s random; use mean 17.5s for the budget.)
+
+START=$(date +%s)
+COUNT_START=$(docker logs tx-generator 2>&1 | grep -c 'Submitted tx')
+sleep 600   # 10 minutes
+COUNT_END=$(docker logs tx-generator 2>&1 | grep -c 'Submitted tx')
+ELAPSED=$(( $(date +%s) - START ))
+ACTUAL=$(( COUNT_END - COUNT_START ))
+EXPECTED=$(( ELAPSED * 100 / 1750 ))   # 100/avg_interval_in_centiseconds
+echo "Submitted: $ACTUAL; expected ~$EXPECTED (±5%)"
+```
+
+## Verify SC-006 (cold start `ready=true` within 1 minute on devnet)
+
+```bash
+docker compose down -v
+START=$(date +%s)
+INTERNAL_NETWORK=false docker compose up -d
+until docker compose exec tx-generator sh -c \
+  'echo "{\"ready\":null}" | socat - UNIX-CONNECT:/sock/indexer.sock 2>/dev/null | jq -e .ready' \
+  >/dev/null 2>&1; do
+  sleep 1
+done
+echo "Indexer ready in $(( $(date +%s) - START )) seconds"
+# Expect: < 60 on a healthy devnet host.
+```
+
+## Verify SC-007 (warm restart returns to ready)
+
+```bash
+START=$(date +%s)
+docker compose restart indexer
+until docker compose exec tx-generator sh -c \
+  'echo "{\"ready\":null}" | socat - UNIX-CONNECT:/sock/indexer.sock 2>/dev/null | jq -e .ready' \
+  >/dev/null 2>&1; do
+  sleep 1
+done
+echo "Indexer warm-ready in $(( $(date +%s) - START )) seconds"
+# Expect: comparable to cold-start (no persistence in v1; re-indexes from genesis).
+```
+
+## Daemon not yet published
+
+If [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) hasn't shipped a published image yet, build the daemon locally and bind-mount the binary into a minimal base image, or override the image with a locally tagged build:
+
+```bash
+cd /code/cardano-node-clients-issue-78    # the daemon's worktree
+just build-image          # produces local/cardano-utxo-indexer:dev
+docker tag local/cardano-utxo-indexer:dev \
+  ghcr.io/lambdasistemi/cardano-utxo-indexer:dev
+cd -
+INTERNAL_NETWORK=false docker compose up -d
+```
+
+This path is for local validation only — the merged compose must reference a published image (constitution Principle VII).
+
+## Troubleshooting
+
+- **`indexer` healthcheck loops red**: check `docker logs indexer` for chain-sync errors. If "ChainSyncProtocolError" or socket-permission errors appear, the relay's socket may be unmounted or the `relay1-state:/state:ro` mount is wrong.
+- **`tx-generator` logs `IndexerUnavailable: Connection refused`**: the indexer container isn't ready yet (compose `depends_on` should prevent this; if it doesn't, the healthcheck command shipped in the daemon image is wrong).
+- **`tx-generator` submits but never refunds**: confirm the active UTxO actually drifts below `REFUND_THRESHOLD_LOVELACE`. If the workload is too slow to drain it, lower `REFUND_TOPUP_LOVELACE` for testing or temporarily set `REFUND_THRESHOLD_LOVELACE=99000000` to force a refund branch in the SDK report.
+- **Dust line still appears once after upgrade**: the leftover active UTxO from a pre-upgrade run can be below threshold; tx-generator's first cycle should refund it. If it doesn't, wipe the state with `docker compose down -v`.
+
+## Tear down
+
+```bash
+docker compose down -v   # -v also drops indexer-sock
+```

--- a/specs/003-indexer-read-side/research.md
+++ b/specs/003-indexer-read-side/research.md
@@ -1,0 +1,113 @@
+# Research: Indexer-Backed Read Side for Test Workloads
+
+**Feature**: 003-indexer-read-side
+**Date**: 2026-04-27
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+Resolves the open implementation questions left by the spec.
+
+## R-001 — Transaction shape: single-output self-pay, change-only
+
+**Decision**: Each self-pay transaction has exactly one output: the change output to the sender's address. No `--tx-out` flags are passed; `cardano-cli transaction build --change-address <addr>` produces one output at index 0.
+
+**Rationale**:
+- The deterministic chain (FR-003) needs the next `TxIn` to be unambiguous from the previous tx body. With a single change output, the next `TxIn` is `(txid, 0)` — point-equality.
+- Today's `tx_generator.py:170–179` builds with N random extra `--tx-out` flags producing N+1-output transactions. That is what makes the next-`TxIn` non-deterministic and is the proximate cause of the dust drift (each split shaves min-UTxO + safety margin off the active leg).
+- The constitution's preference for *realistic workload* (Principle V) puts the load-bearing test signal in asteria-player; tx-generator's value is "keep submitting under fault injection", not "produce diverse UTxO topologies". Single-output is sufficient for that.
+
+**Alternatives considered**:
+- **Splitter-then-loop** (Q1 option D from clarifications): splits the funded address into K parallel UTxOs at startup, runs K independent self-pay chains in round-robin. Rejected — more complex than the user-accepted refund-actor model (Q1 option B), and it doesn't fix dust, only delays it.
+- **Keep multi-output txs but pin change index**: `cardano-cli build` always appends the change output last; we could chain off `(txid, len(tx_outs)-1)`. Rejected — non-determinism in `len(tx_outs)` requires reading the tx body back, and it's a strictly bigger code surface than "no extras, change is index 0".
+
+## R-002 — Refund actor signal: active-UTxO threshold T
+
+**Decision**: tx-generator builds a refund transaction when the active UTxO's lovelace value drops below a configured threshold `T = REFUND_THRESHOLD_LOVELACE` (env var, default 5_000_000 = 5 ADA). The refund transaction consumes the active UTxO plus one faucet UTxO (held under the same key) and produces a single replenished active UTxO with target value `T_top = REFUND_TOPUP_LOVELACE` (env var, default 100_000_000 = 100 ADA). The next self-pay continues off `(refund_txid, 0)`.
+
+**Rationale**:
+- Threshold-driven (rather than fixed-N) is duration-robust (constitution IV): a 1-hour run and a 3-hour run both refund based on the actual draw-down rate of the active UTxO, no schedule to tune.
+- Faucet UTxOs are discovered the same way as the initial active UTxO — `utxos_at` on the sender address — and any UTxO at the same address with `lovelace ≥ T_top + fees` is eligible. There is no separate "faucet address" concept needed; the existing genesis UTxOs at the funded address are the faucet pool.
+- Default `T = 5 ADA` keeps the active leg comfortably above the protocol min-UTxO (~1 ADA) plus margin for two-output ledger costs and a few txs of fee headroom.
+- Default `T_top = 100 ADA` gives 95 ADA of usable lovelace per refund cycle; with ~0.2 ADA per self-pay tx (rough order), that's ~475 self-pays per refund — refunds are rare (a few per hour at the default tx interval), keeping their share of submission load negligible.
+
+**Alternatives considered**:
+- **Submit refund only on next-self-pay-build-failure**: refund triggered when `build` fails with min-UTxO. Rejected — failure-driven means a noisy log entry per refund and a wasted build attempt; threshold-driven is clean.
+- **Refund as a separate restart-the-process step**: kill the active UTxO, spawn a new `genesis.N` chain. Rejected — the docker compose `restart: always` posture would do this for free at the cost of churn; an in-process refund keeps the chain continuous.
+- **No refund, allow dust drift**: not viable — kills the workload (the bug we're fixing).
+
+## R-003 — NDJSON client failure model: surface and pause, never fall back
+
+**Decision**: The `indexer_client.py` module raises a `IndexerUnavailable` exception on any of: connection refused, EOF before a full response line, JSON parse error, `{"error": ...}` response from the daemon. Callers in `tx_generator.py` catch `IndexerUnavailable` at exactly one place (the main submit loop), log at WARNING, sleep `INDEXER_RETRY_BACKOFF` seconds (env var, default 5), and retry — they MUST NOT fall back to `cardano-cli query utxo --address`. There is no other catch site for `IndexerUnavailable`.
+
+**Rationale**:
+- Spec FR-006 mandates "surface clear error and pause submission, NOT fall back to direct node queries". Codifying this as a single named exception caught in exactly one place makes that property structurally enforceable (rather than a recurring `except Exception` worry).
+- Antithesis SDK assertion `unreachable("indexer_silently_unreachable")` is fired in the default `except Exception` arm of the submit loop — i.e. if any other exception type ever masks an indexer failure, the SDK report flags it.
+
+**Alternatives considered**:
+- **Library-side retry with backoff**: client retries internally before raising. Rejected — hides the daemon-down condition from the workload-level observability; the submit loop is already a retry loop, no need for double layering.
+- **Treat indexer-unavailable as a healthcheck signal**: container exits non-zero, compose restarts. Rejected — that's a sledgehammer; consumers should pause and recover, not crash, because the indexer's restart cadence under fault injection is exactly what we're testing through.
+
+## R-004 — Compose healthcheck: `socat` line-write into `ready` request
+
+**Decision**: The `indexer` service's docker compose `healthcheck.test` is a small inline command that writes one NDJSON request line into the daemon's Unix socket and asserts `ready=true`:
+
+```yaml
+healthcheck:
+  test:
+    - "CMD-SHELL"
+    - 'echo ''{"ready":null}'' | socat - UNIX-CONNECT:/sock/indexer.sock | jq -e .ready'
+  interval: 5s
+  timeout: 3s
+  retries: 60
+  start_period: 10s
+```
+
+`tx-generator` and `asteria-player` services declare `depends_on: indexer: { condition: service_healthy }` so they don't start until ready.
+
+**Rationale**:
+- `socat` is already in the testnet's tooling reach (used by other compose services; if not, a tiny helper image is acceptable — TBD when the daemon image lands).
+- Constitution's "Minimal sidecar image" rule (`coreutils + bash + jq + cardano-cli`) applies to *sidecar* composer commands, not to the indexer container itself. The indexer container is allowed to ship `socat` (or expose a CLI subcommand for self-healthcheck) as part of its image.
+- The `ready` request shape is defined in [contracts/indexer-client.md](./contracts/indexer-client.md); same wire as the consumer client.
+
+**Alternatives considered**:
+- **HTTP `/ready` endpoint over TCP**: rejected per Q3 in spec clarifications — this compose has no precedent for service-to-service TCP, and it widens the deterministic-replay surface under Antithesis.
+- **TCP-only-for-healthcheck**: rejected on grounds of consistency; one transport everywhere.
+- **No healthcheck**: rejected — consumers would race the daemon's catch-up.
+
+## R-005 — Tx-confirmation pacing: default off, `await` available
+
+**Decision**: The default tx-generator loop submits, advances to the next deterministic `TxIn` from the just-built tx body, and goes to the next iteration without calling `await` on the daemon. A `TX_GENERATOR_PACING=await` env var switches in a stricter mode that calls `await` on `(txid, 0)` after each submission with a configurable timeout (env `TX_GENERATOR_AWAIT_TIMEOUT_SECONDS`, default 60).
+
+**Rationale**:
+- The deterministic chain assumption is "the previous tx will land or be rejected; either way the next-`TxIn` resolution is correct". If it lands, the chain continues. If it's rejected, the next `build` will fail and the existing `IndexerUnavailable` / build-failure path re-syncs via `utxos_at` (FR-011, User Story 2 scenario 3). There is no functional need to wait between submissions in steady state.
+- `await` is available for outer drivers (Antithesis composer commands) that need a "submission landed" gate before doing something else — exposing this without making it the default avoids penalising tx/sec in normal operation.
+
+**Alternatives considered**:
+- **Always await**: rejected — adds a synchronous round-trip per tx for no functional gain; lowers achievable tx/sec.
+- **Never expose await from tx-generator**: rejected — `await` is the canonical way for an outer test driver to gate on tx confirmation; cutting it off at the consumer boundary forces drivers to invent their own.
+
+## R-006 — Image dependency: placeholder until upstream daemon ships
+
+**Decision**: The indexer service in `docker-compose.yaml` is added in this PR with a placeholder image tag (e.g. `ghcr.io/lambdasistemi/cardano-utxo-indexer:dev` or whatever name [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) settles on). On a clean `docker compose up -d`, that container will fail to pull until the upstream image is published. The smoke-test gate (constitution §"Composer smoke-tests run locally before every push") is honoured by:
+1. Running smoke-test against a local daemon binary (built from the [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) branch) bind-mounted into the container until publish, OR
+2. Holding the final commit (the image-tag bump) until the upstream image is published.
+
+The PR does not merge until path 2 is true (constitution VII). `publish-images` workflow on `cardano-node-antithesis` will then green-light Antithesis runs.
+
+**Rationale**: Decoupling the antithesis-side rewrite from the daemon's publish cadence lets us land the consumer-side commits first (vertical commits 1–3) and finalise the compose wiring in commit 4 once the daemon is published.
+
+**Alternatives considered**:
+- **Wait for [`#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) to ship before opening this PR**: rejected — keeps work serialised when consumer-side commits can be reviewed in parallel.
+- **Vendor the daemon source into this repo**: rejected — duplicates code, breaks upstream's release cadence, and the daemon is explicitly a `cardano-node-clients` deliverable per the spec's clarifications.
+
+## R-007 — Asteria-player rebase contract (informational, no code in this PR)
+
+**Decision**: The asteria-player port to the indexer happens in [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67), not here. This plan provides:
+- The Haskell-side contract: connect to `/sock/indexer.sock` via Unix domain socket, NDJSON line protocol, same request shapes as the Python client (`utxos_at`, `await`, `ready`). See [contracts/indexer-client.md](./contracts/indexer-client.md).
+- The compose wiring: asteria-player services already share the same `indexer-sock` volume mount (added in this PR's compose changes); their entrypoints will call the new client lib once PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) implements it.
+- The acceptance gate: SC-005 (asteria-spawn-v2 acceptance for User Story 1 of [`specs/phase1-asteria-gatherer/spec.md`](../phase1-asteria-gatherer/spec.md) passes end-to-end with zero LSQ-by-address calls from the asteria-player container).
+
+**Rationale**: keeps PRs small and reviewable; the antithesis-side compose wiring + tx-generator port can land independently of the Haskell rewrite.
+
+## Open items
+
+None blocking implementation. The daemon image tag (R-006) is the only deferred decision and lands when [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) ships its first publish.

--- a/specs/003-indexer-read-side/spec.md
+++ b/specs/003-indexer-read-side/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Indexer-Backed Read Side for Test Workloads
+
+**Feature Branch**: `003-indexer-read-side`
+**Created**: 2026-04-26
+**Status**: Draft
+**Input**: "Replace tx-generator's direct LSQ queries (`cardano-cli query utxo --address`) with reads against a small in-memory indexer daemon running alongside the cluster. Fix the lossy self-transfer dust bug via a deterministic tx chain plus a refund actor so the post-submit polling loop disappears. Asteria-player (PR #67) consumes the same indexer."
+**Parent issue**: [cardano-foundation/cardano-node-antithesis#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)
+**Related**:
+- [cardano-foundation/cardano-node-antithesis PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) — asteria-spawn-v2 parked on the same axis.
+- [lambdasistemi/cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78) — minimal address→UTxO indexer daemon (Unix socket, NDJSON, in-memory). This spec consumes it.
+- Rejected upstream candidate (and why): [`lambdasistemi/cardano-utxo-csmt`](https://github.com/lambdasistemi/cardano-utxo-csmt) and the closed transport ticket [`#233`](https://github.com/lambdasistemi/cardano-utxo-csmt/issues/233). That daemon's structure (CSMT column, `Restoring`/`Full`/`KVOnly` dual-mode backend, journal-replay, proof endpoints) exists to commit the UTxO set into a merkle tree and serve inclusion proofs — none of which this spec needs.
+
+## Clarifications
+
+### Session 2026-04-27
+
+- Q: tx-generator chain length & refund model — unbounded, bounded with refund, fixed-N + restart, or splitter-then-loop? → A: Bounded chain with a refund actor — when the active UTxO falls below threshold T, tx-generator submits a refund tx that consumes the active UTxO together with a faucet UTxO (held by the same key) and produces a single replenished active UTxO above T.
+- Q: Build a new indexer or reuse `cardano-utxo-csmt`? → A: Build a new minimal daemon. `cardano-utxo-csmt`'s structure is built around CSMT + inclusion proofs; the dual-mode backend exists because the merkle tree needs different write paths during catch-up vs. live-tip. Without proofs the entire dual-mode disappears, and stripping CSMT leaves roughly nothing reusable. Filed as [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78).
+- Q: TCP-over-bridge or Unix-socket-over-shared-volume for indexer↔consumer IPC? → A: Unix domain socket on a shared volume. Matches the existing compose pattern (every service in this compose reads chain state via a Unix socket mounted from another service's volume); narrower deterministic-replay surface under Antithesis.
+- Q: tx confirmation primitive? → A: Wait for `(txId, ix)` to appear in the index — confirmation reduces to "wait for any output of my submitted tx to land". Single primitive, point-equality predicate, no separate tx-confirmation table inside the daemon.
+- Q: asteria-player's policy/asset queries? → A: For v1, address-keyed lookup + in-process filtering on `value`. Ships, pellets, and the central Asteria UTxO all live at well-known addresses. A policy-keyed endpoint becomes a follow-up only if profiling shows in-process filtering is too slow.
+- Q: Persistence model? → A: In-memory only, re-index from genesis on every restart. Devnet chain is short (seconds). If Antithesis fault-injection times prove unacceptable, persistence is a bounded follow-up on the daemon — one-line backend swap.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — tx-generator runs sustained workload without saturating the relay's LSQ channel (Priority: P1)
+
+A fresh local cluster is up. tx-generator submits transactions continuously. The read side (sender's UTxO discovery, faucet UTxO discovery on refund) is served by the indexer daemon ([cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78)) running alongside the cluster, reachable over a Unix domain socket on a shared volume. The relay's `LocalStateQuery` channel sees no `GetUTxOByAddress` traffic from tx-generator, and submission continues at the configured cadence with no `Tx failed` / `UTxO still present after 120s` lines in tx-generator logs over a 10-minute window.
+
+**Why this priority**: this is the load-bearing change. Without it every Antithesis result is contaminated — "node fell over from query saturation" is indistinguishable from "node fell over from injected fault". Until the read path is moved off LSQ-by-address, the test signal is meaningless under sustained load.
+
+**Independent Test**: bring up `testnets/cardano_node_master` with `INTERNAL_NETWORK=false docker compose up -d`. After 5 minutes: `docker logs tx-generator | grep -cE 'Tx failed|UTxO still present|does not meet'` returns 0, and a packet capture (or LSQ trace) on the relay shows zero `GetUTxOByAddress` requests originating from tx-generator's container.
+
+**Acceptance Scenarios**:
+
+1. **Given** a healthy cluster with the indexer daemon reporting `ready=true`, **When** tx-generator runs for 10 minutes at its configured rate, **Then** every UTxO lookup it performs hits the daemon's `utxos_at` request on the shared-volume Unix socket, no `cardano-cli query utxo --address` invocation appears in tx-generator's process tree or logs, and no `Tx failed` lines appear.
+2. **Given** the daemon is reachable but momentarily lagging (i.e. `slotsBehind > 0`), **When** tx-generator asks for the sender's UTxOs, **Then** it receives the daemon's last-applied set, decides whether to wait or proceed deterministically (see User Story 2), and never falls back to LSQ-by-address against the node.
+3. **Given** the daemon's Unix socket is unreachable for K seconds, **When** tx-generator asks for UTxOs, **Then** it surfaces a clear error and stops attempting submissions until the daemon recovers — it MUST NOT silently fall back to querying the node.
+
+---
+
+### User Story 2 — tx-generator chains self-spends deterministically, refunds before dust, never wedges (Priority: P1)
+
+tx-generator picks an initial active UTxO once (via `utxos_at` on the daemon at startup) and runs a self-pay chain off it. For each subsequent self-pay transaction, the next `TxIn` is computed from the just-built tx body (the new `TxId` plus the known output index) — no UTxO re-query, no post-submit polling. When the active UTxO's value falls below a configured refund threshold T (T > min-UTxO + safety margin), tx-generator builds a refund transaction that consumes the active UTxO plus a faucet UTxO (held under the same key, discovered via the daemon at startup or on demand) and produces a single replenished active UTxO above T. The chain continues off the refund tx's output. After K successive self-spends spanning multiple refunds, tx-generator is still alive, still submitting, and the active UTxO is still well above the min-UTxO floor.
+
+Optionally, tx-generator confirms each submitted tx via `await` on the daemon for the self-pay output's `TxIn`. The deterministic chain does not require this (the next tx can build on the unconfirmed `TxIn`), but `await` is available when stricter pacing is wanted (e.g. an outer Antithesis driver gating on confirmation).
+
+**Why this priority**: the dust-drain bug compounds the LSQ problem (more "looking for a non-dust UTxO" means more LSQ scans) and is the proximate cause of the wedge today. The deterministic-chain pattern eliminates both the post-submit polling loop and the dust drift in one stroke; the refund actor keeps the workload long-running.
+
+**Independent Test**: run tx-generator for 30 minutes against a healthy local cluster, then `docker logs tx-generator | grep -cE 'does not meet the minimum UTxO threshold|UTxO still present'` returns 0; the count of submitted txs (self-pay + refund) roughly equals `elapsed / configured_interval`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a starting active UTxO of value V well above threshold T and a self-pay chain of length N, **When** tx-generator runs the chain for N submissions, **Then** every self-pay tx uses a `TxIn` derived from the previous tx body without any UTxO query, and the active UTxO's value is at least min-UTxO + safety margin at every step (refund txs intercalated as needed).
+2. **Given** the active UTxO's value drops below threshold T mid-chain, **When** tx-generator builds the next tx, **Then** it instead builds a refund tx that consumes the active UTxO plus a faucet UTxO (same key) and produces a single replenished active UTxO above T; the next self-pay tx is built off that refund's output without re-querying.
+3. **Given** a submission failure mid-chain (e.g. node rejects a tx), **When** tx-generator detects the failure, **Then** it re-syncs its known UTxO set via `utxos_at` and resumes the chain from the actual on-chain state.
+4. **Given** the post-submit "wait until consumed" loop in today's `tx_generator.py`, **When** the new chain logic ships, **Then** that loop is removed entirely — there is no remaining code path that re-queries the node to confirm consumption. Where waiting is wanted, it goes via the daemon's `await`.
+5. **Given** no faucet UTxO is reachable when refund is required, **When** tx-generator needs to refund, **Then** it surfaces a clear error and stops submitting; it MUST NOT silently let the active UTxO drift to dust.
+
+---
+
+### User Story 3 — Asteria-player consumes the same daemon for its read side (Priority: P1)
+
+The asteria-player workload (currently parked on PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)) discovers ship UTxOs, pellet UTxOs, and the central Asteria UTxO via the same indexer daemon used by tx-generator. For v1 the lookups are address-scoped: shipyard address, pellet address (spacetime), asteria address — each fetched via `utxos_at` and filtered in-process on `value` to pick out the specific ship token / pellet / admin NFT. No `cardano-cli query utxo --address` calls remain in asteria-player or in any helper it shells out to. PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) can be unparked and merged once this dependency lands.
+
+**Why this priority**: the issue and PR are explicitly coupled — "asteria off-chain code uses the same `queryUTxOs` LSQ pattern, and we agreed it has to stop" ([#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)). Shipping the daemon for tx-generator alone leaves asteria as a second LSQ saturator and PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) still blocked.
+
+**Independent Test**: with the daemon running, execute `parallel_driver_asteria_gatherer.sh` (or the equivalent in PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)'s tree) against a healthy cluster; the gatherer completes a move-and-gather cycle without invoking `cardano-cli query utxo --address` anywhere in its process tree, and the relay's LSQ trace shows zero address-scoped UTxO queries for the duration.
+
+**Acceptance Scenarios**:
+
+1. **Given** the daemon is up and asteria bootstrap has completed, **When** a gatherer replica runs one cycle, **Then** {ship UTxO lookup, nearest-pellet discovery, central Asteria UTxO read} all resolve via `utxos_at` calls on the daemon's Unix socket; zero LSQ-by-address requests reach the relay from the asteria-player container.
+2. **Given** PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)'s branch (`asteria-spawn-v2`) rebased onto the daemon-bearing main, **When** the test workload runs end-to-end, **Then** acceptance for that PR's own user stories still passes and the LSQ-saturation regression observed today does not recur.
+
+---
+
+### User Story 4 — Indexer daemon is part of the standard testnet compose topology (Priority: P2)
+
+The indexer daemon runs as a regular service in `testnets/cardano_node_master/docker-compose.yaml` (and any sibling testnet compose files actually exercised). It mounts one relay's state volume read-only (so it can talk to the relay's Unix socket via N2C chain-sync), holds its index in memory, and listens on a Unix socket placed on a shared `indexer-sock` volume. tx-generator and asteria-player mount that shared volume read-only and connect to the socket. The daemon's `ready` request is wired into a compose healthcheck so dependent services do not proceed until ready.
+
+**Why this priority**: needed for reproducibility and for Antithesis runs (which use the same compose topology). Not P1 because P1/P2/P3 above could in principle be demonstrated with an out-of-band daemon for the first acceptance pass.
+
+**Independent Test**: `docker compose up -d` brings the daemon up alongside the cluster, `docker compose ps` reports it healthy within a documented bound, and a test client from a sibling container connecting to the shared-volume Unix socket gets a well-formed UTxO list for a known funded address.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean checkout, **When** a developer runs `INTERNAL_NETWORK=false docker compose up -d`, **Then** the daemon container starts, becomes healthy (`ready=true`) without manual intervention, and is reachable by tx-generator and asteria-player via the shared-volume Unix socket.
+2. **Given** the daemon container is killed mid-run (Antithesis fault injection), **When** docker compose restarts it, **Then** it re-indexes from genesis (devnet chain is short — seconds), reaches `ready=true` again, and tx-generator / asteria-player resume reads without each needing a restart.
+
+---
+
+### User Story 5 — Tip queries are minimised and clearly justified (Priority: P3)
+
+Any remaining `cardano-cli query tip` call (or equivalent slot/era query) is either: (a) removed because the tx pattern doesn't actually need tip; or (b) replaced by the daemon's `ready` request (which already returns `tipSlot` and `processedSlot`); or (c) retained with a one-line justification next to it. No code path uses tip as a stand-in for "wait until my tx lands" — that reduces to the daemon's `await`.
+
+**Why this priority**: tip queries are constant-time and not the saturator, so this is hygiene rather than a load issue. Worth doing in the same pass to avoid re-introducing an LSQ habit.
+
+**Independent Test**: `grep -n 'query tip' components/tx-generator components/asteria-player` returns either zero hits or hits each accompanied by a justification comment.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new code paths, **When** the read side runs end-to-end, **Then** every retained `query tip` site has an inline justification, no `query tip` call gates "tx was consumed" logic, and where consumers needed slot/tip information they now read it from the daemon's `ready` or use `await`.
+
+---
+
+### Edge Cases
+
+- **Daemon cold start**: re-indexes from genesis on every restart. `ready` returns `false` with `slotsBehind > 0` until caught up; dependent services gate on `ready=true`. On devnet this is seconds.
+- **Rollback handling**: chain-sync rollback events are applied by the daemon. tx-generator's deterministic chain may have used a `TxIn` that gets rolled back; on submission failure or on a snapshot mismatch the consumer re-syncs via `utxos_at` (User Story 2 scenario 3). Pending `await` waiters whose `TxIn` was observed and then rolled back stay pending.
+- **Concurrent consumers**: tx-generator and asteria-player connect concurrently. The daemon must accept multiple Unix-socket clients in parallel; each long-lived `await` connection is independent and must not block snapshot/ready calls.
+- **Authorization**: socket file lives on a shared docker volume; filesystem permissions are the only access control. No TCP exposure to host or external networks.
+- **Submission failures and re-orgs**: when a submitted tx is rejected or re-orged out, the deterministic chain assumption is broken. Recovery: re-sync via `utxos_at`, re-pick the active `TxIn`, continue.
+- **Daemon container killed during Antithesis fault injection**: consumers see EOF / connection refused on the Unix socket; they MUST NOT fall back to direct node queries — they pause submission, retry the connection, resume once `ready=true` again.
+- **Faucet exhaustion**: refund tx requires a faucet UTxO of sufficient value; if none is available, tx-generator surfaces a clear error and stops (User Story 2 scenario 5).
+- **Daemon process crash**: with no persistence, restart loses the in-memory index; recovery is "re-index from genesis", which is acceptable on devnet.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: tx-generator MUST obtain the sender's UTxO set exclusively from the indexer daemon (`utxos_at` over its Unix socket). It MUST NOT invoke `cardano-cli query utxo --address` (or any equivalent `LocalStateQuery GetUTxOByAddress` shell-out) under any code path, including error and retry paths.
+- **FR-002**: Asteria-player (and any helper it invokes) MUST obtain on-chain read state (ship UTxOs, pellet UTxOs, central Asteria UTxO, admin NFT) exclusively from the daemon's `utxos_at` request, with the same prohibition on direct LSQ-by-address calls. v1 uses in-process filtering on `value` for asset-class discovery.
+- **FR-003**: tx-generator MUST submit transactions as a deterministic chain: each subsequent self-pay transaction's input is computed from the previous transaction's body (TxId + known output index), without any UTxO re-query and without any post-submit polling loop. Where confirmation waiting is wanted, it goes via the daemon's `await`.
+- **FR-004**: tx-generator MUST keep the active UTxO above a configured refund threshold T (with T > min-UTxO + safety margin) by submitting refund transactions that consume the active UTxO together with a faucet UTxO (held under the same key) and produce a single replenished active UTxO above T. The chain MUST continue off the refund transaction's output without any UTxO re-query.
+- **FR-004a**: tx-generator MUST discover the faucet UTxO(s) exclusively via the daemon's `utxos_at` request (at startup, and when needed for a refund). It MUST NOT shell out to `cardano-cli query utxo --address` to find the faucet.
+- **FR-004b**: When a refund is required but no faucet UTxO is available via the daemon, tx-generator MUST surface a clear error and stop submitting; it MUST NOT silently allow the active UTxO to drift to dust or fall back to direct node queries.
+- **FR-005**: tx-generator MUST remove the existing post-submit "UTxO still present" polling loop from `tx_generator.py`; it is incompatible with FR-003 and is a contributor to LSQ load.
+- **FR-006**: tx-generator and asteria-player MUST handle a momentarily-lagging or unreachable daemon by surfacing a clear error and pausing submission, NOT by falling back to direct node queries.
+- **FR-007**: The indexer daemon MUST be added to the testnet docker compose topology, MUST mount one relay's state volume read-only (for N2C chain-sync against the relay's Unix socket), and MUST listen on a Unix domain socket placed on a shared volume that consumers mount read-only.
+- **FR-008**: The daemon's `ready` request MUST be wired into a compose healthcheck (or equivalent gating) so dependent services do not begin reads until `ready=true`.
+- **FR-009**: Transaction submission itself MUST remain on the LocalTxSubmission mini-protocol via the existing relay socket; this change does not move submission off the node.
+- **FR-010**: Any retained `cardano-cli query tip` (or equivalent slot/era query) MUST be either removed, replaced by the daemon's `ready` request, or accompanied by an inline justification; tip MUST NOT be used as a proxy for "my tx was consumed" — that reduces to the daemon's `await`.
+- **FR-011**: The read-side path MUST tolerate chain rollbacks: on a submission failure or a snapshot mismatch the consumer MUST re-sync via `utxos_at` rather than failing hard. Rollback handling within the daemon is the daemon's responsibility, per [cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78).
+- **FR-012**: This spec depends on [cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78) (the daemon itself). The compose wiring lands once the daemon ships.
+
+### Key Entities *(include if feature involves data)*
+
+- **Indexer daemon**: A small in-memory service (proposed as [cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78)) that follows the chain via N2C from one relay socket and maintains an address→UTxO index. Two read primitives — `utxos_at` (snapshot) and `await` (block until `TxIn` appears) — plus a `ready` request, all over a Unix domain socket using NDJSON. No persistence, no proofs, no merkle tree, no dual-mode backend.
+- **Sender UTxO chain (tx-generator)**: A deterministic sequence of self-pay UTxOs where the next input is computed from the previous tx body. Includes an *active UTxO* (the head of the chain), a configured *refund threshold T* below which a *refund transaction* fires, and one or more *faucet UTxO(s)* held under the same key that supply lovelace into refund transactions.
+- **Asteria read view**: The set of on-chain entities the asteria workload must observe — ship UTxOs (per shipyard policy token), pellet UTxOs at the spacetime address, the singleton Asteria UTxO at the asteria address, the admin NFT. v1 reads each via `utxos_at` on the relevant address and filters in-process on `value`.
+- **Compose topology**: The docker compose configuration that wires relay → daemon (relay-state volume mount, read-only, for N2C chain-sync) and daemon → consumers (shared `indexer-sock` volume holding the Unix socket file).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After 30 minutes of sustained tx-generator operation against a healthy local cluster, `docker logs tx-generator | grep -cE 'Tx failed|UTxO still present|does not meet the minimum UTxO threshold'` returns 0 (today: 23 in 5 minutes per [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)).
+- **SC-002**: An LSQ trace on the relay over a 10-minute representative workload shows zero `GetUTxOByAddress` requests originating from tx-generator's or asteria-player's containers.
+- **SC-003**: tx-generator's submitted-tx count over a fixed window matches `elapsed / configured_interval` within ±5% (i.e. it is no longer wedging or stalling on UTxO discovery), counting self-pay and refund txs together.
+- **SC-004**: Antithesis runs of duration ≥ 1 hour against the cluster do not produce findings whose root cause is read-side query saturation; any node-fell-over findings can be attributed to injected faults.
+- **SC-005**: PR [#67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) (asteria-spawn-v2) can be rebased and merged on top of the daemon landing; its acceptance for User Story 1 (one move-and-gather cycle) passes end-to-end without LSQ-by-address calls from the asteria-player container.
+- **SC-006**: A clean `docker compose up -d` brings the daemon to `ready=true` within a documented bound (target: under 1 minute on the local devnet); dependent services start reads only after that point.
+- **SC-007**: After a forced restart of the daemon container (e.g. `docker compose restart`), `ready=true` returns within the same bound as cold start (re-indexing from genesis is acceptable at devnet scale).
+
+## Assumptions
+
+- The daemon scoped in [cardano-node-clients#78](https://github.com/lambdasistemi/cardano-node-clients/issues/78) ships before the compose wiring in this spec is finalised. Until then, the read-side rewrite of tx-generator and asteria-player can proceed against an out-of-band test fixture exposing the same Unix-socket NDJSON contract.
+- The relay's chain-sync mini-protocol can serve the daemon's follower in addition to the relay's existing N2N peers. (If it doesn't, that is a separate node-level finding, not a scope expansion of this spec.)
+- tx-generator's current behaviour (self-pay chain) is the intended workload shape; this spec changes how UTxOs are discovered and how the chain is constructed (deterministic chain + refund actor), not the high-level "submit lots of cheap txs" goal.
+- Asteria-player's read pattern (address-scoped UTxO lookup with in-process filter on `value`) is sufficient for v1. Adding a policy-keyed endpoint to the daemon is a follow-up only if profiling shows the in-process filter is too slow.
+- The fix lands first as a single PR on `cardano-node-antithesis`'s `main` branch (this spec); the asteria-spawn-v2 rebase ([PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67)) is the second step, not parallel.
+- Submission via LocalTxSubmission is unchanged and remains acceptable, per [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69).
+- Existing testnet compose files (`testnets/cardano_node_master/docker-compose.yaml` and any actively used siblings) are the integration surface; obsolete or experimental compose variants are out of scope.


### PR DESCRIPTION
## Summary

- Spec, plan, research, contracts, and quickstart for moving tx-generator and asteria-player off `cardano-cli query utxo --address` (LSQ saturation, dust wedge — see [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)) onto a small upstream daemon.
- No code changes; documents only. Implementation lands in follow-up commits on this branch (vertical commits 1–4 per [`plan.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/plan.md)).

## Refs

- Driving issue: [#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69)
- External dependency (the daemon itself): [`lambdasistemi/cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78)
- Coupled consumer rebase: [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) (parked on the same axis, unblocked by this work)
- Rejected upstream candidate (and why): [`cardano-utxo-csmt`](https://github.com/lambdasistemi/cardano-utxo-csmt) — overkill, structured around CSMT inclusion proofs and dual-mode `Restoring`/`Full`/`KVOnly` backend; closed [`#233`](https://github.com/lambdasistemi/cardano-utxo-csmt/issues/233)

## Files

- [`spec.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/spec.md) — 5 user stories (3×P1, P2, P3), 12 FRs, 7 SCs, refund-actor model, deterministic chain.
- [`plan.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/plan.md) — technical context, constitution check (one documented deviation: tx-generator stays a non-composer service), 4-commit vertical-commit plan.
- [`research.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/research.md) — R-001..R-007 design decisions.
- [`contracts/indexer-client.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/contracts/indexer-client.md) — NDJSON wire shapes for `utxos_at`, `await`, `ready`; failure model; SDK assertion sites.
- [`contracts/compose-topology.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/contracts/compose-topology.md) — `indexer` service shape, `indexer-sock` volume, healthcheck, image-tag bump rule.
- [`quickstart.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/003-indexer-read-side/specs/003-indexer-read-side/quickstart.md) — bring-up + SC-001/002/003/006/007 verification commands.

## Test plan

- [ ] Daemon image from [`cardano-node-clients#78`](https://github.com/lambdasistemi/cardano-node-clients/issues/78) published; tag pinned in compose.
- [ ] Vertical commits 1–4 land on this branch (NDJSON client → tx-generator deterministic chain → refund actor → compose wiring + image bump).
- [ ] `just smoke-test` green on this branch.
- [ ] SC-001: 30 min run shows zero `Tx failed` / `UTxO still present` / dust lines (vs. 23 in 5 min on `main`).
- [ ] SC-002: 10 min relay LSQ trace shows zero `GetUTxOByAddress` from tx-generator's container.
- [ ] SC-006: cold `docker compose up -d` reaches `ready=true` within 1 minute on devnet.
- [ ] Antithesis duration=1h run on this branch: `findings_new ≤ baseline` (constitution hard gate).

## Note

[PR #68](https://github.com/cardano-foundation/cardano-node-antithesis/pull/68) merged to `main` while this spec was being written and removed the asteria-* services from compose. The asteria-edit section of `contracts/compose-topology.md` is forward-looking — it lands as real YAML only when [PR #67](https://github.com/cardano-foundation/cardano-node-antithesis/pull/67) reinstates those services on rebase.