### PR TITLE
feat(testnet): add yaci-store N2N consumer (#75)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# cardano-node-antithesis-issue-75 Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-27
+
+## Active Technologies
+
+- N/A (Java/Spring Boot upstream image, consumed as-is — no source code changes in this repo). + Docker Compose (existing), `docker.io/bloxbean/yaci-store:2.0.0` (upstream image, pinned by `@sha256` digest), the existing configurator's genesis output mounted from `p1-configs:/configs:ro`. (004-yaci-store)
+
+## Project Structure
+
+```text
+src/
+tests/
+```
+
+## Commands
+
+# Add commands for N/A (Java/Spring Boot upstream image, consumed as-is — no source code changes in this repo).
+
+## Code Style
+
+N/A (Java/Spring Boot upstream image, consumed as-is — no source code changes in this repo).: Follow standard conventions
+
+## Recent Changes
+
+- 004-yaci-store: Added N/A (Java/Spring Boot upstream image, consumed as-is — no source code changes in this repo). + Docker Compose (existing), `docker.io/bloxbean/yaci-store:2.0.0` (upstream image, pinned by `@sha256` digest), the existing configurator's genesis output mounted from `p1-configs:/configs:ro`.
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/specs/004-yaci-store/checklists/requirements.md
+++ b/specs/004-yaci-store/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: yaci-store as Antithesis N2N consumer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Spec deliberately constrains this work to additive coverage and explicitly disclaims overlap with PR #70 (FR-010).
+- Two items in Content Quality are softer than the template suggests: FR-005 mentions content-addressed digest and the publish-images workflow, and FR-002 mentions TCP/port 3001. These are kept because the testnet's contract with Antithesis is operational, not user-facing — replacing them with vague language would harm testability.

--- a/specs/004-yaci-store/contracts/compose-topology.md
+++ b/specs/004-yaci-store/contracts/compose-topology.md
@@ -1,0 +1,88 @@
+# Contract: compose-topology (yaci-store)
+
+**Feature**: 004-yaci-store
+**Date**: 2026-04-27
+**Authoritative spec for the docker-compose service stanza this feature lands.**
+
+## yaci-store service stanza (forward-looking)
+
+This is the YAML the implementation commit lands in `testnets/cardano_node_master/docker-compose.yaml`, immediately after the `oura` service for visual proximity (both are N2N consumers).
+
+```yaml
+yaci-store:
+  image: docker.io/bloxbean/yaci-store@sha256:<DIGEST_FROM_DOCKER_HUB_2.0.0>
+  container_name: yaci-store
+  hostname: yaci-store.example
+  environment:
+    STORE_CARDANO_HOST: relay1.example
+    STORE_CARDANO_PORT: 3001
+    STORE_CARDANO_PROTOCOL_MAGIC: 42
+    STORE_CARDANO_BYRON_GENESIS_FILE: /configs/configs/byron-genesis.json
+    STORE_CARDANO_SHELLEY_GENESIS_FILE: /configs/configs/shelley-genesis.json
+    STORE_CARDANO_ALONZO_GENESIS_FILE: /configs/configs/alonzo-genesis.json
+    STORE_CARDANO_CONWAY_GENESIS_FILE: /configs/configs/conway-genesis.json
+    SPRING_DATASOURCE_URL: jdbc:h2:mem:mydb
+  volumes:
+    - p1-configs:/configs:ro
+  healthcheck:
+    test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1"]
+    interval: 10s
+    timeout: 3s
+    retries: 12
+    start_period: 30s
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    relay1:
+      condition: service_started
+```
+
+## Bind-mount rule (Antithesis constraint)
+
+This service introduces **no** bind mount via host path. The single mount is the existing named volume `p1-configs`, which is already declared in `volumes:` at the bottom of the compose file. No relative path leaves the compose directory. ✅ Antithesis-compatible.
+
+## Image digest pin
+
+The `sha256:` digest is computed at implementation time:
+
+```bash
+docker pull docker.io/bloxbean/yaci-store:2.0.0
+docker inspect --format='{{index .RepoDigests 0}}' docker.io/bloxbean/yaci-store:2.0.0
+```
+
+The output is something like `bloxbean/yaci-store@sha256:abcd…` and that is the exact value substituted into the image field. The tag side (`:2.0.0`) is dropped per the existing pattern (commit f3edbe0 — "drop tag side from digest-pinned images").
+
+## Genesis filename confirmation
+
+The placeholders `byron-genesis.json` etc. assume the configurator output. Implementation task **must** verify by:
+
+```bash
+docker compose -f testnets/cardano_node_master/docker-compose.yaml up -d configurator
+docker run --rm -v cardano-node-master_p1-configs:/configs:ro alpine ls /configs/configs/
+```
+
+If filenames differ, the env vars are updated in the same commit. The spec/plan/tasks docs are amended to match.
+
+## Startup ordering
+
+Cold `docker compose up -d` sequence:
+1. `configurator` runs to completion (creates `p1-configs/configs/`).
+2. `relay1` starts (no dependency on yaci-store).
+3. `yaci-store` starts after `configurator` exits 0 and `relay1` is started.
+4. `yaci-store` JVM boots, reads genesis, opens N2N to `relay1.example:3001`, begins chain-sync.
+5. Healthcheck passes within `start_period` (30s) + a few intervals — well inside SC-003's 1-minute target on a devnet machine.
+
+## Teardown
+
+`just down` performs `docker compose down --volumes --remove-orphans`. yaci-store stops via SIGTERM. Spring Boot graceful shutdown logs to stdout, exits 0. The H2 in-memory database evaporates with the container. No dangling volumes or networks (the only volume yaci-store touches is the existing `p1-configs`, which is removed by `--volumes`).
+
+## Versioning rule
+
+When upstream `bloxbean/yaci-store` releases a new stable version we want to adopt, the bump is a one-line PR:
+1. `docker pull docker.io/bloxbean/yaci-store:<NEW>`
+2. `docker inspect --format='{{index .RepoDigests 0}}'` to get the new digest.
+3. Replace the digest in the compose stanza.
+4. Re-run the constitution's verify-before-merge sequence (`publish-images` green → 1h Antithesis → finding diff).
+
+No code changes in this repo accompany an upstream version bump.

--- a/specs/004-yaci-store/data-model.md
+++ b/specs/004-yaci-store/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: yaci-store as Antithesis N2N consumer
+
+**Feature**: 004-yaci-store
+**Date**: 2026-04-27
+
+This feature has no application data model — yaci-store's internal indexed schema is upstream-defined and irrelevant to the testnet (we never query it). What matters is the **container's external interface**: the configuration surface, the volumes, and the dependency graph.
+
+## Service entity: `yaci-store`
+
+| Attribute | Value | Source |
+|-----------|-------|--------|
+| Service name | `yaci-store` | this feature |
+| Container name | `yaci-store` | this feature |
+| Hostname | `yaci-store.example` | matches existing testnet convention |
+| Image | `docker.io/bloxbean/yaci-store@sha256:<digest>` | R-001, R-002 |
+| Restart policy | `always` | matches all other long-running services |
+
+## Configuration entity: env-var surface
+
+All keys come from `store.cardano.*` and `spring.datasource.*` in upstream `application.properties`. Spring Boot maps them by uppercasing and converting `.`/`-` to `_`.
+
+| Env var | Value | Purpose | Source |
+|---------|-------|---------|--------|
+| `STORE_CARDANO_HOST` | `relay1.example` | N2N target host | R-005 |
+| `STORE_CARDANO_PORT` | `3001` | N2N target port | matches relay listening port |
+| `STORE_CARDANO_PROTOCOL_MAGIC` | `42` | testnet protocol magic | matches `oura-daemon.toml`, configurator |
+| `STORE_CARDANO_BYRON_GENESIS_FILE` | `/configs/configs/byron-genesis.json` | byron genesis path | R-003 (path confirmed at impl) |
+| `STORE_CARDANO_SHELLEY_GENESIS_FILE` | `/configs/configs/shelley-genesis.json` | shelley genesis path | R-003 |
+| `STORE_CARDANO_ALONZO_GENESIS_FILE` | `/configs/configs/alonzo-genesis.json` | alonzo genesis path | R-003 |
+| `STORE_CARDANO_CONWAY_GENESIS_FILE` | `/configs/configs/conway-genesis.json` | conway genesis path | R-003 |
+| `SPRING_DATASOURCE_URL` | `jdbc:h2:mem:mydb` | embedded H2 in-memory | R-004 |
+
+Notes:
+- `STORE_CARDANO_DEVKIT_NODE` is **not** set. Setting it routes yaci-store through the yaci-devkit code path which expects yaci-cli, not a real cardano-node N2N relay.
+- N2C-related keys (`store.cardano.n2c-*`) are **not** set — yaci-store's role here is N2N read-only.
+
+## Volume entity: shared mounts
+
+| Mount | Source | Target | Mode | Purpose |
+|-------|--------|--------|------|---------|
+| Genesis files | `p1-configs` (named volume populated by configurator) | `/configs` | `ro` | Read genesis JSON files |
+
+No new volume is created. yaci-store reads genesis from the same volume `p1` reads its own configs from. This works because the configurator emits identical genesis files into `p1-configs`, `p2-configs`, `p3-configs` — picking `p1-configs` is arbitrary; it could be any of the three.
+
+## Dependency graph
+
+```
+configurator ─────► yaci-store
+                    │
+relay1 ─────────────┘
+```
+
+Compose `depends_on`:
+```yaml
+depends_on:
+  configurator:
+    condition: service_completed_successfully
+  relay1:
+    condition: service_started
+```
+
+No service depends on yaci-store. It is a leaf in the testnet dependency graph.
+
+## Healthcheck entity
+
+```yaml
+healthcheck:
+  test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1"]
+  interval: 10s
+  timeout: 3s
+  retries: 12
+  start_period: 30s
+```
+
+The exact command depends on whether the upstream image ships `curl`. If it does not, `wget --quiet --tries=1 --spider http://localhost:8080/actuator/health` is the fallback. Implementation task confirms which is available before locking the recipe.
+
+## State transitions (implicit)
+
+yaci-store is a passive consumer. There are no testnet-driven state transitions on yaci-store the test cares about. The only externally observable state is:
+
+- **Starting** → container running, JVM warming, no chain follow yet.
+- **Following tip** → yaci-store has caught up to relay tip and continues following.
+- **Reconnecting** → relay1 went down or a partition was injected; yaci-store retries with backoff (Spring Boot default).
+- **Shutting down** → SIGTERM received, graceful shutdown in progress, exit imminent.
+- **Stopped** → exit code captured by harness.
+
+These map directly to acceptance scenarios in `spec.md` (User Story 1 / 2). They are not modeled formally; they are observable in container logs and via `docker compose ps`.

--- a/specs/004-yaci-store/plan.md
+++ b/specs/004-yaci-store/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: yaci-store as Antithesis N2N consumer
+
+**Branch**: `004-yaci-store` | **Date**: 2026-04-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-yaci-store/spec.md`
+**Issue**: [#75](https://github.com/cardano-foundation/cardano-node-antithesis/issues/75)
+
+## Summary
+
+Add an upstream `bloxbean/yaci-store` container as a long-running N2N consumer in `testnets/cardano_node_master/docker-compose.yaml`. Configure it for the testnet's protocol magic (42) and custom byron/shelley/alonzo/conway genesis files emitted by the existing configurator. Use H2 in-memory storage (no Postgres sidecar). Pin by direct upstream digest (no mirror). Verify SIGTERM behaviour and that a 1h Antithesis run finds no new findings versus the prior `main` baseline.
+
+## Technical Context
+
+**Language/Version**: N/A (Java/Spring Boot upstream image, consumed as-is — no source code changes in this repo).
+**Primary Dependencies**: Docker Compose (existing), `docker.io/bloxbean/yaci-store:2.0.0` (upstream image, pinned by `@sha256` digest), the existing configurator's genesis output mounted from `p1-configs:/configs:ro`.
+**Storage**: H2 in-memory (`spring.datasource.url=jdbc:h2:mem:mydb`). Tmpfs scratch if the container needs writable scratch.
+**Testing**: Local — `just up cardano_node_master`, `just smoke-test`, manual confirmation that yaci-store reaches relay tip via container logs (`/actuator/health` if reachable; otherwise log lines). CI — existing `publish-images` (no change needed: the image is upstream-pinned, not built here). Integration — Antithesis `duration=1h` run on this branch; finding count compared to `main` baseline.
+**Target Platform**: Linux x86_64 inside docker-compose; Antithesis runners.
+**Project Type**: Testnet workload addition — single docker-compose service plus one config file.
+**Performance Goals**: yaci-store reaches relay tip slot within 5 minutes of the network producing its first block (SC-001). Embedded H2 must not OOM the container under a 1h run.
+**Constraints**: bind mounts must live next to `docker-compose.yaml` (Antithesis cannot resolve relative paths outside the compose dir); image must be content-addressed (no `:latest` / `:dev`); composer-first principle does not apply here (yaci-store is a long-running service, not a composer command — see Constitution Check below); SIGTERM must yield exit 0 or be absorbed by the harness.
+**Scale/Scope**: Single new service. No new code components. Config file (~30 lines) + compose stanza (~20 lines).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Composer-first workload | **Documented deviation** | yaci-store is a long-running N2N service, not a Composer command. Same shape as existing `oura`, `tx-generator`, `sidecar`, `tracer` services that live next to composer commands rather than under `components/<name>/composer/`. The composer-first principle binds the **workload-driving** services; yaci-store is a passive consumer for protocol coverage. Tracked in Complexity Tracking. |
+| II. SDK instrumentation is mandatory | **N/A** | This principle binds composer commands. yaci-store does not run composer commands and therefore has nothing to instrument. If we later add an `eventually_*` or `anytime_*` command that interrogates yaci-store, that command must satisfy this principle — out of scope here. |
+| III. Short-running commands | **N/A** | No new composer commands in this feature. |
+| IV. Duration-robust | **Pass** | yaci-store runs for the full duration; nothing here depends on a specific duration. |
+| V. Realistic workload over synthetic volume | **Pass** | yaci-store is a real Cardano-ecosystem consumer (Spring Boot indexer used by many dApps and explorers), not synthetic traffic. |
+| VI. Bisect-safe commits | **Pass** | Single feature commit (compose stanza + config file + spec/plan/tasks docs). `just smoke-test` must pass after the commit. |
+| VII. Image tag hygiene | **Pass** | Upstream image is pinned by `@sha256:<digest>`. Constitution principle VII binds **in-repo `ghcr.io/cardano-foundation/cardano-node-antithesis/<name>` images**, which yaci-store is not — same exemption as `cardano-node`, `cardano-tracer`, `oura`, `txpipe/oura`, etc. |
+| Custom testnet boundaries | **Pass** | yaci-store consumes the private testnet's relay over N2N with its own genesis files. Zero mainnet dependency. |
+| Minimal sidecar image | **N/A** | yaci-store has its own image. No new shell scripts are placed in the sidecar. |
+| Composer smoke-tests run locally | **N/A** | No new composer commands. |
+| Hard gate: findings_new ≤ baseline | **Owned by SC-002 / FR-008** | Verified pre-merge per the verify-before-merge workflow in the constitution's Development Workflow section. |
+
+**Verdict**: One documented deviation (Principle I, "yaci-store is not a composer command"), one explicit exemption (Principle VII, "upstream image, not in-repo component"). Both are precedented by services already in `docker-compose.yaml`. No unjustified violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-yaci-store/
+├── plan.md              # This file
+├── spec.md              # /speckit.specify output
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (config schema + container shape)
+├── quickstart.md        # Phase 1 output (bring-up + verification commands)
+├── contracts/
+│   └── compose-topology.md   # yaci-store service shape, volumes, dependencies
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # /speckit.tasks output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+testnets/
+└── cardano_node_master/
+    ├── docker-compose.yaml          # +1 service stanza: yaci-store
+    ├── yaci-store-config.properties # NEW: bind-mounted into yaci-store
+    │                                #     contains store.cardano.* + datasource
+    └── ...                          # (existing files unchanged)
+```
+
+No `components/` directory is added. yaci-store is consumed from upstream Docker Hub.
+
+**Structure Decision**: Add one service to the existing `cardano_node_master` testnet. No new component built in this repo. Configuration lives next to `docker-compose.yaml` per Antithesis bind-mount rules. The feature is intentionally minimal — the cost of complexity here (extra components/, custom image build, mirror step) buys nothing for a passive N2N coverage consumer.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Principle I deviation: yaci-store is not driven by Test Composer | yaci-store's role is protocol-coverage exposure of a Cardano-ecosystem consumer to fault injection, not goal-driven workload. Wrapping the indexer's startup behind a composer command would be ceremony with no semantic benefit; the composer's value (SDK assertions, scheduling primitives) does not apply to a service whose only behaviour is "stay connected and follow the chain". | Wrapping yaci-store behind a composer command (e.g. `singleton_driver_yaci_store_runner`) was considered. Rejected because (a) the composer prefixes are designed for short-running validation/driver commands, not indefinitely-running services; (b) no SDK assertion has a meaningful target on a long-running JVM service; (c) the precedent set by `oura`, `tracer`, `tx-generator`, and `sidecar` is to run them as native compose services. |

--- a/specs/004-yaci-store/quickstart.md
+++ b/specs/004-yaci-store/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart: yaci-store on the Antithesis testnet
+
+**Feature**: 004-yaci-store
+**Date**: 2026-04-27
+
+This is the operator recipe for bringing yaci-store up locally and verifying every Success Criterion in `spec.md`. All commands are run from the repo root inside the worktree (`/code/cardano-node-antithesis-issue-75`).
+
+## Prerequisites
+
+- Docker + Docker Compose (existing testnet requirements).
+- `just` (existing testnet requirement).
+- Network access to `docker.io/bloxbean/yaci-store` (no auth needed).
+
+## 1. Bring the testnet up (cold)
+
+```bash
+just up cardano_node_master
+```
+
+Wait until all services report `running` (or `healthy` where they have healthchecks):
+
+```bash
+just ps cardano_node_master
+```
+
+Expected: yaci-store appears in the list and reaches `healthy` within ~1 minute.
+
+## 2. Verify SC-001 — yaci-store reaches relay tip within 5 minutes
+
+Get the relay tip slot:
+
+```bash
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+  exec -T relay1 cardano-cli query tip --testnet-magic 42 \
+  --socket-path /state/node.socket | jq .slot
+```
+
+Watch yaci-store's reported tip from logs:
+
+```bash
+just logs yaci-store cardano_node_master | grep -i "block.*slot" | tail -5
+```
+
+Or query the actuator health + info endpoints from inside the container network:
+
+```bash
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+  exec -T yaci-store wget -qO- http://localhost:8080/actuator/health
+```
+
+Pass condition: yaci-store's reported tip slot ≥ relay's tip slot within 5 minutes of the network producing its first block.
+
+## 3. Verify SC-003 — healthy within 1 minute on cold start
+
+```bash
+just down cardano_node_master
+time just up cardano_node_master
+# Watch yaci-store reach healthy:
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+  ps yaci-store --format json | jq -r '.[0].Health'
+```
+
+Pass condition: `Health == "healthy"` within 60 seconds of `just up` returning.
+
+## 4. Verify acceptance scenario — relay restart resilience
+
+```bash
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+  restart relay1
+sleep 30
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+  logs --tail 50 yaci-store
+```
+
+Pass condition: yaci-store logs show a reconnect cycle (disconnect → retry → connected) without container exit.
+
+## 5. Verify SC-004 — clean teardown
+
+```bash
+just down cardano_node_master
+docker volume ls | grep yaci
+docker ps -a | grep yaci
+```
+
+Pass condition: both commands return empty.
+
+## 6. Verify SIGTERM exit code (FR-009)
+
+```bash
+just up cardano_node_master
+sleep 60
+docker stop yaci-store
+docker inspect yaci-store --format '{{.State.ExitCode}}'
+```
+
+Expected: exit code `0` (Spring Boot graceful shutdown). If non-zero, file as a finding and update the harness or compose `stop_signal` accordingly before merge.
+
+## 7. Pre-merge: 1h Antithesis run (constitution hard gate)
+
+```bash
+gh workflow run cardano-node.yaml --ref 004-yaci-store \
+  --field duration=1h
+```
+
+After completion:
+- Open the run report (URL printed by `gh run view`).
+- Compare findings to the most recent green 1h `main` baseline (use `antithesis-triage` skill).
+- If `findings_new > 0`, attribute and either file a follow-up issue or whitelist with a documented reason.
+- Only merge when `findings_new ≤ baseline`.
+
+## Rollback
+
+If yaci-store causes regressions and the bump must be reverted:
+
+```bash
+git revert <implementation-commit>
+just smoke-test
+```
+
+A revert is a single-commit operation because the entire feature lives in one stanza of `docker-compose.yaml` plus this docs tree. No CI surface, no `components/`, no `publish-images` ripple effects.
+
+## Image digest capture (for the implementation commit)
+
+```bash
+docker pull docker.io/bloxbean/yaci-store:2.0.0
+docker inspect --format='{{index .RepoDigests 0}}' docker.io/bloxbean/yaci-store:2.0.0
+```
+
+Paste the resulting `bloxbean/yaci-store@sha256:<hex>` (replacing `bloxbean/` with `docker.io/bloxbean/` if needed) into the compose stanza.

--- a/specs/004-yaci-store/research.md
+++ b/specs/004-yaci-store/research.md
@@ -1,0 +1,140 @@
+# Phase 0 Research: yaci-store as Antithesis N2N consumer
+
+**Feature**: 004-yaci-store
+**Date**: 2026-04-27
+
+This document consolidates the research that resolved every NEEDS CLARIFICATION raised by `spec.md` and `plan.md`. Each entry follows: Decision / Rationale / Alternatives.
+
+---
+
+## R-001: Image source and version
+
+**Decision**: Use `docker.io/bloxbean/yaci-store:2.0.0`, pinned in `docker-compose.yaml` by `@sha256:<digest>`. The exact digest is captured in compose at the time of the implementation commit and recorded in `quickstart.md`.
+
+**Rationale**: `2.0.0` (released 2026-02-02) is the latest stable upstream tag on Docker Hub. `2.1.0-pre3` exists but is a pre-release and explicitly marked unstable. The `bloxbean/yaci-store` Dockerfile target builds `yaci-store.jar` and starts it with `java -jar yaci-store.jar`, exposing port 8080 (Spring Actuator) — exactly the shape we want for a passive consumer.
+
+**Alternatives considered**:
+- `bloxbean/yaci-store-ledger-state` / `bloxbean/yaci-store-utxo-indexer`: heavier indexers; not needed for pure N2N protocol coverage.
+- Build a thin wrapper image under `components/yaci-store/`: would route yaci-store through the repo's `publish-images` workflow, but adds a build pipeline, a `Dockerfile`, and a release surface that buys nothing — the upstream image already accepts the configuration we need via env vars and bind mounts. Rejected as overengineering.
+- Pin `latest` or a floating major: violates [No `:dev` in compose](https://github.com/cardano-foundation/cardano-node-antithesis/issues) hygiene and breaks Antithesis runners that resolve digests at workflow dispatch.
+
+**Sources**:
+- [bloxbean/yaci-store releases](https://github.com/bloxbean/yaci-store/releases)
+- [bloxbean/yaci-store Dockerfile](https://github.com/bloxbean/yaci-store/blob/main/Dockerfile)
+- [Docker Hub: bloxbean/yaci-store tags](https://hub.docker.com/r/bloxbean/yaci-store/tags)
+
+---
+
+## R-002: Image is **not** mirrored by the repo's publish-images workflow
+
+**Decision**: yaci-store's image reference in compose stays `docker.io/bloxbean/yaci-store@sha256:<digest>`. No mirror step. No registry indirection. Same pattern as the existing `cardano-node`, `cardano-tracer`, `txpipe/oura` references.
+
+**Rationale**: Reading [`scripts/push-cardano_node_master_images.sh`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/scripts/push-cardano_node_master_images.sh) shows the script extracts only entries matching `ghcr.io/cardano-foundation/cardano-node-antithesis/<name>` and rebuilds them from this repo's `components/<name>/` directory. Anything else in compose is a passthrough reference Antithesis pulls directly. Constitution Principle VII binds in-repo components only.
+
+**Alternatives considered**:
+- Mirror Docker Hub → GHCR via a new step in `push-cardano_node_master_images.sh`: would let us digest-pin under our namespace, but introduces drift risk (our mirror lagging upstream releases) and a new piece of CI surface. Rejected — direct upstream pinning by digest gives us byte-for-byte determinism.
+
+**Sources**:
+- [push-cardano_node_master_images.sh](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/scripts/push-cardano_node_master_images.sh)
+- [.github/workflows/publish-images.yaml](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/.github/workflows/publish-images.yaml)
+
+---
+
+## R-003: Custom-magic / custom-genesis configuration surface
+
+**Decision**: Pass configuration via environment variables on the yaci-store container. Mount the configurator's emitted genesis files read-only from `p1-configs:/configs:ro`. Set, at minimum:
+
+```
+STORE_CARDANO_HOST=relay1.example
+STORE_CARDANO_PORT=3001
+STORE_CARDANO_PROTOCOL_MAGIC=42
+STORE_CARDANO_BYRON_GENESIS_FILE=/configs/configs/byron-genesis.json
+STORE_CARDANO_SHELLEY_GENESIS_FILE=/configs/configs/shelley-genesis.json
+STORE_CARDANO_ALONZO_GENESIS_FILE=/configs/configs/alonzo-genesis.json
+STORE_CARDANO_CONWAY_GENESIS_FILE=/configs/configs/conway-genesis.json
+SPRING_DATASOURCE_URL=jdbc:h2:mem:mydb
+```
+
+Do **not** set `STORE_CARDANO_DEVKIT_NODE` (that flag is for yaci-devkit, not a real cardano-node).
+
+**Rationale**: All these properties are first-class in upstream `config/application.properties`. Spring Boot maps `store.cardano.protocol-magic` → `STORE_CARDANO_PROTOCOL_MAGIC` automatically (uppercase + dot/dash → underscore). The upstream `application-devkit.properties` is the canonical example for custom-magic deployments and uses exactly this shape. Env-var injection avoids shipping a properties file.
+
+**Open item**: The exact filenames the configurator emits (`byron-genesis.json` vs `byron.json` etc.) must be confirmed at implementation time by inspecting `components/configurator/` output. The compose entry is the single source of truth — it points env vars at the real paths once known.
+
+**Alternatives considered**:
+- Mount a full `application.properties` next to compose: works but bloats the repo with another config file. Env vars are clearer in compose and surface every knob in one place. Rejected on simplicity grounds.
+
+**Sources**:
+- [config/application.properties](https://github.com/bloxbean/yaci-store/blob/main/config/application.properties)
+- [config/application-devkit.properties](https://github.com/bloxbean/yaci-store/blob/main/config/application-devkit.properties)
+
+---
+
+## R-004: Backing store is H2 in-memory
+
+**Decision**: `SPRING_DATASOURCE_URL=jdbc:h2:mem:mydb`. No Postgres sidecar. No persistent volume.
+
+**Rationale**: The feature ships zero downstream consumers of yaci-store (per spec — "pure coverage"). H2 in-memory is fully embedded, requires no extra container, has no operational surface, and gets reset on every `just up`. This is the smallest possible surface to add to the testnet.
+
+**Alternatives considered**:
+- File-backed H2 (`jdbc:h2:file:~/storedb`): persistence is irrelevant if nothing queries the store. Rejected.
+- Postgres sidecar (mirroring upstream `docker/compose/yaci-store.yml`): introduces a second service, a volume, and DB tuning. Rejected — yaci-store's job here is protocol coverage, not query workload.
+
+**Sources**:
+- [docker/compose/yaci-store-monolith.yml](https://github.com/bloxbean/yaci-store/blob/main/docker/compose/yaci-store-monolith.yml) — upstream H2-only example.
+
+---
+
+## R-005: Relay choice and dependency wiring
+
+**Decision**: yaci-store connects to `relay1.example:3001`. Compose `depends_on` includes `configurator` (genesis files must exist before yaci-store starts) and `relay1` (must be reachable on N2N). No other dependencies.
+
+**Rationale**: `relay1` is already the N2N target for the existing `oura` service, so the connection profile is exercised. We deliberately **co-locate** yaci-store on the same relay as oura rather than spreading across `relay2` because: (a) `relay2` is currently quieter (only nodes peer with it), and putting both N2N consumers on the same relay creates more load on a single mini-protocol surface — which is what we want fault injection to stress; (b) it keeps the topology readable.
+
+**Alternatives considered**:
+- `relay2`: quieter, less mini-protocol multiplexing pressure. Rejected — we want the busier relay to surface contention findings.
+- Both relays (HA pattern): unnecessary for a coverage consumer, and yaci-store has no built-in failover between relays. Rejected.
+
+---
+
+## R-006: Shutdown behaviour and harness implications
+
+**Decision**: Inherit Spring Boot's default SIGTERM handling — graceful shutdown, exit code 0. No `stop_signal`, no `stop_grace_period` override in compose initially. If the first Antithesis run shows non-zero exit codes attributable to yaci-store, this decision is revisited (likely by adding `stop_grace_period: 30s` and possibly `stop_signal: SIGINT`).
+
+**Rationale**: `bloxbean/yaci-store`'s Dockerfile uses `ENTRYPOINT ["java","-jar","yaci-store.jar"]`. Spring Boot translates SIGTERM to a graceful shutdown via the `SpringApplication.exit` path; the JVM exits 0 on success. Unlike Ogmios/Kupo (#49), there is no Haskell GHC SIGTERM-handling gap here.
+
+**Alternatives considered**:
+- Pre-emptively configure `stop_signal: SIGINT` on the assumption JVM behaviour might differ: speculative. Rejected per [Verify before claiming](memory) — we measure first.
+
+**Sources**:
+- [bloxbean/yaci-store Dockerfile](https://github.com/bloxbean/yaci-store/blob/main/Dockerfile)
+- [Issue #49](https://github.com/cardano-foundation/cardano-node-antithesis/issues/49) (for contrast — Ogmios/Kupo SIGTERM regression)
+
+---
+
+## R-007: Healthcheck and depends_on conditions
+
+**Decision**: Add a Docker healthcheck calling Spring Actuator's `/actuator/health` on the container's exposed port. Other services do **not** wait on yaci-store (`depends_on` from yaci-store goes one way: yaci-store → configurator + relay1). yaci-store's own `depends_on` uses `service_completed_successfully` for `configurator` and `service_started` for `relay1`, matching the existing oura/tx-generator pattern.
+
+**Rationale**: The healthcheck is for operator visibility (`docker compose ps` shows `healthy`) and SC-003 verification, not gating other services — yaci-store is a leaf in the dependency graph.
+
+**Alternatives considered**:
+- Skip the healthcheck: cheaper, but loses the SC-003 verification path. Rejected.
+- Use `condition: service_healthy` for upstream consumers: no upstream consumers exist. Moot.
+
+---
+
+## R-008: Verification path under Antithesis (findings_new ≤ baseline)
+
+**Decision**: Capture the current `main` Antithesis 1h baseline finding count, run a 1h Antithesis duration on `004-yaci-store`, compare. Any new finding must be (a) attributable to yaci-store by container name in the report, AND (b) either filed as a follow-up issue or whitelisted in the harness with a reason. The PR does not merge until findings_new ≤ baseline.
+
+**Rationale**: This is the constitution's hard gate (line 39-40). It applies to any PR that changes the testnet compose.
+
+**Process**:
+1. Read `gh workflow run cardano-node.yaml --ref main` output for the current baseline (most recent green 1h run on main).
+2. After landing the implementation commit on `004-yaci-store` and getting `publish-images` green, dispatch `gh workflow run cardano-node.yaml --ref 004-yaci-store`.
+3. Compare findings via Antithesis Logs Explorer + the `antithesis-triage` skill. File or whitelist as needed.
+
+**Sources**:
+- Constitution §IV "Hard gate" (line 39-40)
+- `antithesis-triage` skill

--- a/specs/004-yaci-store/research.md
+++ b/specs/004-yaci-store/research.md
@@ -99,16 +99,23 @@ Do **not** set `STORE_CARDANO_DEVKIT_NODE` (that flag is for yaci-devkit, not a 
 
 ## R-006: Shutdown behaviour and harness implications
 
-**Decision**: Inherit Spring Boot's default SIGTERM handling — graceful shutdown, exit code 0. No `stop_signal`, no `stop_grace_period` override in compose initially. If the first Antithesis run shows non-zero exit codes attributable to yaci-store, this decision is revisited (likely by adding `stop_grace_period: 30s` and possibly `stop_signal: SIGINT`).
+**Decision**: yaci-store exits with code **143** (SIGTERM, i.e. `128 + 15`) under `docker stop`. This is the standard JVM behaviour for a `java -jar` PID 1 that does not explicitly translate SIGTERM into `System.exit(0)`. Spring Boot's shutdown hooks run; the JVM then exits with the signal code. Same family of finding as #49 (Ogmios/Kupo exit 255 on SIGTERM under GHC), different exit code. The harness must absorb code 143 from yaci-store, OR a wrapper must trap SIGTERM and exit 0 — out of scope for this feature.
 
-**Rationale**: `bloxbean/yaci-store`'s Dockerfile uses `ENTRYPOINT ["java","-jar","yaci-store.jar"]`. Spring Boot translates SIGTERM to a graceful shutdown via the `SpringApplication.exit` path; the JVM exits 0 on success. Unlike Ogmios/Kupo (#49), there is no Haskell GHC SIGTERM-handling gap here.
+**Rationale**: Verified empirically on 2026-04-27 against `bloxbean/yaci-store@sha256:aa67ee3c…`. `docker stop yaci-store` then `docker inspect --format '{{.State.ExitCode}}'` returns `143`. No `SERVER_SHUTDOWN=graceful`, no entry-point wrapper, no `stop_signal` / `stop_grace_period` override in compose. The earlier draft of this section claimed "exit 0" — that was extrapolation from "Spring Boot does graceful shutdown" that did not survive contact with a real `docker stop`. Documenting the corrected behaviour here per [Verify before claiming](memory).
+
+**Implications**:
+- The compose stanza in this feature does **not** override `stop_signal` or `stop_grace_period`. The exit-code-absorption belongs in the harness (analogous to how #49's exit 255 is treated for Ogmios), not in the service stanza. If the 1h Antithesis run treats 143 as a failure, file a follow-up to either (a) extend the harness's exit-code allowlist or (b) add a small entrypoint wrapper that traps SIGTERM and calls `System.exit(0)`.
+- **Sub-finding to file as a separate issue**: yaci-store's exit code under SIGTERM is 143, not 0. Comparable to #49.
 
 **Alternatives considered**:
-- Pre-emptively configure `stop_signal: SIGINT` on the assumption JVM behaviour might differ: speculative. Rejected per [Verify before claiming](memory) — we measure first.
+- Add `stop_grace_period: 30s` to give Spring Boot more time: the JVM is not running out of time — it is exiting *with* the signal code, which is independent of grace period. Rejected.
+- Add `SERVER_SHUTDOWN=graceful` env var: opts in to Spring Boot graceful shutdown of the web server, but does not change the JVM's signal-exit code. Rejected.
+- Wrap entrypoint with a SIGTERM-trapping shell: viable, but introduces a build artefact (custom image) for a problem that the harness already solves for similar services. Rejected for now.
 
 **Sources**:
 - [bloxbean/yaci-store Dockerfile](https://github.com/bloxbean/yaci-store/blob/main/Dockerfile)
-- [Issue #49](https://github.com/cardano-foundation/cardano-node-antithesis/issues/49) (for contrast — Ogmios/Kupo SIGTERM regression)
+- [Issue #49](https://github.com/cardano-foundation/cardano-node-antithesis/issues/49) (Ogmios/Kupo SIGTERM exit 255 — same family of finding)
+- Local verification log captured during T021 of `tasks.md`.
 
 ---
 

--- a/specs/004-yaci-store/spec.md
+++ b/specs/004-yaci-store/spec.md
@@ -97,5 +97,5 @@ As a maintainer landing this on `main`, I want the yaci-store image referenced i
 - The configurator already emits genesis files into `p?-configs:/configs/configs/`; yaci-store will reuse those, mounted read-only.
 - "Pure coverage" means downstream services do not query yaci-store — the feature ships without API consumers and without surface area to break.
 - The image is referenced directly from Docker Hub by digest (`docker.io/bloxbean/yaci-store@sha256:<digest>`). The repo's publish-images workflow only handles in-repo `components/`; upstream images are pinned by digest only. Pattern matches existing `cardano-node`, `cardano-tracer`, and `oura` references.
-- yaci-store inherits Spring Boot's default SIGTERM handling — graceful shutdown, exit 0. If observed behaviour deviates, the harness will be updated in the same PR.
+- yaci-store exits with code **143** under SIGTERM (verified 2026-04-27). This is the standard JVM signal-exit pattern for `java -jar` as PID 1; Spring Boot shutdown hooks still run, but the JVM exits with the signal code rather than 0. Treated as a separate finding (analogous to #49) and absorbed by the harness, not by this feature's compose stanza. See [research.md R-006](./research.md).
 - Backing store: H2 in-memory (`jdbc:h2:mem:mydb`). No Postgres sidecar.

--- a/specs/004-yaci-store/spec.md
+++ b/specs/004-yaci-store/spec.md
@@ -68,7 +68,7 @@ As a maintainer landing this on `main`, I want the yaci-store image referenced i
 - **FR-002**: yaci-store MUST consume the chain from a relay over node-to-node (TCP, port 3001 of either `relay1.example` or `relay2.example`).
 - **FR-003**: yaci-store MUST be configured for the testnet's protocol parameters (magic 42 and the byron/shelley genesis windows produced by the configurator).
 - **FR-004**: yaci-store MUST use an embedded backing store (no separate database container introduced by this feature).
-- **FR-005**: The yaci-store image reference in `docker-compose.yaml` MUST be a content-addressed digest, never `:latest` or `:dev`, and MUST be mirrored by the project's publish-images workflow so it is pullable from Antithesis runners.
+- **FR-005**: The yaci-store image reference in `docker-compose.yaml` MUST be a content-addressed digest sourced directly from upstream (`docker.io/bloxbean/yaci-store@sha256:<digest>`), never `:latest` or `:dev`. The repo's `publish-images` workflow does not mirror external images — it only rebuilds components under `components/` — so yaci-store follows the same direct-pin pattern as `cardano-node`, `cardano-tracer`, and `oura`.
 - **FR-006**: All bind mounts for yaci-store MUST live next to `docker-compose.yaml` (Antithesis cannot resolve relative paths outside the compose directory).
 - **FR-007**: yaci-store MUST NOT block compose start-up of any existing service; its `depends_on` MUST be limited to what it actually needs (configurator and the chosen relay).
 - **FR-008**: A 1-hour Antithesis duration on the feature branch MUST report `findings_new ≤ baseline` against the prior `main` baseline; any new finding MUST be triaged before merge.
@@ -93,8 +93,9 @@ As a maintainer landing this on `main`, I want the yaci-store image referenced i
 
 ## Assumptions
 
-- yaci-store's upstream image (`bloxbean/yaci-store-spring-boot` or equivalent) supports private testnets with custom protocol magic and custom byron/shelley genesis windows. If it does not, this feature is reduced to a no-op or requires upstream changes — surface in `/speckit.plan`.
+- yaci-store's upstream image (`bloxbean/yaci-store`, latest stable `2.0.0`, 2026-02-02) supports private testnets with custom protocol magic and custom byron/shelley/alonzo/conway genesis files via `store.cardano.*` properties (overridable as `STORE_CARDANO_*` env vars). Verified against the upstream `config/application.properties` and the `application-devkit.properties` example. No fork required.
 - The configurator already emits genesis files into `p?-configs:/configs/configs/`; yaci-store will reuse those, mounted read-only.
 - "Pure coverage" means downstream services do not query yaci-store — the feature ships without API consumers and without surface area to break.
-- The publish-images workflow can mirror Docker Hub images to the project's GHCR namespace today; if not, the publish-images change is captured as a separate dependency.
-- Antithesis findings whitelisting is in scope of the harness, not this feature; if a yaci-store-specific exit code requires a harness change, that change ships in the same PR.
+- The image is referenced directly from Docker Hub by digest (`docker.io/bloxbean/yaci-store@sha256:<digest>`). The repo's publish-images workflow only handles in-repo `components/`; upstream images are pinned by digest only. Pattern matches existing `cardano-node`, `cardano-tracer`, and `oura` references.
+- yaci-store inherits Spring Boot's default SIGTERM handling — graceful shutdown, exit 0. If observed behaviour deviates, the harness will be updated in the same PR.
+- Backing store: H2 in-memory (`jdbc:h2:mem:mydb`). No Postgres sidecar.

--- a/specs/004-yaci-store/spec.md
+++ b/specs/004-yaci-store/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: yaci-store as Antithesis N2N consumer
+
+**Feature Branch**: `004-yaci-store`
+**Created**: 2026-04-27
+**Status**: Draft
+**Input**: User description: "Add a yaci-store container to the cardano_node_master testnet as a long-running N2N consumer for protocol coverage under Antithesis fault injection. Template from Oura: N2N TCP to a relay (relay1 or relay2), magic=42, custom byron/shelley genesis windows. Backing store: embedded (H2) — pure coverage, no app reads. Image: pinned digest from bloxbean/yaci-store-spring-boot, re-published via the repo's publish-images workflow. Scope is additive: independent of PR #70's indexer-read-side. Refs #75."
+**Issue**: [#75](https://github.com/cardano-foundation/cardano-node-antithesis/issues/75)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - yaci-store joins the testnet and tracks the chain (Priority: P1)
+
+As a test engineer running the Antithesis testnet, I want yaci-store to come up alongside the existing services, connect to a relay over node-to-node, and follow the chain to the current tip — so that the testnet exercises a real-world N2N consumer profile alongside Oura.
+
+**Why this priority**: Without P1, the feature delivers no coverage. yaci-store is the most-used Java/Spring-Boot indexer in the Cardano ecosystem; running it under fault injection is the entire point of the ticket.
+
+**Independent Test**: `just up cardano_node_master`, wait for nodes to produce blocks (existing smoke test), then verify that yaci-store reports a tip block with slot equal to or greater than the current relay tip within an agreed time budget. No coupling to other services beyond the relay it consumes from.
+
+**Acceptance Scenarios**:
+
+1. **Given** the testnet is brought up cold, **When** all configured nodes have produced at least one block and yaci-store has been running for the configured warm-up window, **Then** yaci-store's reported tip slot equals or exceeds the relay's reported tip slot.
+2. **Given** the testnet is running steady-state, **When** the relay yaci-store connects to is restarted, **Then** yaci-store reconnects and resumes following the chain without operator intervention.
+3. **Given** a fresh testnet, **When** yaci-store starts before the network has produced any blocks, **Then** it waits and starts indexing once block production begins (no crash on empty chain).
+
+---
+
+### User Story 2 - yaci-store survives Antithesis fault injection without corrupting the test verdict (Priority: P1)
+
+As an Antithesis test author, I want yaci-store to either keep running through fault injection or fail in a way that does not produce false-positive findings on the testnet.
+
+**Why this priority**: Antithesis findings are the product the testnet exists to deliver. A new container that crashes spuriously under SIGTERM/SIGKILL/network partition would make every run noisy and is worse than not having the container at all. yaci-store **may** crash under fault injection — what matters is that the harness is configured to absorb the noise correctly.
+
+**Independent Test**: Run a 1-hour Antithesis duration on this branch. Compare findings against the previous baseline (current `main`): any new finding must be attributable to yaci-store by name, and the count of new findings must be zero, or each new finding must be triaged and either filed as a separate issue or whitelisted in the harness with a reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** a 1-hour Antithesis run on this branch, **When** the report is compared to the prior baseline, **Then** `findings_new ≤ baseline` (constitution hard gate).
+2. **Given** yaci-store receives SIGTERM during teardown, **When** the container exits, **Then** the exit code is recorded; if non-zero (cf. #49 for Ogmios/Kupo), the harness does not fail the run on that exit code alone.
+
+---
+
+### User Story 3 - yaci-store's published image is reproducible and reachable from Antithesis (Priority: P2)
+
+As a maintainer landing this on `main`, I want the yaci-store image referenced in `docker-compose.yaml` to be a content-addressed digest pointing at an image that the publish-images workflow has actually mirrored, so that scheduled Antithesis runs do not break with `manifest unknown`.
+
+**Why this priority**: Past breakage in this area is documented (memory: "No `:dev` in compose", commits 4ebc583 / b89004d / 8c54012 pinning every image to its content digest). This is a P2 because if P1/P2 above are met but the image cannot be pulled by Antithesis, the testnet is broken in production.
+
+**Independent Test**: Inspect the `publish-images.sh` log for the commit that lands this feature. The yaci-store entry must appear with a resolved digest, and the digest in `docker-compose.yaml` must match. A `docker pull` of the digest from a fresh machine must succeed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the compose file is on `main`, **When** the publish-images workflow runs, **Then** the yaci-store image is mirrored under the project's GHCR namespace and the compose digest resolves to a real manifest.
+2. **Given** the upstream image is on Docker Hub, **When** the compose references it, **Then** the reference uses the `docker.io/` prefix Antithesis requires.
+
+### Edge Cases
+
+- yaci-store starts before any block is produced (cold boot of a private testnet).
+- The relay yaci-store consumes from is restarted, killed, or partitioned.
+- yaci-store's embedded store hits its disk quota on a long Antithesis run.
+- yaci-store receives SIGTERM during compose teardown — JVM shutdown semantics under the harness.
+- The custom magic / genesis windows do not match what yaci-store expects (mainnet-only assumptions in the upstream image).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The testnet MUST include a yaci-store service in `testnets/cardano_node_master/docker-compose.yaml` that comes up with `just up` and is torn down with `just down`.
+- **FR-002**: yaci-store MUST consume the chain from a relay over node-to-node (TCP, port 3001 of either `relay1.example` or `relay2.example`).
+- **FR-003**: yaci-store MUST be configured for the testnet's protocol parameters (magic 42 and the byron/shelley genesis windows produced by the configurator).
+- **FR-004**: yaci-store MUST use an embedded backing store (no separate database container introduced by this feature).
+- **FR-005**: The yaci-store image reference in `docker-compose.yaml` MUST be a content-addressed digest, never `:latest` or `:dev`, and MUST be mirrored by the project's publish-images workflow so it is pullable from Antithesis runners.
+- **FR-006**: All bind mounts for yaci-store MUST live next to `docker-compose.yaml` (Antithesis cannot resolve relative paths outside the compose directory).
+- **FR-007**: yaci-store MUST NOT block compose start-up of any existing service; its `depends_on` MUST be limited to what it actually needs (configurator and the chosen relay).
+- **FR-008**: A 1-hour Antithesis duration on the feature branch MUST report `findings_new ≤ baseline` against the prior `main` baseline; any new finding MUST be triaged before merge.
+- **FR-009**: The shutdown exit code of yaci-store under the harness MUST be observed and documented; if non-zero on SIGTERM (analogous to #49), the harness MUST be configured to absorb that exit code or yaci-store MUST be reconfigured to exit cleanly.
+- **FR-010**: This feature MUST NOT modify the read path of `tx-generator` or `asteria-player`; yaci-store is additive coverage only and is independent of #70.
+
+### Key Entities
+
+- **yaci-store service**: A new long-running container. Inputs: TCP connection to a relay, custom protocol magic, byron/shelley genesis windows. Output: an embedded indexed view of the chain (used for nothing in this feature — pure coverage).
+- **yaci-store image digest**: A content-addressed image reference recorded in the compose file and mirrored by the publish-images workflow.
+- **yaci-store config artifact**: A configuration file (or environment overrides) bind-mounted into the container, capturing magic + genesis windows. Lives next to `docker-compose.yaml`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After `just up cardano_node_master`, yaci-store reaches a tip slot equal to or greater than the relay's tip slot within 5 minutes of the network producing its first block, on a developer laptop.
+- **SC-002**: A 1-hour Antithesis run on `004-yaci-store` produces no new findings versus the prior `main` baseline; if any new findings appear, each is triaged and either filed or whitelisted with a documented reason.
+- **SC-003**: Cold `docker compose up -d` succeeds and the yaci-store service is `healthy` (or `running` if no healthcheck) within 1 minute on a devnet machine.
+- **SC-004**: After `just down`, no yaci-store volumes, networks, or processes are left behind (clean teardown).
+- **SC-005**: The yaci-store image digest in `main` is resolvable by `docker pull` from a machine that has never seen the upstream Docker Hub image — i.e., publish-images has mirrored it.
+
+## Assumptions
+
+- yaci-store's upstream image (`bloxbean/yaci-store-spring-boot` or equivalent) supports private testnets with custom protocol magic and custom byron/shelley genesis windows. If it does not, this feature is reduced to a no-op or requires upstream changes — surface in `/speckit.plan`.
+- The configurator already emits genesis files into `p?-configs:/configs/configs/`; yaci-store will reuse those, mounted read-only.
+- "Pure coverage" means downstream services do not query yaci-store — the feature ships without API consumers and without surface area to break.
+- The publish-images workflow can mirror Docker Hub images to the project's GHCR namespace today; if not, the publish-images change is captured as a separate dependency.
+- Antithesis findings whitelisting is in scope of the harness, not this feature; if a yaci-store-specific exit code requires a harness change, that change ships in the same PR.

--- a/specs/004-yaci-store/tasks.md
+++ b/specs/004-yaci-store/tasks.md
@@ -1,0 +1,175 @@
+---
+
+description: "Task list for 004-yaci-store"
+---
+
+# Tasks: yaci-store as Antithesis N2N consumer
+
+**Input**: Design documents from `/specs/004-yaci-store/`
+**Prerequisites**: [plan.md](./plan.md) (required), [spec.md](./spec.md) (required for user stories), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/compose-topology.md](./contracts/compose-topology.md), [quickstart.md](./quickstart.md)
+
+**Tests**: This feature ships no Haskell/Java unit tests — its tests are operational (`just smoke-test`, the SC-001..SC-005 commands in `quickstart.md`, and the constitution's 1h Antithesis hard gate). Tasks below schedule those operational checks at the points where they are meaningful.
+
+**Organization**: Tasks are grouped by user story to enable independent verification. The MVP is User Story 1 (yaci-store joins the testnet and tracks the chain).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- All file paths are absolute under `/code/cardano-node-antithesis-issue-75/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Pre-implementation discovery — confirm the assumptions the contract builds on.
+
+- [ ] T001 Pull the upstream image and capture its `sha256` digest, recording it in a scratch note for use in T010: `docker pull docker.io/bloxbean/yaci-store:2.0.0 && docker inspect --format='{{index .RepoDigests 0}}' docker.io/bloxbean/yaci-store:2.0.0`. Reference: [research.md R-001](./research.md), [contracts/compose-topology.md "Image digest pin"](./contracts/compose-topology.md).
+- [ ] T002 Confirm the genesis filenames the configurator emits into `p1-configs:/configs/configs/`: bring the configurator service up alone via `docker compose -f testnets/cardano_node_master/docker-compose.yaml up -d configurator`, then `docker run --rm -v cardano-node-master_p1-configs:/configs:ro alpine ls /configs/configs/`. If filenames differ from the contract's placeholders (`byron-genesis.json` etc.), record the real names. Reference: [contracts/compose-topology.md "Genesis filename confirmation"](./contracts/compose-topology.md).
+- [ ] T003 [P] Confirm whether the upstream image ships `curl` or `wget` for the healthcheck: `docker run --rm --entrypoint=sh docker.io/bloxbean/yaci-store:2.0.0 -c 'which curl wget'`. Pick whichever is present for T011. Reference: [data-model.md "Healthcheck entity"](./data-model.md).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None for this feature. There are no shared prerequisites between user stories — every story is verified against the same single compose stanza, and the stanza itself is implemented once in Phase 3.
+
+**Checkpoint**: Setup tasks T001..T003 complete; assumptions verified. Implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — yaci-store joins the testnet and tracks the chain (Priority: P1) 🎯 MVP
+
+**Goal**: Add the yaci-store service to the testnet so it comes up cold, follows the chain over N2N from a relay, and survives a relay restart.
+
+**Independent Test**: After `just up cardano_node_master`, yaci-store reaches a tip slot equal to or greater than the relay's tip slot within 5 minutes of the network producing its first block, and continues to follow after a `docker compose restart relay1` (per `quickstart.md` step 2 + step 4).
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Append the `yaci-store` service stanza to `/code/cardano-node-antithesis-issue-75/testnets/cardano_node_master/docker-compose.yaml`, immediately after the `oura` service. Use the exact YAML in [contracts/compose-topology.md](./contracts/compose-topology.md), substituting the `sha256` digest from T001 and the genesis filenames from T002. Do **not** add any new named volume — reuse `p1-configs`.
+- [ ] T011 [US1] In the same stanza, set the healthcheck command to whichever of `curl` / `wget` was confirmed by T003. Default in the contract is `wget`; switch to `curl` only if T003 found `curl` and not `wget`.
+- [ ] T012 [US1] Run the local smoke recipe: `just down cardano_node_master && just up cardano_node_master`. Observe that all existing services still start (no regression), then check that yaci-store reaches `healthy` within 1 minute (`docker compose -f testnets/cardano_node_master/docker-compose.yaml ps yaci-store`). Reference: [quickstart.md step 1](./quickstart.md), SC-003.
+- [ ] T013 [US1] Verify SC-001 (yaci-store reaches relay tip within 5 minutes) per [quickstart.md step 2](./quickstart.md). Capture the relay tip slot, then capture yaci-store's reported tip from `just logs yaci-store`. Record the actual time-to-tip in the PR description.
+- [ ] T014 [US1] Verify the relay-restart acceptance scenario (User Story 1 #2) per [quickstart.md step 4](./quickstart.md): `docker compose ... restart relay1`, then confirm yaci-store reconnects without exiting.
+- [ ] T015 [US1] Verify SC-004 (clean teardown): `just down cardano_node_master`; confirm no yaci-store volumes or containers remain. Reference: [quickstart.md step 5](./quickstart.md).
+
+**Checkpoint**: User Story 1 is functional and testable independently. The compose stanza is in place, the testnet still comes up, and yaci-store is following the chain. From this checkpoint the feature already delivers value (an additional N2N consumer is exercised by every local `just up`); the remaining stories raise it to merge-ready.
+
+---
+
+## Phase 4: User Story 2 — yaci-store survives Antithesis fault injection without corrupting the verdict (Priority: P1)
+
+**Goal**: Confirm that yaci-store under fault injection produces no new findings versus the prior `main` baseline, and document its SIGTERM behaviour.
+
+**Independent Test**: A 1-hour Antithesis duration on `004-yaci-store` produces `findings_new ≤ baseline` (constitution hard gate). yaci-store's exit code on SIGTERM is recorded.
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Capture the current `main` 1h Antithesis baseline finding count: locate the most recent green `cardano-node.yaml` 1h run on `main` via `gh run list -R cardano-foundation/cardano-node-antithesis -w cardano-node.yaml --branch main --limit 5`, open the report, record the finding count (and any stable finding IDs we already accept). Note: this is read-only against `main`.
+- [ ] T021 [US2] Verify SIGTERM behaviour locally per [quickstart.md step 6](./quickstart.md): `docker stop yaci-store` and capture the exit code. Expected `0`. If non-zero, do **not** proceed to T022 — instead, file a follow-up issue and either (a) configure `stop_signal: SIGINT` / `stop_grace_period: 30s` in the compose stanza or (b) coordinate a harness whitelist. Reference: FR-009, [research.md R-006](./research.md).
+- [ ] T022 [US2] After T010..T015 land on the branch and `publish-images` is green, dispatch a 1h Antithesis run: `gh workflow run cardano-node.yaml --ref 004-yaci-store --field duration=1h`. Record the run URL.
+- [ ] T023 [US2] When the 1h run completes, compare its findings against the baseline from T020 using the `antithesis-triage` skill. For every new finding: (a) attribute it to a container by name; (b) if attributable to yaci-store, file a follow-up issue and either fix or whitelist with a documented reason. PR cannot merge until `findings_new ≤ baseline`.
+- [ ] T024 [US2] Update the PR description with: the baseline finding count, the run URL from T022, the actual finding count, the diff, and any follow-up issue numbers.
+
+**Checkpoint**: User Story 2 satisfied. The constitution's hard gate is met or the follow-ups are filed. Merge is unblocked from the testing axis.
+
+---
+
+## Phase 5: User Story 3 — yaci-store's image is reproducible and reachable from Antithesis (Priority: P2)
+
+**Goal**: Confirm that the digest pinned in compose is mechanically resolvable from a fresh machine, so scheduled Antithesis runs do not break with `manifest unknown`.
+
+**Independent Test**: A `docker pull` of the digest from a machine that has never seen the upstream image succeeds.
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] On a host that has not yet pulled `docker.io/bloxbean/yaci-store`, run `docker pull docker.io/bloxbean/yaci-store@sha256:<DIGEST>` where `<DIGEST>` is the value committed in T010. Confirm success. (Locally: `docker rmi docker.io/bloxbean/yaci-store:2.0.0` to force a re-pull from a fresh state.)
+- [ ] T031 [US3] After pushing the branch (Phase 6), verify the `publish-images` workflow run on the PR is green. The workflow does **not** rebuild yaci-store (it is upstream); confirm it does not error on the new compose entry. Reference: [research.md R-002](./research.md).
+
+**Checkpoint**: User Story 3 satisfied. The image reference is durable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Things that affect the PR as a whole.
+
+- [ ] T040 [P] Update `/code/cardano-node-antithesis-issue-75/testnets/cardano_node_master/README.md` (if present) to mention yaci-store as the second N2N consumer. If the README does not exist, skip this task.
+- [ ] T041 [P] Run `just smoke-test cardano_node_master` end-to-end on the branch one final time before pushing. This is the same smoke test CI runs.
+- [ ] T042 Push the branch: `git push -u origin 004-yaci-store`. Reference: workflow rule "Always push for review".
+- [ ] T043 Open the PR with `gh pr create`, body sourced from this directory's specs (link to spec.md, plan.md, contracts, quickstart). Title: `feat(testnet): add yaci-store N2N consumer`. Labels: `enhancement`. Assignee: `paolino`. Refs #75.
+- [ ] T044 Add the PR to the planner board (Antithesis category, Work ownership) per the workflow rule. Use `gh api graphql` per the workflow skill's instructions.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- Phase 1 (Setup) → Phase 3 (US1).
+- Phase 3 (US1) → Phase 4 (US2). Phase 4 needs the compose change to be on the branch and `publish-images` green before dispatching the 1h Antithesis run.
+- Phase 3 (US1) → Phase 5 (US3). Phase 5 needs the digest committed.
+- Phase 4 + Phase 5 → Phase 6 polish. Specifically, T043 (open PR) lands after the 1h run is at least dispatched (the PR description references it); T024 updates the PR after the run completes.
+
+### User story dependencies
+
+- US1 has no dependency on other stories.
+- US2 depends on US1's compose change being on the branch.
+- US3 depends on US1's digest being committed.
+- US2 and US3 can run in parallel after US1 lands.
+
+### Within each user story
+
+- Implementation tasks are sequential within US1 because they modify the same file (`docker-compose.yaml`).
+- US2 tasks T020 (baseline read) and T021 (local SIGTERM check) can run in parallel; T022/T023/T024 are sequential.
+- US3 tasks T030 and T031 can run in parallel.
+
+### Parallel opportunities
+
+- T003 runs in parallel with T001 + T002 (different containers, different commands).
+- T020 ‖ T021 (US2).
+- T030 ‖ T031 (US3).
+- T040 ‖ T041 (Phase 6 polish).
+
+---
+
+## Parallel example: User Story 2
+
+```bash
+# T020 (baseline) and T021 (SIGTERM check) are independent:
+gh run list -R cardano-foundation/cardano-node-antithesis -w cardano-node.yaml --branch main --limit 5 &
+( just up cardano_node_master && sleep 60 && docker stop yaci-store && \
+  docker inspect yaci-store --format '{{.State.ExitCode}}' )
+wait
+```
+
+---
+
+## Implementation strategy
+
+### MVP first (User Story 1 only)
+
+1. Phase 1: Setup (T001..T003) — verify assumptions.
+2. Phase 3: US1 (T010..T015) — land the compose change and verify it works locally.
+3. STOP and VALIDATE: at this point the feature is merge-ready *operationally* but not yet *Antithesis-verified*. Do **not** push for merge yet.
+
+### Verification (US2 + US3 in parallel)
+
+4. Phase 4 (US2) and Phase 5 (US3) can run in parallel by different operators or sequentially.
+5. T020 reads baseline, T022 dispatches the 1h run, T023 + T024 close the loop.
+6. T030/T031 confirm the image pin is durable.
+
+### Polish and PR
+
+7. Phase 6 (T040..T044) — final smoke test, push, PR, planner.
+8. Merge gate: constitution's verify-before-merge sequence (publish-images green → 1h Antithesis findings ≤ baseline → `mcp__merge-guard__guard-merge` with `mergeMethod: rebase`).
+
+---
+
+## Notes
+
+- [P] = different files / different commands, no dependencies.
+- The single source code touch in this entire feature is `testnets/cardano_node_master/docker-compose.yaml`. Everything else is documentation, verification, and process.
+- Every task references the document or section that owns its details, per the [Tasks reference contracts](memory) workflow rule.
+- Do **not** modify `tx-generator`, `asteria-player`, or any composer command — yaci-store is additive coverage (FR-010).
+- Do **not** add a new component under `components/` — yaci-store is an upstream image (FR-005, R-001).

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -125,6 +125,34 @@ services:
       relay1:
         condition: service_started
 
+  yaci-store:
+    image: docker.io/bloxbean/yaci-store@sha256:aa67ee3c222eb2e6371b34dcda198ae9f2c32c90fcaf5ebdd1d8353e3205da87
+    container_name: yaci-store
+    hostname: yaci-store.example
+    environment:
+      STORE_CARDANO_HOST: relay1.example
+      STORE_CARDANO_PORT: 3001
+      STORE_CARDANO_PROTOCOL_MAGIC: 42
+      STORE_CARDANO_BYRON_GENESIS_FILE: /configs/configs/byron-genesis.json
+      STORE_CARDANO_SHELLEY_GENESIS_FILE: /configs/configs/shelley-genesis.json
+      STORE_CARDANO_ALONZO_GENESIS_FILE: /configs/configs/alonzo-genesis.json
+      STORE_CARDANO_CONWAY_GENESIS_FILE: /configs/configs/conway-genesis.json
+      SPRING_DATASOURCE_URL: jdbc:h2:mem:mydb
+    volumes:
+      - p1-configs:/configs:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:8080/actuator/health || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+    restart: always
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+      relay1:
+        condition: service_started
+
   tx-generator:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator@sha256:ce79d589b97e47a44d8c60f78027a1400345c89994763cec926bd6eaf02c62fa
     container_name: tx-generator


### PR DESCRIPTION
## Summary

Adds [`bloxbean/yaci-store`](https://hub.docker.com/r/bloxbean/yaci-store) as a long-running N2N consumer in `testnets/cardano_node_master/docker-compose.yaml`, alongside the existing `oura` service. Pure protocol coverage — yaci-store is a widely-used Spring-Boot indexer in the Cardano ecosystem; running it under fault injection exercises a real consumer profile.

Refs [#75](https://github.com/cardano-foundation/cardano-node-antithesis/issues/75). Independent of [#70](https://github.com/cardano-foundation/cardano-node-antithesis/pull/70) (different role — additive coverage, not the tx-generator read path).

## ⚠️ Merge-blocked: 1 new finding on the 1h Antithesis run

**Constitution hard gate (`findings_new ≤ baseline`) is NOT met.** Antithesis run [25039550313](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25039550313) on commit `35bec7f` reports:

| Findings | Count |
|----------|------:|
| **new** | **1** |
| ongoing | 0 |
| resolved | 0 |
| rare | 0 |

Triage report: [link (auth-scoped)](https://cardano.antithesis.com/report/EcRRbPcTI3ggQzFGa4Sb5_hr/pcHC8NymWnFxmP9WzuBcT2HkvlRpLIPgKITu11BCOe0.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA0LTI4VDA3OjQwOjE0LjI3MjYzNzI5MVoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoicGNIQzhOeW1XbkZ4bVA5V3p1QmNUMkhrdmxScExJUGdLSVR1MTFCQ09lMC5odG1sIiwicmVwb3J0X2lkIjoiRWNSUmJQY1RJM2dnUXpGR2E0U2I1X2hyIn19fSfGteN-arPxTBjcrjcyDj2O1Dy99Z0I6xRK7u5QbOPthNMnc4wXFbIeWJGE7zdhsbl6vrWzaDT4h6XzMPvTGwc).

Compared to the most recent green main 1h baseline ([06c0a64f, yest 11:12](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/24988994718)) which had 0 new findings, this branch adds **1 new finding directly attributable to yaci-store**.

### The finding

**Property**: `Correctness › No unexpected container exits › container: yaci-store, exit code: 1`
- failingCount: 18, passingCount: 0 (yaci-store dies in every timeline; `restart: always` causes a crash-loop)
- 32 other properties pass.

### Root cause (from log [example index 0](https://cardano.antithesis.com/search?...))

```
2026-04-28T07:33:24.665Z ERROR 1 --- [Yaci Store App] [main] o.s.boot.SpringApplication : Application run failed

java.lang.IllegalStateException: Genesis points not found. From point could not be decided.
    at com.bloxbean.cardano.yaci.store.core.service.StartService.start(StartService.java:103)
```

**What happens:**
1. vtime 16.7s — yaci-store JVM starts, begins Spring init.
2. vtime 17.8s — fault injector applies a `network/clog` (`Jammed`) on links between `relay1.example` and `yaci-store.example`, `max_duration=2.75s`.
3. vtime 19.1s — fault injector restores network.
4. vtime 37.7s — yaci-store's `StartService.start` throws because the chain-handshake with the relay (interrupted by the earlier clog) failed to populate the chain "from point". Container exits 1.
5. Restart loop repeats; in faults_enabled timelines, the same race recurs.

**This is a fault-injection-sensitive startup race in yaci-store, not a SIGTERM/teardown issue.** It is also unrelated to the [SIGTERM-143 finding from local T021](#) — that was about teardown. This is about cold-start with adversarial network conditions.

**Why it didn't show up locally**: my T012/T013 verification used `just up` (no fault injection). yaci-store reaches the relay tip in ~30s when the network is clean. With a 2.75s clog at vtime 17.8s, the handshake never completes and the JVM exits.

### Possible fixes (need decision before merge)

1. **Set explicit start-point env vars** so yaci-store does not depend on the live relay handshake to find genesis points. Likely candidates: `STORE_CARDANO_SYNC_START_SLOT=0` plus `STORE_CARDANO_SYNC_START_BLOCKHASH=<computed_byron_genesis_hash>`. Lowest-risk, closest to "fix-in-this-PR".
2. **Drop `restart: always`** so a single crash kills yaci-store cleanly; combined with #1 if the first attempt still races. Removes the crash-loop noise but leaves the underlying brittleness.
3. **Whitelist the property in the harness** for yaci-store on startup. Wrong choice — masks a real signal that yaci-store will misbehave at any point a relay flickers, not just at boot.
4. **Revert the compose change** and file a follow-up issue with these findings; land later when #1 is verified.

## Design docs

Full speckit feature folder: [`specs/004-yaci-store/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/004-yaci-store/specs/004-yaci-store).
- [`spec.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/spec.md) — 3 user stories (2×P1 + 1×P2), 10 FRs, 5 SCs.
- [`plan.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/plan.md) — Constitution check with one documented Principle I deviation.
- [`research.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/research.md) — R-001..R-008.
- [`contracts/compose-topology.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/contracts/compose-topology.md) — exact YAML stanza.
- [`quickstart.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/quickstart.md) — bring-up + every SC/FR verification command.
- [`tasks.md`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/004-yaci-store/specs/004-yaci-store/tasks.md) — T001..T044.

## What changed

Single source code touch: `testnets/cardano_node_master/docker-compose.yaml` gains one service stanza:

- Image: `docker.io/bloxbean/yaci-store@sha256:aa67ee3c222eb2e6371b34dcda198ae9f2c32c90fcaf5ebdd1d8353e3205da87` (upstream `2.0.0`, latest stable).
- N2N target: `relay1.example:3001`, magic 42.
- Genesis files: read-only mount of the existing `p1-configs` named volume.
- Storage: `SPRING_DATASOURCE_URL=jdbc:h2:mem:mydb`.
- Healthcheck: `wget` on `/actuator/health`.
- `depends_on`: `configurator` (must complete) and `relay1` (must be started).

No new component under `components/`. No `publish-images` change.

## Local verification (T010..T015, T021)

| Check | Spec ref | Result |
|-------|----------|--------|
| Compose validates | T010 | ✅ |
| yaci-store healthy within 60s of cold `up` | SC-003, T012 | ✅ 25s |
| yaci-store cursor matches relay tip within 5 min | SC-001, T013 | ✅ ~30s, slot=28 hash match |
| Survives `docker compose restart relay1` | US1 #2, T014 | ✅ no container restart, clean reconnect |
| Clean teardown | SC-004, T015 | ✅ |
| `just smoke-test` end-to-end | T041 | ✅ |
| SIGTERM exit code | FR-009, T021 | ⚠️ 143 (JVM signal-exit, separate issue from the Antithesis finding) |
| Cold `docker pull` of digest | SC-005, T030 | ✅ |
| `publish-images` PR check green | T031 | ✅ all 8 checks |
| **1h Antithesis findings ≤ baseline** | **constitution hard gate** | ❌ **+1 finding (genesis-points race), see above** |

## Findings (cumulative)

1. **Antithesis [merge-blocking]** — `No unexpected container exits` fails 18×: yaci-store's startup chain-handshake is not tolerant of brief network faults on the relay link. Triage details above.
2. **Local [non-blocking]** — SIGTERM exit code is 143, not 0. Standard JVM signal-exit pattern. Documented in `research.md` R-006. Same family as [#49](https://github.com/cardano-foundation/cardano-node-antithesis/issues/49).

## Constitution compliance

- **I. Composer-first workload**: documented deviation (passive consumer, same precedent as oura).
- **VII. Image tag hygiene**: upstream image, digest-pinned, exempt.
- **Hard gate (`findings_new ≤ baseline`)**: ❌ NOT met (1 > 0). Merge-blocked until resolved.