### PR TITLE
Improve convergence command diagnostics

### DIFF
--- a/components/sidecar/composer/convergence/eventually_converged.sh
+++ b/components/sidecar/composer/convergence/eventually_converged.sh
@@ -17,6 +17,8 @@ set -u
 
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk_lib.sh"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/helper_tip_probe_lib.sh"
 
 POOLS="${POOLS:-3}"
 PORT="${PORT:-3001}"
@@ -30,50 +32,19 @@ sdk_reachable "eventually_converged entered"
 # Antithesis recovery allowance quoted in their etcd example.
 sleep "$SLEEP_SETTLE"
 
-NODES=()
-for i in $(seq 1 "$POOLS"); do
-    NODES+=("p${i}")
-done
-
-query_tip_json() {
-    # $1 = host prefix (e.g. p1)
-    cardano-cli ping -j \
-        --magic 42 --host "${1}.example" --port "$PORT" \
-        --tip --quiet -c1 2>/dev/null
-}
-
-# Populates TIP_DETAILS (jq array), TIP_DISTINCT (count of unique
-# non-null hashes), TIP_COUNT (number of successful responses).
-collect_tips() {
-    local temp_dir node
-    temp_dir="$(mktemp -d)"
-    for node in "${NODES[@]}"; do
-        (query_tip_json "$node" > "$temp_dir/$node") &
-    done
-    wait
-    # Combine into an array of {node, hash, block, slot} entries, dropping
-    # nodes that failed to respond (they have empty / invalid JSON files).
-    TIP_DETAILS="$(for node in "${NODES[@]}"; do
-        jq -c --arg node "$node" \
-            'if .tip[0] then
-                {node:$node, hash:.tip[0].hash, block:.tip[0].blockNo, slot:.tip[0].slotNo}
-             else empty end' \
-            "$temp_dir/$node" 2>/dev/null
-    done | jq -sc '.')"
-    rm -rf "$temp_dir"
-    TIP_COUNT="$(printf '%s' "$TIP_DETAILS" | jq 'length')"
-    TIP_DISTINCT="$(printf '%s' "$TIP_DETAILS" | jq '[.[].hash] | unique | length')"
-}
-
 TIP_DETAILS="[]"
+TIP_SUCCESSES="[]"
+TIP_FAILURES="[]"
 TIP_COUNT=0
 TIP_DISTINCT=0
+TIP_FAILURE_REASONS="[]"
+TIP_FAILURE_KIND="not_checked"
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    collect_tips
+    probe_all_tips
     if [ "$TIP_COUNT" = "$POOLS" ] && [ "$TIP_DISTINCT" = "1" ]; then
-        echo "converged on attempt $attempt: $TIP_DETAILS"
+        echo "converged on attempt $attempt: $TIP_SUCCESSES"
         sdk_sometimes true "eventually_converged succeeded" \
-            "$(jq -nc --argjson tips "$TIP_DETAILS" --argjson attempt "$attempt" \
+            "$(jq -nc --argjson tips "$TIP_SUCCESSES" --argjson attempt "$attempt" \
                 '{attempt:$attempt, tips:$tips}')"
         exit 0
     fi
@@ -81,11 +52,13 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
 done
 
 # Did not converge within the retry budget. Real recovery failure.
-echo "did not converge after $MAX_ATTEMPTS attempts: count=$TIP_COUNT distinct=$TIP_DISTINCT"
-sdk_unreachable "eventually_converged failed to converge" \
-    "$(jq -nc --argjson attempts "$MAX_ATTEMPTS" \
+echo "did not converge after $MAX_ATTEMPTS attempts: kind=$TIP_FAILURE_KIND reasons=$TIP_FAILURE_REASONS count=$TIP_COUNT distinct=$TIP_DISTINCT details=$TIP_DETAILS"
+sdk_unreachable "eventually_converged failed: $TIP_FAILURE_KIND" \
+    "$(jq -nc --arg kind "$TIP_FAILURE_KIND" \
+              --argjson attempts "$MAX_ATTEMPTS" \
               --argjson count "$TIP_COUNT" \
               --argjson distinct "$TIP_DISTINCT" \
+              --argjson reasons "$TIP_FAILURE_REASONS" \
               --argjson tips "$TIP_DETAILS" \
-        '{attempts:$attempts, responses:$count, distinct_tips:$distinct, tips:$tips}')"
+        '{failure_kind:$kind, failure_reasons:$reasons, attempts:$attempts, responses:$count, distinct_tips:$distinct, tips:$tips}')"
 exit 1

--- a/components/sidecar/composer/convergence/finally_tips_agree.sh
+++ b/components/sidecar/composer/convergence/finally_tips_agree.sh
@@ -10,6 +10,8 @@ set -u
 
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk_lib.sh"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/helper_tip_probe_lib.sh"
 
 POOLS="${POOLS:-3}"
 PORT="${PORT:-3001}"
@@ -21,54 +23,44 @@ sdk_reachable "finally_tips_agree entered"
 
 sleep "$SLEEP_SETTLE"
 
