### PR TITLE
testnet: pin sidecar by content digest

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -130,7 +130,7 @@ services:
         condition: service_started
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f237cbf
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar@sha256:5e363f5d99da044c551e148ecb782fb1a195af81f1e0a00167b2f95bad1dcee0
     environment:
       NETWORKMAGIC: 42
       PORT: 3001


### PR DESCRIPTION
PR #80 (https://github.com/cardano-foundation/cardano-node-antithesis/pull/80) bumped \`sidecar\` to \`:f237cbf\` as a **tag-only** reference. After PR #71 (https://github.com/cardano-foundation/cardano-node-antithesis/pull/71) every other compose image is digest-pinned (\`name@sha256:DIGEST\`); sidecar is the lone outlier — a re-tag of \`f237cbf\` upstream would silently change the bytes Antithesis pulls.

This PR pins it:

\`\`\`
ghcr.io/.../sidecar@sha256:5e363f5d99da044c551e148ecb782fb1a195af81f1e0a00167b2f95bad1dcee0
\`\`\`

Resolved against ghcr today. \`publish-images\` already understands the digest-only form (per PR #71's script change) and will skip rebuilding sidecar entries that don't carry a tag — image already exists at this digest.