### PR TITLE
Fix pre-readiness final tip checks

### DIFF
--- a/components/sidecar/composer/convergence/finally_tips_agree.sh
+++ b/components/sidecar/composer/convergence/finally_tips_agree.sh
@@ -30,8 +30,12 @@ TIP_COUNT=0
 TIP_DISTINCT=0
 TIP_FAILURE_REASONS="[]"
 TIP_FAILURE_KIND="not_checked"
+SAW_TIP_RESPONSE=false
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     probe_all_tips
+    if [ "$TIP_COUNT" != "0" ]; then
+        SAW_TIP_RESPONSE=true
+    fi
     if [ "$TIP_COUNT" = "$POOLS" ] && [ "$TIP_DISTINCT" = "1" ]; then
         echo "tips agree: $TIP_SUCCESSES"
         sdk_always true "all producer tips reachable at final check" \
@@ -42,6 +46,11 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     fi
     sleep "$RETRY_DELAY"
 done
+
+if [ "$SAW_TIP_RESPONSE" = "false" ] && [ "$TIP_FAILURE_KIND" = "no_tip_protocol_success" ]; then
+    echo "producer tip protocol never became ready during finally_tips_agree: kind=$TIP_FAILURE_KIND reasons=$TIP_FAILURE_REASONS details=$TIP_DETAILS; treating as startup readiness miss"
+    exit 0
+fi
 
 echo "divergent/incomplete at end-of-workload: kind=$TIP_FAILURE_KIND reasons=$TIP_FAILURE_REASONS count=$TIP_COUNT distinct=$TIP_DISTINCT details=$TIP_DETAILS"
 if [ "$TIP_COUNT" != "$POOLS" ]; then

--- a/specs/079-convergence-command-diagnostics/spec.md
+++ b/specs/079-convergence-command-diagnostics/spec.md
@@ -42,6 +42,19 @@ As a maintainer, I need Antithesis setup completion to wait for the same produce
 1. **Given** producers are starting, **When** the sidecar signals Antithesis setup complete, **Then** every producer has already answered a sidecar-originated `cardano-cli ping --tip`.
 2. **Given** a producer accepts TCP before tip probing is ready, **When** the sidecar setup loop checks readiness, **Then** setup continues polling instead of declaring completion.
 
+### User Story 4 - Suppress Pre-Readiness Final Checks (Priority: P1)
+
+As a maintainer reading a branch Antithesis report, I need a `finally_tips_agree.sh` invocation that runs before any producer has ever served the tip protocol to be treated as a startup readiness miss, so that the report does not classify an early Composer scheduling race as a final convergence failure.
+
+**Why this priority**: The Composer can schedule a `finally_` command before the producer tip protocol is ready. When all producers return `tip_protocol_deserialise_failure` and no producer returns a tip during the whole retry window, the command has not observed enough state to assert final reachability or final agreement.
+
+**Independent Test**: Run `finally_tips_agree.sh` with a stubbed `cardano-cli` that always fails with `PingClientFindIntersectDeserialiseFailure`; verify the command exits 0 and does not emit false `all producer tips reachable at final check` or `finally_tips_agree holds` assertions.
+
+**Acceptance Scenarios**:
+
+1. **Given** every producer probe fails with `tip_protocol_deserialise_failure` for the entire retry window, **When** `finally_tips_agree.sh` exhausts its attempts, **Then** it exits 0 as a readiness miss.
+2. **Given** at least one producer returned a tip during the retry window, **When** the final check still ends incomplete or divergent, **Then** the command keeps the existing failure behavior and emits structured failure details.
+
 ## Requirements
 
 ### Functional Requirements
@@ -52,6 +65,8 @@ As a maintainer, I need Antithesis setup completion to wait for the same produce
 - **FR-004**: Local smoke tests MUST execute a convergence command from the sidecar container.
 - **FR-005**: The implementation MUST stay within the current sidecar runtime dependencies unless a follow-up issue replaces the shell command layer.
 - **FR-006**: Sidecar setup readiness MUST use `cardano-cli ping --tip`, not plain ping, so setup and convergence share the same readiness definition.
+- **FR-007**: `finally_tips_agree.sh` MUST treat a retry window with zero successful tip responses and only `tip_protocol_deserialise_failure` outcomes as a non-failing readiness miss.
+- **FR-008**: `finally_tips_agree.sh` MUST continue failing incomplete or divergent final checks once it has observed at least one producer tip response during the retry window.
 
 ## Success Criteria
 
@@ -61,6 +76,7 @@ As a maintainer, I need Antithesis setup completion to wait for the same produce
 - **SC-002**: A healthy local cluster passes sidecar convergence from `scripts/smoke-test.sh`.
 - **SC-003**: Maintainers can tell from report text/details whether a failure is name resolution, connection failure, tip-protocol failure, missing tip data, or tip divergence.
 - **SC-004**: Antithesis setup completion is not emitted until sidecar-originated `--tip` probes succeed for all producers.
+- **SC-005**: The no-tip-protocol startup-race case exits 0 without writing false final-check SDK assertions, while reachable divergence still exits 1.
 
 ## Assumptions
 

--- a/specs/079-convergence-command-diagnostics/tasks.md
+++ b/specs/079-convergence-command-diagnostics/tasks.md
@@ -13,6 +13,10 @@
 
 - [X] T012 Update `components/sidecar/sidecar.sh` setup readiness to require sidecar-originated `cardano-cli ping --tip` success.
 
+## Phase 1.6: Pre-Readiness Final Check Race
+
+- [X] T013 Treat an all-`tip_protocol_deserialise_failure` `finally_tips_agree.sh` retry window with zero successful tip responses as a non-failing startup readiness miss.
+
 ## Phase 2: Local Coverage
 
 - [X] T005 Extend `scripts/smoke-test.sh` to execute sidecar convergence from the sidecar container.

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -150,7 +150,7 @@ services:
         condition: service_completed_successfully
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar@sha256:5e363f5d99da044c551e148ecb782fb1a195af81f1e0a00167b2f95bad1dcee0
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f889dbc
     environment:
       NETWORKMAGIC: 42
       PORT: 3001


### PR DESCRIPTION
Closes #85

## Summary

- Treat `finally_tips_agree.sh` runs that never observe any producer tip and only see `tip_protocol_deserialise_failure` as a startup readiness miss.
- Preserve the existing failure behavior once at least one producer tip has been observed, so reachable divergence and incomplete final checks still report structured SDK failures.
- Point `cardano_node_master` at the sidecar commit containing the fix so PR CI can build and smoke-test the updated sidecar.

## Verification

- `bash -n components/sidecar/composer/convergence/finally_tips_agree.sh scripts/push-cardano_node_master_images.sh scripts/smoke-test.sh components/sidecar/sidecar.sh`
- `shellcheck components/sidecar/composer/convergence/finally_tips_agree.sh`
- `git diff --check`
- `INTERNAL_NETWORK=false docker compose -f testnets/cardano_node_master/docker-compose.yaml config --quiet`
- Stubbed all-producer `PingClientFindIntersectDeserialiseFailure` case: exits 0 and emits no false final-check SDK assertions.
- Stubbed reachable divergent-tip case: exits 1 and keeps the existing false `finally_tips_agree holds` assertion.