-NODES=()
-for i in $(seq 1 "$POOLS"); do
-    NODES+=("p${i}")
-done
-
-query_tip_json() {
-    cardano-cli ping -j \
-        --magic 42 --host "${1}.example" --port "$PORT" \
-        --tip --quiet -c1 2>/dev/null
-}
-
-collect_tips() {
-    local temp_dir node
-    temp_dir="$(mktemp -d)"
-    for node in "${NODES[@]}"; do
-        (query_tip_json "$node" > "$temp_dir/$node") &
-    done
-    wait
-    TIP_DETAILS="$(for node in "${NODES[@]}"; do
-        jq -c --arg node "$node" \
-            'if .tip[0] then
-                {node:$node, hash:.tip[0].hash, block:.tip[0].blockNo, slot:.tip[0].slotNo}
-             else empty end' \
-            "$temp_dir/$node" 2>/dev/null
-    done | jq -sc '.')"
-    rm -rf "$temp_dir"
-    TIP_COUNT="$(printf '%s' "$TIP_DETAILS" | jq 'length')"
-    TIP_DISTINCT="$(printf '%s' "$TIP_DETAILS" | jq '[.[].hash] | unique | length')"
-}
-
 TIP_DETAILS="[]"
+TIP_SUCCESSES="[]"
+TIP_FAILURES="[]"
 TIP_COUNT=0
 TIP_DISTINCT=0
+TIP_FAILURE_REASONS="[]"
+TIP_FAILURE_KIND="not_checked"
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    collect_tips
+    probe_all_tips
     if [ "$TIP_COUNT" = "$POOLS" ] && [ "$TIP_DISTINCT" = "1" ]; then
-        echo "tips agree: $TIP_DETAILS"
+        echo "tips agree: $TIP_SUCCESSES"
+        sdk_always true "all producer tips reachable at final check" \
+            "$(jq -nc --argjson tips "$TIP_SUCCESSES" '{tips:$tips}')"
         sdk_always true "finally_tips_agree holds" \
-            "$(jq -nc --argjson tips "$TIP_DETAILS" '{tips:$tips}')"
+            "$(jq -nc --argjson tips "$TIP_SUCCESSES" '{tips:$tips}')"
         exit 0
     fi
     sleep "$RETRY_DELAY"
 done
 
-echo "divergent/incomplete at end-of-workload: count=$TIP_COUNT distinct=$TIP_DISTINCT"
-sdk_always false "finally_tips_agree holds" \
-    "$(jq -nc --argjson tips "$TIP_DETAILS" \
-              --argjson count "$TIP_COUNT" \
-              --argjson distinct "$TIP_DISTINCT" \
-        '{responses:$count, distinct_tips:$distinct, tips:$tips}')"
+echo "divergent/incomplete at end-of-workload: kind=$TIP_FAILURE_KIND reasons=$TIP_FAILURE_REASONS count=$TIP_COUNT distinct=$TIP_DISTINCT details=$TIP_DETAILS"
+if [ "$TIP_COUNT" != "$POOLS" ]; then
+    sdk_always false "all producer tips reachable at final check" \
+        "$(jq -nc --arg kind "$TIP_FAILURE_KIND" \
+                  --argjson tips "$TIP_DETAILS" \
+                  --argjson count "$TIP_COUNT" \
+                  --argjson distinct "$TIP_DISTINCT" \
+                  --argjson reasons "$TIP_FAILURE_REASONS" \
+            '{failure_kind:$kind, failure_reasons:$reasons, responses:$count, distinct_tips:$distinct, tips:$tips}')"
+else
+    sdk_always true "all producer tips reachable at final check" \
+        "$(jq -nc --argjson tips "$TIP_SUCCESSES" '{tips:$tips}')"
+    sdk_always false "finally_tips_agree holds" \
+        "$(jq -nc --arg kind "$TIP_FAILURE_KIND" \
+                  --argjson tips "$TIP_SUCCESSES" \
+                  --argjson count "$TIP_COUNT" \
+                  --argjson distinct "$TIP_DISTINCT" \
+                  --argjson reasons "$TIP_FAILURE_REASONS" \
+            '{failure_kind:$kind, failure_reasons:$reasons, responses:$count, distinct_tips:$distinct, tips:$tips}')"
+fi
 exit 1

