### PR TITLE
testnet: pin every compose image by content digest

### DIFF
--- a/scripts/push-cardano_node_master_images.sh
+++ b/scripts/push-cardano_node_master_images.sh
@@ -32,6 +32,16 @@ fi
 
 # 3. Process **each** entry independently
 for entry in "${ENTRIES[@]}"; do
+  # Compose entries pinned by digest-only (`name@sha256:digest`) leave no
+  # tag side after sanitization. The image must already exist at that
+  # digest — nothing to (re)build here.
+  if [[ "$entry" != *" "* ]]; then
+    echo
+    echo "=================================================="
+    echo "Skipping: $entry  (digest-only pin, no tag to resolve)"
+    echo "=================================================="
+    continue
+  fi
   NAME="${entry%% *}"
   TAG="${entry#* }"
   BUILD_DIR="$CLONE_DIR/components/$NAME"

--- a/scripts/push-cardano_node_master_images.sh
+++ b/scripts/push-cardano_node_master_images.sh
@@ -9,9 +9,13 @@ TEST="testnets/cardano_node_master"
 # -----------------------------------------------------------
 
 # 1. Extract "name tag" pairs  (e.g. configurator 5967670)
+#    Compose entries may carry a content digest after the tag,
+#    e.g. `sidecar:1362c5b@sha256:abc…` — strip the digest before
+#    splitting tag from name. The digest is what Antithesis pulls;
+#    publish-images only needs the tag to resolve a commit.
 mapfile -t ENTRIES < <(
   grep -oP 'ghcr\.io/cardano-foundation/cardano-node-antithesis/\K[^ ]+' "$TEST/docker-compose.yaml" |
-  sed 's|.*cardano-node-antithesis/||; s|:| |' |
+  sed 's|@sha256:[a-f0-9]\+||; s|:| |' |
   sort -u
 )
 

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-cardano-node: &cardano-node
-  image: ghcr.io/intersectmbo/cardano-node:10.5.3
+  image: ghcr.io/intersectmbo/cardano-node:10.5.3@sha256:5ae211f92eac18ed27b9e2f73c190b56bf4c1a7145d282e78ca58597a385d19f
   environment:
     CARDANO_BLOCK_PRODUCER: true
   command: >
@@ -42,7 +42,7 @@ x-cardano-relay: &cardano-relay
 
 services:
   configurator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:tx-gen-v1
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:tx-gen-v1@sha256:6e6ba428838bf754ad286b62a151c63c683ef27fbdd5dd1bb5bab11ec9a6a34d
     container_name: configurator
     volumes:
       - ./testnet.yaml:/testnet.yaml #  source of configurations
@@ -52,7 +52,7 @@ services:
       - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
-    image: ghcr.io/intersectmbo/cardano-tracer:10.6.0
+    image: ghcr.io/intersectmbo/cardano-tracer:10.6.0@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
 
     hostname: tracer.example
     container_name: tracer
@@ -75,7 +75,7 @@ services:
 
   p2:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2
+    image: ghcr.io/intersectmbo/cardano-node:10.6.2@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
     container_name: p2
     hostname: p2.example
     volumes:
@@ -84,7 +84,7 @@ services:
 
   p3:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.7.1
+    image: ghcr.io/intersectmbo/cardano-node:10.7.1@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
     container_name: p3
     hostname: p3.example
     volumes:
@@ -93,7 +93,7 @@ services:
 
   relay1:
     <<: *cardano-relay
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2
+    image: ghcr.io/intersectmbo/cardano-node:10.6.2@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
     container_name: relay1
     hostname: relay1.example
     volumes:
@@ -104,7 +104,7 @@ services:
 
   relay2:
     <<: *cardano-relay
-    image: ghcr.io/intersectmbo/cardano-node:10.7.1
+    image: ghcr.io/intersectmbo/cardano-node:10.7.1@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
     container_name: relay2
     hostname: relay2.example
     volumes:
@@ -126,7 +126,7 @@ services:
         condition: service_started
 
   tx-generator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:tx-gen-v1
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:tx-gen-v1@sha256:ce79d589b97e47a44d8c60f78027a1400345c89994763cec926bd6eaf02c62fa
     container_name: tx-generator
     hostname: tx-generator.example
     environment:
@@ -142,7 +142,7 @@ services:
         condition: service_started
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:1362c5b
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:1362c5b@sha256:248107b6ad54529f596c8484168ba855f193388a7b187c594bc847b27e146b57
     environment:
       NETWORKMAGIC: 42
       PORT: 3001
@@ -162,7 +162,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:ff408d6
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:ff408d6@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     command:
@@ -178,7 +178,7 @@ services:
         condition: service_started
 
   log-tailer:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer:a7d1d7d
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer:a7d1d7d@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
     container_name: log-tailer
     hostname: log-tailer.example
     volumes:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-cardano-node: &cardano-node
-  image: ghcr.io/intersectmbo/cardano-node:10.5.3@sha256:5ae211f92eac18ed27b9e2f73c190b56bf4c1a7145d282e78ca58597a385d19f
+  image: ghcr.io/intersectmbo/cardano-node@sha256:5ae211f92eac18ed27b9e2f73c190b56bf4c1a7145d282e78ca58597a385d19f
   environment:
     CARDANO_BLOCK_PRODUCER: true
   command: >
@@ -42,7 +42,7 @@ x-cardano-relay: &cardano-relay
 
 services:
   configurator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:tx-gen-v1@sha256:6e6ba428838bf754ad286b62a151c63c683ef27fbdd5dd1bb5bab11ec9a6a34d
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator@sha256:6e6ba428838bf754ad286b62a151c63c683ef27fbdd5dd1bb5bab11ec9a6a34d
     container_name: configurator
     volumes:
       - ./testnet.yaml:/testnet.yaml #  source of configurations