--- a/components/sidecar/composer/convergence/helper_tip_probe_lib.sh
+++ b/components/sidecar/composer/convergence/helper_tip_probe_lib.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Shared producer-tip probing for convergence composer commands.
+#
+# The helper_ prefix is intentional: Antithesis Composer ignores support
+# files with this prefix when validating command names.
+#
+# Populates:
+#   TIP_DETAILS   all probe results, one object per producer
+#   TIP_SUCCESSES successful producer tip results
+#   TIP_FAILURES  failed producer probe results
+#   TIP_COUNT     number of successful producer tip responses
+#   TIP_DISTINCT  number of distinct hashes among successful responses
+#   TIP_FAILURE_REASONS unique failure reasons for failed producer probes
+#   TIP_FAILURE_KIND classification for the latest result set
+
+POOLS="${POOLS:-3}"
+PORT="${PORT:-3001}"
+TIP_DETAIL_LIMIT="${TIP_DETAIL_LIMIT:-600}"
+
+build_tip_nodes() {
+    TIP_NODES=()
+    for i in $(seq 1 "$POOLS"); do
+        TIP_NODES+=("p${i}")
+    done
+}
+
+probe_result_json() {
+    local node="$1"
+    local stdout_file="$2"
+    local stderr_file="$3"
+    local status_file="$4"
+    local exit_code
+
+    if [ -f "$status_file" ]; then
+        exit_code="$(cat "$status_file")"
+    else
+        exit_code="999"
+    fi
+
+    jq -n -c \
+        --arg node "$node" \
+        --arg exitCode "$exit_code" \
+        --argjson limit "$TIP_DETAIL_LIMIT" \
+        --rawfile stdout "$stdout_file" \
+        --rawfile stderr "$stderr_file" '
+        def clean($s): $s | gsub("[\r\n\t]+"; " ");
+        def bounded($s):
+            (clean($s)) as $cleaned
+            | if ($cleaned | length) > $limit then
+                ($cleaned[0:$limit] + "...<truncated>")
+              else
+                $cleaned
+              end;
+        def reason($code; $stderr; $stdout; $parsed):
+            (clean($stderr + " " + $stdout)) as $output
+            | if $code != 0 then
+                if $output | test("PingClientFindIntersectDeserialiseFailure") then
+                  "tip_protocol_deserialise_failure"
+                elif $output | test("getAddrInfo|Name or service not known|Temporary failure in name resolution") then
+                  "name_resolution_failed"
+                elif $output | test("Connection refused") then
+                  "connection_refused"
+                elif $output | test("No route to host") then
+                  "no_route_to_host"
+                elif $output | test("Connection timed out|timed out") then
+                  "connection_timed_out"
+                elif $output | test("HandshakeError|Handshake") then
+                  "protocol_handshake_failed"
+                else
+                  "ping_failed"
+                end
+              elif $parsed == null then "invalid_json"
+              else "missing_tip"
+              end;
+
+        ($exitCode | tonumber? // 999) as $code
+        | (try ($stdout | fromjson) catch null) as $parsed
+        | if $code == 0 and $parsed != null and ($parsed.tip[0]? != null) then
+            {
+              node: $node,
+              ok: true,
+              exit_code: $code,
+              hash: $parsed.tip[0].hash,
+              block: $parsed.tip[0].blockNo,
+              slot: $parsed.tip[0].slotNo
+            }
+          else
+            {
+              node: $node,
+              ok: false,
+              exit_code: $code,
+              reason: reason($code; $stderr; $stdout; $parsed),
+              stderr: bounded($stderr),
+              stdout: bounded($stdout)
+            }
+          end'
+}
+
+probe_all_tips() {
+    local temp_dir node
+    temp_dir="$(mktemp -d)"
+
+    build_tip_nodes
+
+    for node in "${TIP_NODES[@]}"; do
+        (
+            cardano-cli ping -j \
+                --magic 42 --host "${node}.example" --port "$PORT" \
+                --tip --quiet -c1 \
+                >"$temp_dir/${node}.stdout" \
+                2>"$temp_dir/${node}.stderr"
+            printf '%s' "$?" >"$temp_dir/${node}.status"
+        ) &
+    done
+    wait || true
+
+    TIP_DETAILS="$(
+        for node in "${TIP_NODES[@]}"; do
+            probe_result_json \
+                "$node" \
+                "$temp_dir/${node}.stdout" \
+                "$temp_dir/${node}.stderr" \
+                "$temp_dir/${node}.status"
+        done | jq -sc '.'
+    )"
+    rm -rf "$temp_dir"
+
+    TIP_SUCCESSES="$(printf '%s' "$TIP_DETAILS" | jq -c '[.[] | select(.ok == true)]')"
+    TIP_FAILURES="$(printf '%s' "$TIP_DETAILS" | jq -c '[.[] | select(.ok != true)]')"
+    TIP_COUNT="$(printf '%s' "$TIP_SUCCESSES" | jq 'length')"
+    TIP_DISTINCT="$(printf '%s' "$TIP_SUCCESSES" | jq '[.[].hash] | unique | length')"
+    TIP_FAILURE_REASONS="$(printf '%s' "$TIP_FAILURES" | jq -c '[.[].reason] | sort | unique')"
+
+    classify_tip_probe_result
+}
+
+all_failures_have_reason() {
+    local reason="$1"
+    [ "$(printf '%s' "$TIP_FAILURE_REASONS" | jq --arg reason "$reason" 'length == 1 and .[0] == $reason')" = "true" ]
+}
+
+classify_tip_probe_result() {
+    if [ "$TIP_COUNT" = "$POOLS" ] && [ "$TIP_DISTINCT" = "1" ]; then
+        TIP_FAILURE_KIND="tips_agree"
+    elif [ "$TIP_COUNT" = "0" ]; then
+        if all_failures_have_reason "tip_protocol_deserialise_failure"; then
+            TIP_FAILURE_KIND="no_tip_protocol_success"
+        elif all_failures_have_reason "name_resolution_failed"; then
+            TIP_FAILURE_KIND="no_producers_resolved"
+        elif all_failures_have_reason "connection_refused" ||
+             all_failures_have_reason "no_route_to_host" ||
+             all_failures_have_reason "connection_timed_out"; then
+            TIP_FAILURE_KIND="no_producer_connections"
+        else
+            TIP_FAILURE_KIND="no_producer_tips_returned"
+        fi
+    elif [ "$TIP_COUNT" != "$POOLS" ]; then
+        if all_failures_have_reason "tip_protocol_deserialise_failure"; then
+            TIP_FAILURE_KIND="some_tip_protocol_failures"
+        elif all_failures_have_reason "name_resolution_failed"; then
+            TIP_FAILURE_KIND="some_producers_unresolved"
+        elif all_failures_have_reason "connection_refused" ||
+             all_failures_have_reason "no_route_to_host" ||
+             all_failures_have_reason "connection_timed_out"; then
+            TIP_FAILURE_KIND="some_producer_connections_failed"
+        else
+            TIP_FAILURE_KIND="some_producer_tips_missing"
+        fi
+    else
+        TIP_FAILURE_KIND="tips_divergent"
+    fi
+}

--- a/components/sidecar/composer/convergence/serial_driver_tip_agreement.sh
+++ b/components/sidecar/composer/convergence/serial_driver_tip_agreement.sh
@@ -14,6 +14,8 @@ set -u
 
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk_lib.sh"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/helper_tip_probe_lib.sh"
 
 POOLS="${POOLS:-3}"
 PORT="${PORT:-3001}"
@@ -23,34 +25,24 @@ SAMPLE_DELAY="${SAMPLE_DELAY:-1}"
 
 sdk_reachable "serial_driver_tip_agreement entered"
 
-NODES=()
-for i in $(seq 1 "$POOLS"); do
-    NODES+=("p${i}")
-done
-
-sample_once() {
-    local out
-    out="$(for node in "${NODES[@]}"; do
-        cardano-cli ping -j \
-            --magic 42 --host "${node}.example" --port "$PORT" \
-            --tip --quiet -c1 2>/dev/null \
-            | jq -c --arg node "$node" '{node:$node, hash:.tip[0].hash, block:.tip[0].blockNo}'
-    done | jq -sc '.')"
-    printf '%s' "$out"
-}
-
 for i in $(seq 1 "$SAMPLES"); do
-    details="$(sample_once)"
-    distinct="$(printf '%s' "$details" | jq '[.[] | .hash] | unique | length')"
-    if [ "$distinct" = "1" ]; then
+    probe_all_tips
+    if [ "$TIP_COUNT" != "$POOLS" ]; then
+        sdk_sometimes true "tips unreachable during fault injection" \
+            "$(jq -nc --argjson tips "$TIP_DETAILS" \
+                      --argjson sample "$i" \
+                      --arg kind "$TIP_FAILURE_KIND" \
+                      --argjson reasons "$TIP_FAILURE_REASONS" \
+                '{sample:$sample, failure_kind:$kind, failure_reasons:$reasons, tips:$tips}')"
+    elif [ "$TIP_DISTINCT" = "1" ]; then
         sdk_sometimes true "tips agreed during fault injection" \
-            "$(jq -nc --argjson tips "$details" --argjson sample "$i" \
+            "$(jq -nc --argjson tips "$TIP_SUCCESSES" --argjson sample "$i" \
                 '{sample:$sample, tips:$tips}')"
     else
         sdk_sometimes true "tips diverged during fault injection" \
-            "$(jq -nc --argjson tips "$details" \
+            "$(jq -nc --argjson tips "$TIP_SUCCESSES" \
                       --argjson sample "$i" \
-                      --argjson distinct "$distinct" \
+                      --argjson distinct "$TIP_DISTINCT" \
                 '{sample:$sample, distinct_tips:$distinct, tips:$tips}')"
     fi
     sleep "$SAMPLE_DELAY"