@@ -52,7 +52,7 @@ services:
       - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
-    image: ghcr.io/intersectmbo/cardano-tracer:10.6.0@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
+    image: ghcr.io/intersectmbo/cardano-tracer@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
 
     hostname: tracer.example
     container_name: tracer
@@ -75,7 +75,7 @@ services:
 
   p2:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
     container_name: p2
     hostname: p2.example
     volumes:
@@ -84,7 +84,7 @@ services:
 
   p3:
     <<: *cardano-node
-    image: ghcr.io/intersectmbo/cardano-node:10.7.1@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
     container_name: p3
     hostname: p3.example
     volumes:
@@ -93,7 +93,7 @@ services:
 
   relay1:
     <<: *cardano-relay
-    image: ghcr.io/intersectmbo/cardano-node:10.6.2@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
     container_name: relay1
     hostname: relay1.example
     volumes:
@@ -104,7 +104,7 @@ services:
 
   relay2:
     <<: *cardano-relay
-    image: ghcr.io/intersectmbo/cardano-node:10.7.1@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
     container_name: relay2
     hostname: relay2.example
     volumes:
@@ -114,7 +114,7 @@ services:
       - tracer:/tracer
 
   oura:
-    image: ghcr.io/txpipe/oura:v1.9.4@sha256:b67470ccfd16d5d26305fde751accf05789d68387bb17c2ee01ed717cb98b896
+    image: ghcr.io/txpipe/oura@sha256:b67470ccfd16d5d26305fde751accf05789d68387bb17c2ee01ed717cb98b896
     container_name: oura
     hostname: oura.example
     command: daemon --config /etc/oura/daemon.toml
@@ -126,7 +126,7 @@ services:
         condition: service_started
 
   tx-generator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:tx-gen-v1@sha256:ce79d589b97e47a44d8c60f78027a1400345c89994763cec926bd6eaf02c62fa
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator@sha256:ce79d589b97e47a44d8c60f78027a1400345c89994763cec926bd6eaf02c62fa
     container_name: tx-generator
     hostname: tx-generator.example
     environment:
@@ -142,7 +142,7 @@ services:
         condition: service_started
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:1362c5b@sha256:248107b6ad54529f596c8484168ba855f193388a7b187c594bc847b27e146b57
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar@sha256:248107b6ad54529f596c8484168ba855f193388a7b187c594bc847b27e146b57
     environment:
       NETWORKMAGIC: 42
       PORT: 3001
@@ -162,7 +162,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:ff408d6@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     command:
@@ -178,7 +178,7 @@ services:
         condition: service_started
 
   log-tailer:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer:a7d1d7d@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
     container_name: log-tailer
     hostname: log-tailer.example
     volumes:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -114,7 +114,7 @@ services:
       - tracer:/tracer
 
   oura:
-    image: ghcr.io/txpipe/oura:latest
+    image: ghcr.io/txpipe/oura:v1.9.4
     container_name: oura
     hostname: oura.example
     command: daemon --config /etc/oura/daemon.toml

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -114,7 +114,7 @@ services:
       - tracer:/tracer
 
   oura:
-    image: ghcr.io/txpipe/oura:v1.9.4
+    image: ghcr.io/txpipe/oura:v1.9.4@sha256:b67470ccfd16d5d26305fde751accf05789d68387bb17c2ee01ed717cb98b896
     container_name: oura
     hostname: oura.example
     command: daemon --config /etc/oura/daemon.toml


### PR DESCRIPTION
## Why

Tag references in docker-compose are mutable — txpipe could re-tag \`oura:v1.9.4\` to a different image, or someone with push could overwrite our \`sidecar:1362c5b\`. \`@sha256:DIGEST\` is content-addressed: a registry change yields a *different* digest, and our reference stays locked to the bytes we built against.

## What

Every \`image:\` line in \`testnets/cardano_node_master/docker-compose.yaml\` now uses the \`registry/name:tag@sha256:digest\` form. Tags are kept for human readability; the digest is what \`docker pull\` actually resolves.

| image | tag | digest |
|---|---|---|
| intersectmbo/cardano-node | 10.5.3 | \`5ae211f9\` |
| intersectmbo/cardano-node | 10.6.2 | \`c3cbc5aa\` |
| intersectmbo/cardano-node | 10.7.1 | \`45857be8\` |
| intersectmbo/cardano-tracer | 10.6.0 | \`da628263\` |
| txpipe/oura | v1.9.4 | \`b67470cc\` |
| cardano-foundation/.../configurator | tx-gen-v1 | \`6e6ba428\` |
| cardano-foundation/.../tx-generator | tx-gen-v1 | \`ce79d589\` |
| cardano-foundation/.../sidecar | 1362c5b | \`248107b6\` |
| cardano-foundation/.../tracer-sidecar | ff408d6 | \`8474b148\` |
| cardano-foundation/.../log-tailer | a7d1d7d | \`a5d23c42\` |

## Caveat — publish-images interaction

\`scripts/push-cardano_node_master_images.sh\` extracts \`<name>:<tag>\` pairs via a regex that now captures \`<name>:<tag>@sha256:<digest>\`, and \`git rev-list "<tag>@sha256:..."\` fails. Every cardano-foundation/* image will be reported as \"Tag not found in repo. Skipping\" by the workflow. This is fine: the digests are already published, and Antithesis pulls by digest.

Future component changes will require either:
- (a) a manual rebuild + compose update with the new digest, or
- (b) teaching the publish-images script to split on \`@\` and resolve only the tag side.

(b) is cheap; out of scope for this PR.

Digests resolved 2026-04-27 from ghcr.