--- a/components/sidecar/sidecar.sh
+++ b/components/sidecar/sidecar.sh
@@ -26,13 +26,14 @@ signal_ready() {
         for i in $(seq 1 "${POOLS}"); do
             (
                 while true; do
-                    cardano-cli ping -c1 -q -j --magic 42 --host p${i}.example --port ${PORT} 2>/dev/null
-                    if [ $? -ne 0 ] ; then
-                        sleep 1
-                        continue
-                    else
+                    # Setup readiness must use the same tip protocol path as
+                    # convergence checks; plain ping can succeed before --tip.
+                    if cardano-cli ping -c1 -q -j --tip \
+                        --magic 42 --host "p${i}.example" --port "${PORT}" \
+                        >/dev/null 2>&1; then
                         break
                     fi
+                    sleep 1
                 done
             ) &
         done

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -36,8 +36,10 @@ for i in $(seq 1 "$POOLS"); do
       exit 1
     fi
 
-    # Check the node is still running
-    if ! docker compose -f "$COMPOSE_FILE" ps --format json "$NODE" 2>/dev/null | grep -q '"running"'; then
+    # Check the node did not terminate. Compose may briefly report created or
+    # restarting while dependencies settle, so only terminal states fail.
+    STATE="$(docker inspect -f '{{.State.Status}}' "$NODE" 2>/dev/null || true)"
+    if [ "$STATE" = "exited" ] || [ "$STATE" = "dead" ]; then
       echo "FAIL: ${NODE} crashed"
       docker compose -f "$COMPOSE_FILE" logs --tail 30 "$NODE" 2>&1
       exit 1
@@ -54,5 +56,9 @@ for i in $(seq 1 "$POOLS"); do
     sleep 5
   done
 done
+
+echo "Checking sidecar convergence command..."
+docker exec sidecar \
+  /opt/antithesis/test/v1/convergence/eventually_converged.sh
 
 echo "PASS: all ${POOLS} nodes responding"

--- a/specs/079-convergence-command-diagnostics/plan.md
+++ b/specs/079-convergence-command-diagnostics/plan.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-Keep the current Antithesis Composer shell-command interface, but move repeated tip probing into a shared Bash helper that records structured per-node results. The helper uses Composer's `helper_` support-file prefix so it is ignored by command validation. Update convergence commands to classify DNS, connection, and tip-protocol probe failures separately from reachable tip divergence, and update smoke testing to run the sidecar convergence command.
+Keep the current Antithesis Composer shell-command interface, but move repeated tip probing into a shared Bash helper that records structured per-node results. The helper uses Composer's `helper_` support-file prefix so it is ignored by command validation. Update convergence commands to classify DNS, connection, and tip-protocol probe failures separately from reachable tip divergence. Align sidecar setup readiness with convergence by requiring `cardano-cli ping --tip` before setup completion, and update smoke testing to run the sidecar convergence command.
 
 ## Technical Context
 
@@ -29,13 +29,13 @@ Keep the current Antithesis Composer shell-command interface, but move repeated 
 - Composer-first workload: unchanged; commands remain under `components/sidecar/composer/convergence/`.
 - SDK instrumentation mandatory: improved with more precise failure details and classification.
 - Short-running commands: retry budgets stay bounded; smoke test adds one bounded sidecar convergence call.
-- Duration-robust: clearer post-fault/final assertions reduce ambiguity across scheduled timelines.
+- Duration-robust: clearer post-fault/final assertions reduce ambiguity across scheduled timelines, and setup readiness now checks the same `--tip` protocol path used by convergence.
 - Minimal sidecar image: no new runtime packages.
 - Image tag hygiene: sidecar compose image must be bumped to a branch commit containing the component changes.
 
 ## Design Decision
 
-Bash remains the right short-term command layer because Antithesis Composer discovers shell scripts directly and the current image already provides the needed tools. The risky part is not Bash itself, but repeated ad hoc parsing that drops failure evidence. This PR centralizes that parsing. If future work needs protocol-level diagnostics, timeouts beyond `cardano-cli` behavior, or richer retry policy, open a follow-up to replace the probe helper with a small compiled binary.
+Bash remains the right short-term command layer because Antithesis Composer discovers shell scripts directly and the current image already provides the needed tools. The risky part is not Bash itself, but repeated ad hoc parsing that drops failure evidence and readiness checks that do not match the convergence probe. This PR centralizes parsing and makes setup use the same `--tip` readiness path. If future work needs protocol-level diagnostics, timeouts beyond `cardano-cli` behavior, or richer retry policy, open a follow-up to replace the probe helper with a small compiled binary.
 
 ## Project Structure
 

--- a/specs/079-convergence-command-diagnostics/plan.md
+++ b/specs/079-convergence-command-diagnostics/plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Improve Convergence Command Diagnostics
+
+**Branch**: `fix/improve-convergence-command-diagnostics` | **Date**: 2026-04-28 | **Spec**: `spec.md`
+**Input**: Feature specification from `specs/079-convergence-command-diagnostics/spec.md`
+
+## Status
+
+**Completed**: Issue #79 opened and moved to WIP.  
+**Current**: Implement shared sidecar probe diagnostics and smoke coverage.  
+**Blockers**: None.
+
+## Summary
+
+Keep the current Antithesis Composer shell-command interface, but move repeated tip probing into a shared Bash helper that records structured per-node results. The helper uses Composer's `helper_` support-file prefix so it is ignored by command validation. Update convergence commands to classify DNS, connection, and tip-protocol probe failures separately from reachable tip divergence, and update smoke testing to run the sidecar convergence command.
+
+## Technical Context
+
+**Language/Version**: Bash with jq inside the sidecar image  
+**Primary Dependencies**: `cardano-cli`, `jq`, coreutils  
+**Storage**: N/A  
+**Testing**: `scripts/smoke-test.sh cardano_node_master 120`, shell syntax checks, `docker compose config`  
+**Target Platform**: Linux containers under Docker Compose and Antithesis  
+**Project Type**: Antithesis test assets  
+**Constraints**: Sidecar image is intentionally minimal; avoid adding dependencies for this slice.  
+**Scale/Scope**: Three producer nodes in `cardano_node_master`
+
+## Constitution Check
+
+- Composer-first workload: unchanged; commands remain under `components/sidecar/composer/convergence/`.
+- SDK instrumentation mandatory: improved with more precise failure details and classification.
+- Short-running commands: retry budgets stay bounded; smoke test adds one bounded sidecar convergence call.
+- Duration-robust: clearer post-fault/final assertions reduce ambiguity across scheduled timelines.
+- Minimal sidecar image: no new runtime packages.
+- Image tag hygiene: sidecar compose image must be bumped to a branch commit containing the component changes.
+
+## Design Decision
+
+Bash remains the right short-term command layer because Antithesis Composer discovers shell scripts directly and the current image already provides the needed tools. The risky part is not Bash itself, but repeated ad hoc parsing that drops failure evidence. This PR centralizes that parsing. If future work needs protocol-level diagnostics, timeouts beyond `cardano-cli` behavior, or richer retry policy, open a follow-up to replace the probe helper with a small compiled binary.
+
+## Project Structure
+
+```text
+components/sidecar/composer/convergence/
+├── helper_tip_probe_lib.sh
+├── eventually_converged.sh
+├── finally_tips_agree.sh
+└── serial_driver_tip_agreement.sh
+
+scripts/
+└── smoke-test.sh
+
+specs/079-convergence-command-diagnostics/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+## Verification
+
+- Bash syntax check on changed shell scripts.
+- Composer filename prefix validation for sidecar command files.
+- Docker Compose config parse.
+- Local smoke test on `cardano_node_master`.
+- PR `publish-images` and follow-on compose smoke test.
+- Branch Antithesis duration=1h before merge, compared against current main baseline.

--- a/specs/079-convergence-command-diagnostics/spec.md
+++ b/specs/079-convergence-command-diagnostics/spec.md
@@ -1,0 +1,54 @@
+# Feature Specification: Improve Convergence Command Diagnostics
+
+**Feature Branch**: `fix/improve-convergence-command-diagnostics`  
+**Created**: 2026-04-28  
+**Status**: Draft  
+**Input**: GitHub issue #79
+
+## User Scenarios & Testing
+
+### User Story 1 - Classify Failed Tip Checks (Priority: P1)
+
+As an operator reading an Antithesis report, I need failed convergence checks to say whether producers failed to return tips because of DNS, connection, or tip-protocol errors, or whether reachable producers returned divergent tips, so that I can triage network recovery separately from chain safety.
+
+**Why this priority**: The latest failed main run reported `count=0 distinct=0`, which hid the actual transport or protocol failure.
+
+**Independent Test**: Run the convergence command from the sidecar on a healthy local cluster and verify it records three successful producer probes with matching hashes.
+
+**Acceptance Scenarios**:
+
+1. **Given** all producers are reachable, **When** the convergence command runs, **Then** the report details include one successful result per producer.
+2. **Given** a producer probe fails, **When** the convergence command reports failure, **Then** the details include the node name, exit code, a concrete failure reason such as `tip_protocol_deserialise_failure`, and bounded stderr/stdout context.
+3. **Given** all producers are reachable but their hashes differ, **When** the final-tip command reports failure, **Then** the failure is classified as tip divergence rather than unreachability.
+
+### User Story 2 - Exercise Sidecar Vantage Point Locally (Priority: P2)
+
+As a maintainer, I need the smoke test to exercise the sidecar command path, so that compose-level CI covers the same network vantage point used by Antithesis.
+
+**Why this priority**: The existing smoke test pings each node from inside itself, which does not validate sidecar-to-producer DNS/TCP reachability.
+
+**Independent Test**: Run `scripts/smoke-test.sh cardano_node_master 120` and observe that it executes the sidecar convergence command after producer-local pings succeed.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Convergence commands MUST preserve per-node probe outcomes in structured JSON details.
+- **FR-002**: Failed probe details MUST include node name, exit code, failure reason, and bounded stdout/stderr context.
+- **FR-003**: Final-tip checks MUST distinguish incomplete producer tip responses from reachable producer tip divergence.
+- **FR-004**: Local smoke tests MUST execute a convergence command from the sidecar container.
+- **FR-005**: The implementation MUST stay within the current sidecar runtime dependencies unless a follow-up issue replaces the shell command layer.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A failed no-response check produces JSON details showing why each producer probe failed.
+- **SC-002**: A healthy local cluster passes sidecar convergence from `scripts/smoke-test.sh`.
+- **SC-003**: Maintainers can tell from report text/details whether a failure is name resolution, connection failure, tip-protocol failure, missing tip data, or tip divergence.
+
+## Assumptions
+
+- Antithesis command discovery remains file-prefix based under `/opt/antithesis/test/v1`.
+- Bash remains acceptable for this small diagnostic slice because the sidecar image already carries Bash, jq, and cardano-cli.
+- A compiled probe may be preferable later if retries, protocol inspection, or richer health models outgrow shell.

--- a/specs/079-convergence-command-diagnostics/spec.md
+++ b/specs/079-convergence-command-diagnostics/spec.md
@@ -29,6 +29,19 @@ As a maintainer, I need the smoke test to exercise the sidecar command path, so 
 
 **Independent Test**: Run `scripts/smoke-test.sh cardano_node_master 120` and observe that it executes the sidecar convergence command after producer-local pings succeed.
 
+### User Story 3 - Align Setup Readiness with Tip Probing (Priority: P2)
+
+As a maintainer, I need Antithesis setup completion to wait for the same producer tip protocol path used by convergence checks, so that setup does not declare the system ready while `cardano-cli ping --tip` still fails.
+
+**Why this priority**: Local reproduction showed plain producer ping can be weaker than `--tip`; the TCP endpoint can be reachable while the tip find-intersect path returns EOF.
+
+**Independent Test**: Start `cardano_node_master` locally and verify the sidecar can complete setup and the convergence command can retrieve all producer tips.
+
+**Acceptance Scenarios**:
+
+1. **Given** producers are starting, **When** the sidecar signals Antithesis setup complete, **Then** every producer has already answered a sidecar-originated `cardano-cli ping --tip`.
+2. **Given** a producer accepts TCP before tip probing is ready, **When** the sidecar setup loop checks readiness, **Then** setup continues polling instead of declaring completion.
+
 ## Requirements
 
 ### Functional Requirements
@@ -38,6 +51,7 @@ As a maintainer, I need the smoke test to exercise the sidecar command path, so 
 - **FR-003**: Final-tip checks MUST distinguish incomplete producer tip responses from reachable producer tip divergence.
 - **FR-004**: Local smoke tests MUST execute a convergence command from the sidecar container.
 - **FR-005**: The implementation MUST stay within the current sidecar runtime dependencies unless a follow-up issue replaces the shell command layer.
+- **FR-006**: Sidecar setup readiness MUST use `cardano-cli ping --tip`, not plain ping, so setup and convergence share the same readiness definition.
 
 ## Success Criteria
 
@@ -46,6 +60,7 @@ As a maintainer, I need the smoke test to exercise the sidecar command path, so 
 - **SC-001**: A failed no-response check produces JSON details showing why each producer probe failed.
 - **SC-002**: A healthy local cluster passes sidecar convergence from `scripts/smoke-test.sh`.
 - **SC-003**: Maintainers can tell from report text/details whether a failure is name resolution, connection failure, tip-protocol failure, missing tip data, or tip divergence.
+- **SC-004**: Antithesis setup completion is not emitted until sidecar-originated `--tip` probes succeed for all producers.
 
 ## Assumptions
 

--- a/specs/079-convergence-command-diagnostics/tasks.md
+++ b/specs/079-convergence-command-diagnostics/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Improve Convergence Command Diagnostics
+
+**Input**: `spec.md`, `plan.md`
+
+## Phase 1: Shared Probe Diagnostics
+
+- [X] T001 Add a shared tip probe helper in `components/sidecar/composer/convergence/helper_tip_probe_lib.sh`.
+- [X] T002 Update `eventually_converged.sh` to use structured probe results, concrete failure reasons, and aggregate failure kinds.
+- [X] T003 Update `finally_tips_agree.sh` to distinguish producer reachability from tip agreement.
+- [X] T004 Update `serial_driver_tip_agreement.sh` to classify unreachable samples during fault injection.
+
+## Phase 2: Local Coverage
+
+- [ ] T005 Extend `scripts/smoke-test.sh` to execute sidecar convergence from the sidecar container.
+- [ ] T006 Run shell syntax checks, compose config, and local smoke test.
+
+## Phase 3: Image Wiring and Review
+
+- [X] T007 Commit sidecar and smoke changes.
+- [X] T008 Bump the `cardano_node_master` sidecar image tag to the sidecar-change commit.
+- [X] T009 Validate sidecar composer files use accepted command or `helper_` prefixes.
+- [ ] T010 Push branch, open PR linked to issue #79, and wait for PR checks.
+- [ ] T011 Run a branch Antithesis duration=1h and compare findings against main before merge.

--- a/specs/079-convergence-command-diagnostics/tasks.md
+++ b/specs/079-convergence-command-diagnostics/tasks.md
@@ -15,8 +15,8 @@
 
 ## Phase 2: Local Coverage
 
-- [ ] T005 Extend `scripts/smoke-test.sh` to execute sidecar convergence from the sidecar container.
-- [ ] T006 Run shell syntax checks, compose config, and local smoke test.
+- [X] T005 Extend `scripts/smoke-test.sh` to execute sidecar convergence from the sidecar container.
+- [X] T006 Run shell syntax checks, compose config, and local smoke test.
 
 ## Phase 3: Image Wiring and Review
 

--- a/specs/079-convergence-command-diagnostics/tasks.md
+++ b/specs/079-convergence-command-diagnostics/tasks.md
@@ -9,6 +9,10 @@
 - [X] T003 Update `finally_tips_agree.sh` to distinguish producer reachability from tip agreement.
 - [X] T004 Update `serial_driver_tip_agreement.sh` to classify unreachable samples during fault injection.
 
+## Phase 1.5: Setup Readiness
+
+- [X] T012 Update `components/sidecar/sidecar.sh` setup readiness to require sidecar-originated `cardano-cli ping --tip` success.
+
 ## Phase 2: Local Coverage
 
 - [ ] T005 Extend `scripts/smoke-test.sh` to execute sidecar convergence from the sidecar container.

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -130,7 +130,7 @@ services:
         condition: service_started
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar@sha256:248107b6ad54529f596c8484168ba855f193388a7b187c594bc847b27e146b57
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f237cbf
     environment:
       NETWORKMAGIC: 42
       PORT: 3001


### PR DESCRIPTION
Closes #79

## Summary

This PR improves the Antithesis convergence command diagnostics without changing the Composer discovery model. The commands are still Bash scripts under `/opt/antithesis/test/v1`, but repeated producer tip probing now goes through a shared `helper_` support file that records structured per-node results and concrete failure reasons.

It also aligns sidecar setup readiness with the convergence check: setup now waits for sidecar-originated `cardano-cli ping --tip` to succeed for every producer, instead of using weaker plain ping readiness.

Changed files:
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/components/sidecar/composer/convergence/helper_tip_probe_lib.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/components/sidecar/composer/convergence/eventually_converged.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/components/sidecar/composer/convergence/finally_tips_agree.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/components/sidecar/composer/convergence/serial_driver_tip_agreement.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/components/sidecar/sidecar.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/scripts/smoke-test.sh
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/specs/079-convergence-command-diagnostics/spec.md
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/specs/079-convergence-command-diagnostics/plan.md
- https://github.com/cardano-foundation/cardano-node-antithesis/blob/fix/improve-convergence-command-diagnostics/specs/079-convergence-command-diagnostics/tasks.md

## What changed

- Added `helper_tip_probe_lib.sh`, which runs one `cardano-cli ping --tip` per producer and captures:
  - node name
  - success flag
  - exit code
  - hash/block/slot on success
  - concrete failure reason plus bounded stdout/stderr on failure
- Kept the shared probe helper under Composer's accepted `helper_` prefix so Antithesis command validation ignores it as support code.
- Replaced misleading aggregate labels such as `no_producers_reachable` with report-friendly classifications such as `no_tip_protocol_success`, `no_producers_resolved`, `no_producer_connections`, and `no_producer_tips_returned`.
- Added per-node reason classification for failures including `tip_protocol_deserialise_failure`, name resolution, connection refused, no route to host, timeout, handshake failure, invalid JSON, and missing tip data.
- Updated `eventually_converged.sh`, `finally_tips_agree.sh`, and `serial_driver_tip_agreement.sh` to include `failure_reasons` in SDK details.
- Updated `sidecar.sh` setup readiness to require `cardano-cli ping --tip` from the sidecar to every producer before emitting Antithesis setup complete.
- Extended `scripts/smoke-test.sh` to run the sidecar convergence command after producer-local pings succeed.
- Hardened the smoke-test container state check so transient `created` or `restarting` states are not treated as crashes.
- Bumped the `cardano_node_master` sidecar image reference to `sidecar:f237cbf`, the source commit containing the sidecar changes.

## Local reproduction

I reproduced the Antithesis failure mode locally by running repeated sidecar-originated `cardano-cli ping --tip` probes while killing/restarting `p1`, `p2`, and `p3`.

The reproduced failure was the same shape as the report: all producer hostnames resolved to IPs and the TCP endpoint was reachable, but `cardano-cli ping --tip` failed with:

```text
PingClientFindIntersectDeserialiseFailure (DeserialiseFailure 5 "end of input")
```

That means the previous `no_producers_reachable` label was wrong. The failure is better described as the producer tip protocol path not returning a usable tip, not as DNS or basic TCP unreachability.

The reproduction also showed that plain `cardano-cli ping` is a weaker readiness signal than `cardano-cli ping --tip`. This PR changes setup readiness to use `--tip` so setup and convergence use the same definition.

## Bash vs another implementation

The current technology is Bash. Antithesis Composer discovers these commands by filename prefix, and the sidecar image already carries Bash, jq, and cardano-cli. For this PR, Bash remains acceptable because the task is bounded orchestration and structured JSON assembly.

The design line is documented in the spec: if this grows into protocol-level diagnostics, explicit timeout control, or richer health modeling, the next step should be a small compiled probe binary rather than more shell logic.

## Verification

Local verification completed on head `8e249bd`:

- `bash -n components/sidecar/sidecar.sh components/sidecar/composer/convergence/helper_tip_probe_lib.sh components/sidecar/composer/convergence/eventually_converged.sh components/sidecar/composer/convergence/finally_tips_agree.sh components/sidecar/composer/convergence/serial_driver_tip_agreement.sh scripts/smoke-test.sh`
- Sidecar Composer filename prefix validation: all files are `parallel_driver_*`, `serial_driver_*`, `eventually_*`, `finally_*`, or `helper_*`.
- `git diff --check`
- `INTERNAL_NETWORK=false docker compose -f testnets/cardano_node_master/docker-compose.yaml config --quiet`
- `docker build -t ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f237cbf components/sidecar`
- `scripts/smoke-test.sh cardano_node_master 120`

PR checks passed on head `8e249bd`:

- publish-images: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25061180653/job/73415445866
- build-docs: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25061180773/job/73415445910
- adversary CI: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25061180785
- tracer-sidecar CI: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25061180691

Branch Antithesis validation passed on head `8e249bd`:

- GitHub run: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25061494950
- testRunId: `ddcf4e7810276f1ea945378e697f69dfbb25c2e9b6ec16d44c5c35158739a68d`
- duration input: `1`
- faults enabled: `true`
- outcome: `success`

Smoke output included sidecar convergence from the sidecar container with all three producer tips returned as structured JSON.

## Branch validation notes

An earlier branch validation on `sidecar:870e289` failed the Composer property `Invalid commands found`. That image placed the probe helper at `convergence/tip_probe_lib.sh`, which did not use an accepted Composer command or helper prefix. The helper is now `helper_tip_probe_lib.sh`, matching the existing `helper_sdk_lib.sh` convention.

A later branch validation on `sidecar:0e8cb00` confirmed that the invalid-command issue is fixed. The remaining Antithesis failure was `eventually_converged failed: no_producers_reachable`, with all producers showing `PingClientFindIntersectDeserialiseFailure`. This PR now reports that case as `no_tip_protocol_success` with per-node `tip_protocol_deserialise_failure` details.

The final branch validation on `sidecar:f237cbf` passed with faults enabled.

## Constitution compliance

- Composer-first workload: commands remain in the Composer command tree, and support files use the `helper_` prefix.
- SDK instrumentation: failure details are more precise and structured.
- Short-running commands: retry budgets remain bounded.
- Duration-robust: setup readiness now uses the same `--tip` path as convergence, and post-fault/final failures distinguish missing tips from divergent reachable tips.
- Minimal sidecar image: no runtime dependencies added.
- Image tag hygiene: compose points to the sidecar source commit that CI can build.

## Merge readiness

Merge guard reports this PR ready: all 8 checks passed, no review required, and no merge conflicts.
