### PR TITLE
docs(adversary): refresh component doc, add roadmap

### DIFF
--- a/docs/components/adversary-roadmap.md
+++ b/docs/components/adversary-roadmap.md
@@ -1,0 +1,184 @@
+# Adversary roadmap
+
+Long-term plan for adversarial workload against the testnet. The
+[adversary component][adversary-doc] today is a one-shot chain-sync
+client; this page is the north star for where it is going.
+
+## Goals
+
+1. **Move the adversary from one-shot to long-running.** Mirror the
+   [tx-generator][tx-generator-doc] design: a daemon listening on a
+   UNIX control socket, with composer scripts firing one NDJSON
+   request per Antithesis tick.
+2. **Cover more of the protocol surface than chain-sync.** Add
+   block-fetch, tx-submission, keep-alive, handshake, and N2C
+   adversaries — and an upstream-peer (server) mode for the canonical
+   "Byzantine peer" tests.
+3. **Steer adversarial choices with the Antithesis hypervisor.** Every
+   randomness draw must come from an injectable `RandomSource` so
+   Antithesis can bias the run.
+4. **Move the daemon home to [`lambdasistemi/cardano-node-clients`][cnc].**
+   The tx-generator daemon already lives there; adversary inherits
+   the same `Provider`, `Submitter`, `TxBuild`, and control-wire
+   conventions, and the same release flow. This repo keeps only the
+   image-tag pin, the composer drivers, and the compose wiring.
+
+## Architecture target
+
+```
+                   +---------------------------------+
+                   |    cardano-adversary daemon     |
+                   |    (Haskell, in cardano-node-   |
+                   |    clients)                     |
+                   |                                 |
+   composer        |   - keeps a pool of N2N         |
+   parallel_       |     initiator connections to    |
+   driver_*.sh --->|     producers                   |
+   over NDJSON     |   - keeps a pool of N2C         |
+   on UNIX socket  |     connections to relays       |
+                   |   - exposes /state/adversary-   |
+                   |     control.sock                |
+                   |   - one request → one           |
+                   |     adversarial action          |
+                   |   - emits SDK reachable/        |
+                   |     sometimes/always per action |
+                   +---------------------------------+
+```
+
+### Mapping from tx-generator
+
+| tx-generator (today) | cardano-adversary (planned) |
+|---|---|
+| `cardano-tx-generator` daemon | `cardano-adversary` daemon |
+| `/state/tx-generator-control.sock` | `/state/adversary-control.sock` |
+| `parallel_driver_transact.sh` / `_refill.sh` | one driver script per misbehaviour archetype |
+| `eventually_population_grew.sh` | `eventually_adversary_active.sh` |
+| `finally_pressure_summary.sh` | `finally_adversary_summary.sh` |
+| Wire spec at `specs/034-cardano-tx-generator/contracts/control-wire.md` | Wire spec at `specs/0XX-cardano-adversary/contracts/control-wire.md` |
+
+### Implementation seams to reuse from `cardano-node-clients`
+
+- `Cardano.Node.Client.Provider` / `Submitter` / `TxBuild` — for the
+  N2C-side adversaries (mempool flooding, malformed tx submission).
+- `Adversary.ChainSync.Connection` from this repo becomes the
+  initiator-library half of an N2N adversary library; we add a
+  responder-library half for upstream-peer mode.
+- A single `RandomSource` typeclass — the one already used by the
+  asteria-player at
+  [`components/asteria-player/src/Asteria/RandomSource.hs`][rs] —
+  with an `antithesis_random` CLI implementation and a
+  `System.Random` fallback. Every adversarial decision draws from
+  it.
+
+## Tier list of misbehaviour archetypes
+
+Each archetype = one daemon endpoint + one composer
+`parallel_driver_*.sh` + a documented invariant the cluster must
+preserve under it. Order is implementation order, easiest first.
+
+### Tier 1 — port the existing surface into the daemon
+
+1. **`chain_sync_flap`** — what we have today: pick random
+   intersection point, sync `LIMIT` blocks, disconnect. Becomes a
+   single endpoint of the new daemon. Removes the stand-alone
+   `adversary` binary.
+2. **`chain_sync_thrash`** — same connection, repeatedly
+   `MsgFindIntersect` to a different random point without finishing
+   the sync. Stresses the producer's intersection-finding cache.
+3. **`chain_sync_slow_loris`** — open the connection, complete
+   handshake, then send `MsgRequestNext` at a deliberately slow
+   cadence; assert the connection is kept alive (or assert it gets
+   evicted, whichever the protocol promises).
+
+### Tier 2 — other mini-protocols, downstream side
+
+4. **`block_fetch_replay`** — `BlockFetch` client that requests
+   already-fetched ranges back-to-back, plus ranges straddling
+   rollback boundaries.
+5. **`tx_submission_flood`** — N2N `TxSubmission2` client that
+   announces tx-ids the producer has not requested, or refuses to
+   deliver bodies after announcing them.
+6. **`tx_submission_garbage`** — submits well-formed-CBOR but
+   ledger-invalid txs at high rate (mempool pressure).
+7. **`keepalive_abuse`** — `KeepAlive` cookies out of order or never
+   replied to.
+
+### Tier 3 — upstream-peer mode (the canonical Byzantine peer)
+
+This is the big one — promised by the original component pitch, never
+implemented. Cluster nodes must dial the adversary, so the adversary
+becomes a node-to-node *server*. Then:
+
+8. **`upstream_fork_serve`** — announce a tip on the honest chain's
+   history but `MsgRollForward` with a fabricated header. ChainSel
+   must discard.
+9. **`upstream_equivocate`** — serve two contradictory headers at
+   the same slot to two peers.
+10. **`upstream_too_far_ahead`** — announce a tip 10× past the real
+    tip; producer must not fetch.
+11. **`upstream_long_rollback`** — induce a rollback past *k* and
+    verify the honest peer rejects.
+
+Tier 3 needs a topology change (relays peer with adversary in their
+`topology.json`). That is a separate testnet variant; it does not
+disturb the current `cardano_node_master` testnet.
+
+### Tier 4 — N2C abuse (lower priority)
+
+12. **`lsq_flood`** — open many `LocalStateQuery` sessions against a
+    relay, hold them.
+13. **`local_tx_submission_garbage`** — N2C variant of #6.
+
+## Sequenced PR plan
+
+- **PR A (this repo, doc-only)** — refresh
+  `docs/components/adversary.md` to match implementation; publish
+  this roadmap. *No behaviour change.*
+- **PR B (cardano-node-clients)** — scaffold `cardano-adversary`
+  package next to `cardano-tx-generator`, with `Provider`/`Submitter`
+  reuse, control-wire spec, daemon skeleton emitting
+  `sdk_reachable` only.
+- **PR C (cardano-node-clients)** — implement `chain_sync_flap`
+  endpoint by porting `Adversary.Application` into the daemon. Add
+  `RandomSource` plumbing.
+- **PR D (this repo)** — switch `components/adversary/` to consume
+  the new image, update compose + composer drivers to the daemon
+  shape; delete the stand-alone Haskell binary.
+- **PR E (cardano-node-clients)** — `chain_sync_thrash` +
+  `chain_sync_slow_loris` endpoints. Tier 1 complete.
+- After Tier 1 is green on Antithesis: start Tier 2 issues, one
+  endpoint per PR.
+- Tier 3 starts when there is appetite for the topology variant;
+  track as its own parent epic with sub-issues per archetype.
+
+## Tickets
+
+Filed in
+[`cardano-foundation/cardano-node-antithesis`][repo]:
+
+- "Adversary roadmap: long-running daemon + parallel-driver fan-out
+  (epic)" — links to this page.
+- "Move adversary daemon home to cardano-node-clients; keep only
+  image + composer drivers here" (PR D driver).
+- "Tier 3: upstream-peer Byzantine adversary testnet variant"
+  (separate epic).
+
+To be filed in
+[`lambdasistemi/cardano-node-clients`][cnc]:
+
+- "Scaffold cardano-adversary daemon (PR B)".
+- "Port chain_sync_flap into adversary daemon (Tier 1.1)".
+- "chain_sync_thrash endpoint (Tier 1.2)".
+- "chain_sync_slow_loris endpoint (Tier 1.3)".
+- "block_fetch_replay endpoint (Tier 2.4)".
+- "tx_submission_{flood,garbage} endpoints (Tier 2.5–2.6)".
+- "keepalive_abuse endpoint (Tier 2.7)".
+- "Upstream-peer responder library + topology variant (Tier 3 epic)".
+
+<!-- MARKDOWN LINKS & IMAGES -->
+
+[adversary-doc]: adversary.md
+[tx-generator-doc]: https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/components/tx-generator
+[cnc]: https://github.com/lambdasistemi/cardano-node-clients
+[rs]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/asteria-player/src/Asteria/RandomSource.hs
+[repo]: https://github.com/cardano-foundation/cardano-node-antithesis

--- a/docs/components/adversary.md
+++ b/docs/components/adversary.md
@@ -1,101 +1,163 @@
-# Adversarial node for Cardano-Antithesis
+# Adversary
 
-The idea is to create an executable which:
+A node-to-node downstream client that connects to producer nodes, asks
+for a chain sync from a randomly-chosen intersection point, pulls a
+bounded number of blocks, and disconnects. The composer fires it
+repeatedly under fault injection so producers see concurrent connection
+churn while their chain is being rolled back, paused, or partitioned.
 
-- can be triggered by Antithesis
-- behaves like a node but with unusual, potentially adversarial behaviours
-- in order to test the "real" nodes in the cluster run by Antithesis
+## What it does today
 
-Cardano protocol details:
+The component ships a single Haskell binary, `adversary`, run inside
+the `sidecar` container.
 
-- Node to node protocol (we act like a node)
-- Specifically chain sync mini-protocol (p.21 of [Network-spec][Netspec]), peer
-  propagation protocol.
+- Initiator-only N2N client (`NodeToNodeV_14`,
+  `InitiatorOnlyDiffusionMode`).
+- Implements the **chain-sync mini-protocol only** (mini-protocol
+  number 2).
+- Reads a list of chain points from `CHAINPOINT_FILEPATH`. The file is
+  harvested by `tracer-sidecar` from real cardano-tracer logs at run
+  time; one chain point per line, plus the implicit `origin` point.
+- Spawns `NCONNS` concurrent connections fanned out over the producer
+  hostnames in `NODES`. Each connection picks a random starting point,
+  sends `MsgFindIntersect [point]`, then loops `MsgRequestNext` until
+  `LIMIT` blocks have been pulled or the producer's tip is reached,
+  then disconnects.
+- All connections terminate. The driver script exits 0 on completion.
+- Randomness comes from `newStdGen` (host RNG entropy). It is **not**
+  wired to the Antithesis hypervisor's random source today.
 
-- As a downstream peer:
-  - Unsual behaviours:
-    * ask to sync to random intersection points (for example, blocks that might have been rolled back)
-    * multiple random connect/follow/disconnect (maybe use Antithesis for randomness?)
-- As an upstream peer:
-  - serve incorrect headers/blocks/chains.
+This exercises:
 
-Overall approach:
+- Producer mux / connection-management code under N concurrent N2N
+  initiators.
+- The intersection-finding logic, with both well-known and historic /
+  rolled-back points.
+- ChainSync server state-machine handling under concurrent peers.
 
-1. Using tracer sidecar, get all intersection points from logs of nodes in cluster
-2. Write these chain points into a file on disk
-3. Adversarial node reads this file selects random points
-4. Provide a command (to let Antithesis decide when to use it)
-5. When command is called, select random point from file and do a chain sync
+This does **not** exercise:
 
-Implementation considerations:
+- Block-fetch, tx-submission, keep-alive, or handshake mini-protocols.
+- Upstream-peer (server) behaviour — the adversary never serves a chain.
+- Mid-protocol misbehaviour — the loop only ever sends well-formed
+  requests.
+- Steered fault injection — Antithesis cannot bias the adversary's
+  choices.
 
-- Make a Haskell executable
-- Feasible to start from scratch; cardano-wallet code as reference
-- Must have [ouroboros-network][Ouroboros] (and possibly ouroboros-consensus-cardano) as dependencies
-- Might need external C libraries (libsodium)
-- All this might make it necessary to use Nix to get all dependencies working
+The full long-term plan is in [adversary-roadmap.md](adversary-roadmap.md).
 
+## Composer driver
 
-### Issue
+`parallel_driver_flaky_chain_sync.sh` lives at
+`components/sidecar/composer/chain-sync-client/` and is mounted into
+the `sidecar` container at
+`/opt/antithesis/test/v1/chain-sync-client/`. It:
 
-To be controlled by antithesis we have to create an idling container with scripts at the special directory `/opt/antithesis/test/v1`
+- Resolves the producer hostnames from `POOLS` (and optional
+  `EXTRA_NODES`).
+- Validates that `CHAINPOINT_FILEPATH` exists. If the file is missing
+  the script exits 0, so an early-test invocation while
+  `tracer-sidecar` is still warming up does not fail the run (see
+  [#9][issue-9]).
+- Execs the `adversary` binary with the resolved arguments.
 
-To test it we have to exec into the container and run the script `parallel_driver_flaky_chain_sync.sh` located at `/opt/antithesis/test/v1/chain-sync-client/`
+A duplicate of the same script lives at
+`components/adversary/composer/chain-sync-client/` for the component's
+local test loop; the canonical copy is the one in
+`components/sidecar/`.
 
-The scripts are located in the `compose` directory of this adversary component.
+## Environment variables
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `POOLS` | (required) | Number of producer pools; the script generates `p1`, `p2`, ..., `p$POOLS` as target hostnames |
+| `EXTRA_NODES` | empty | Whitespace-separated extra hostnames to append (e.g. relays) |
+| `PORT` | `3001` | Producer N2N port |
+| `NETWORKMAGIC` | `42` | Cardano network magic for handshake |
+| `LIMIT` | `100` | Maximum number of blocks pulled per connection before disconnecting |
+| `NCONNS` | `100` | Number of concurrent connections per invocation |
+| `CHAINPOINT_FILEPATH` | (required) | File written by `tracer-sidecar` listing harvested chain points |
+
+## Wiring on `cardano_node_master`
+
+The adversary runs inside the `sidecar` service. The relevant compose
+fragment in [`testnets/cardano_node_master/docker-compose.yaml`][compose]:
+
+```yaml
+sidecar:
+  image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar@sha256:...
+  environment:
+    NETWORKMAGIC: 42
+    PORT: 3001
+    LIMIT: 100
+    POOLS: "3"
+    NCONNS: 1
+    CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+  volumes:
+    - tracer:/opt/cardano-tracer
+```
+
+Note `NCONNS: 1` on the deployed testnet — the value is intentionally
+conservative until we have signal on whether higher fan-out causes
+spurious findings.
 
 ## Build the image
 
+The adversary is published as part of the `sidecar` image (see
+[`components/sidecar/`][sidecar-comp]). It is also buildable
+standalone for local development.
+
 ### Nix
 
-1. Install Nix package manager from https://nixos.org/download.html
-2. Connect to the Cachix cache for faster builds
-    ```bash
-    nix shell nixpkgs#cachix -c cachix use paolino
-    ```
-2. Build the image
-    ```bash
-    nix build .#docker-image
-    version=$(nix eval --raw .#version)
-    docker load < ./result
-    ```
+```bash
+cd components/adversary
+nix build .#docker-image
+docker load < ./result
+```
 
-### Non-nix
+### Non-Nix
 
-There is a Dockerfile available
-1. Build the image
-    ```bash
-    version=$(cat ./version)
-    docker build -t ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:dev -f ./Dockerfile .
-    ```
+```bash
+cd components/adversary
+docker build \
+    -t ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:dev \
+    -f ./Dockerfile .
+```
 
-## Run the test script
+## Local test loop
 
-1. Change the image tag in the compose to `dev`
-    ```bash
-    test=../../testnets/cardano_node_master/docker-compose.yml
-    sed -i 's|ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:.*|ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:dev|' $test
-    ```
-2. Start the testnet
-    ```bash
-    docker compose -f $test up -d
-    ```
-3. Exec into the adversary container
-    ```bash
-    docker compose -f $test exec adversary /bin/bash
-    ```
-4. Run the script
-    ```bash
-    /opt/antithesis/test/v1/chain-sync-client/parallel_driver_flaky_chain_sync.sh
-    ```
+```bash
+just up
+docker compose -f testnets/cardano_node_master/docker-compose.yaml \
+    exec sidecar bash
+/opt/antithesis/test/v1/chain-sync-client/parallel_driver_flaky_chain_sync.sh
+```
 
+## Source layout
 
-## See Also
+```
+components/adversary/
+├── adversary.cabal
+├── app/Main.hs                          — argv parsing, point file load
+├── src/Adversary.hs                     — reexports + chain-point parse
+├── src/Adversary/Application.hs         — chain-sync state machine,
+│                                          repeatedAdversaryApplication
+├── src/Adversary/ChainSync/
+│   ├── Codec.hs                         — codec for Header/Point/Tip
+│   └── Connection.hs                    — connectToNode + Ouroboros
+├── composer/chain-sync-client/
+│   └── parallel_driver_flaky_chain_sync.sh
+├── test/                                — AdversarySpec.hs unit tests
+├── flake.nix
+└── Dockerfile
+```
 
-- link(s) to more detailed project documents
-- License: see LICENSE
-- Contributing: see CONTRIBUTING.md
-- Security: see SECURITY.md
+## See also
+
+- [Adversary roadmap](adversary-roadmap.md) — long-term plan: long-running daemon, parallel-driver fan-out, full tier list of misbehaviour archetypes, planned home in `lambdasistemi/cardano-node-clients`.
+- [#9][issue-9] — the chainpoint-file race that the driver tolerates.
+- [Network spec PDF][Netspec] — chain-sync mini-protocol on p. 21.
+- [ouroboros-network][Ouroboros] — the upstream library we depend on.
 - Other projects by [HAL][HAL]
 - Other projects by the [Cardano Foundation][CF]
 - About [Cardano][Cardano]
@@ -104,6 +166,9 @@ There is a Dockerfile available
 
 [Ouroboros]: https://github.com/IntersectMBO/ouroboros-network
 [Netspec]: https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf
+[issue-9]: https://github.com/cardano-foundation/cardano-node-antithesis/issues/9
+[sidecar-comp]: https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/components/sidecar
+[compose]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/testnets/cardano_node_master/docker-compose.yaml
 [HAL]: https://github.com/cardano-foundation/hal
 [CF]: https://github.com/cardano-foundation
 [Cardano]: https://cardano.org/

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,13 @@ This repository contains test assets and configurations for running [Antithesis]
 
 Docker containers that set up and drive the Antithesis test environment. Depending on their role, they range from simple wrappers around external executables to complex services for actively or passively testing Cardano Nodes.
 
-- `adversary/`: A node-to-node client that behaves maliciously to test the robustness of Cardano Node implementations.
+- `adversary/`: A node-to-node downstream chain-sync client that connects to producers from a random intersection point, pulls a bounded number of blocks, then disconnects. Today's surface is downstream-only; the long-term plan is a long-running daemon with parallel-driver fan-out (see [adversary roadmap](components/adversary-roadmap.md)).
+- `asteria-player/`: Long-running container that plays the [asteria](https://github.com/txpipe/asteria) game inside the cluster, driving real Plutus traffic (spend script, mint, reference inputs, validity bounds) under fault injection.
 - `configurator/`: Generates genesis files, node configuration, and signing keys for the testnet using the [testnet-generation-tool](https://github.com/cardano-foundation/testnet-generation-tool).
 - `config/`: Antithesis platform configuration container.
 - `sidecar/`: Network health checks and Antithesis assertions that validate testnet status.
 - `tracer-sidecar/`: Processes structured node logs from cardano-tracer into Antithesis assertions (chain convergence, error detection).
+- `tx-generator/`: Long-running daemon that submits well-formed ADA transfers via N2C; composer drivers fire `transact` and `refill` requests over its control socket.
 
 ## Testnets
 

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -16,7 +16,8 @@ This testnet exercises the node-to-node protocol across multiple cardano-node ve
 | **configurator** | Generates genesis files, node configs, and signing keys at startup |
 | **tracer** | cardano-tracer daemon collecting structured logs from all nodes |
 | **tracer-sidecar** | Processes tracer logs into Antithesis assertions (chain convergence, error detection) |
-| **sidecar** | Network health checks and Antithesis setup signal |
+| **sidecar** | Network health checks, the Antithesis setup signal, and the host of the chain-sync `adversary` driver (see [Adversary](../components/adversary.md)). |
+| **tx-generator** | Long-running daemon submitting well-formed ADA transfers via N2C (see `components/tx-generator/`). |
 | **asteria-bootstrap** | One-shot. Deploys asteria validators and creates the initial game UTxO. See [Asteria Player](../components/asteria-player.md). |
 | **asteria-player-1**, **asteria-player-2** | Long-running asteria game players. Drive realistic tx traffic (spendScript, mint, ref-inputs, validity bounds) through the cluster. |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Configurator: components/configurator.md
       - Config: components/config.md
       - Adversary: components/adversary.md
+      - Adversary roadmap: components/adversary-roadmap.md
       - Asteria Player: components/asteria-player.md
   - Testnets:
       - testnets/index.md


### PR DESCRIPTION
Closes #87.

## Why

`docs/components/adversary.md` was a 2023-style design pitch that described both downstream and upstream node-to-node modes as if equally implemented. Only the chain-sync downstream client exists. Anyone planning the next adversary work was building on an inaccurate baseline.

This PR is the gating doc-only step before any code work on the adversary. Subsequent PRs (move daemon to `cardano-node-clients`, add new misbehaviour archetypes) will plan against an honest picture of today.

## What changed

### `docs/components/adversary.md` — full rewrite

Now describes what the binary actually does:

- Initiator-only N2N client, NodeToNodeV_14, chain-sync mini-protocol only.
- Reads chain points harvested by `tracer-sidecar` from real cardano-tracer logs.
- Spawns `NCONNS` concurrent connections; each picks a random starting point, sends `MsgFindIntersect`, loops `MsgRequestNext` until `LIMIT` blocks pulled, disconnects.
- Randomness from `newStdGen` — **not** the Antithesis hypervisor.
- Composer driver canonical copy lives in `components/sidecar/composer/chain-sync-client/`; the duplicate at `components/adversary/composer/chain-sync-client/` is for the local test loop.

Tables for env vars, the `cardano_node_master` compose fragment, build instructions, and the source-tree layout.

### `docs/components/adversary-roadmap.md` — new

The long-term plan as agreed in the brainstorm:

- **Architecture target**: copy the `tx-generator` shape — long-running daemon with `/state/adversary-control.sock`, composer scripts firing one NDJSON request per Antithesis tick, SDK `reachable`/`sometimes`/`always` per action.
- **Home of the daemon**: `lambdasistemi/cardano-node-clients`, alongside `cardano-tx-generator`. This repo keeps only the image-tag pin, composer drivers, and compose wiring.
- **Tier list of misbehaviour archetypes**:
  - Tier 1 (port today's surface): `chain_sync_flap`, `chain_sync_thrash`, `chain_sync_slow_loris`.
  - Tier 2 (other mini-protocols, downstream): `block_fetch_replay`, `tx_submission_flood`, `tx_submission_garbage`, `keepalive_abuse`.
  - Tier 3 (upstream-peer Byzantine adversary): `upstream_fork_serve`, `upstream_equivocate`, `upstream_too_far_ahead`, `upstream_long_rollback`.
  - Tier 4 (N2C abuse): `lsq_flood`, `local_tx_submission_garbage`.
- **Sequenced PR plan** A → E covering: this doc PR, daemon scaffold, `chain_sync_flap` port, this repo's switch to consuming the new image, the rest of Tier 1.

### `docs/index.md`

Adversary line no longer claims upstream-peer behaviour. Adds entries for `asteria-player` and `tx-generator` so the components list matches today's build.

### `docs/testnets/cardano-node-master.md`

Adds `tx-generator` to the supporting-services table; clarifies that the `sidecar` row is also where the chain-sync adversary driver lives.

### `mkdocs.yml`

Adds the new roadmap page to the nav.

## Out of scope (explicit)

- No code changes. The adversary binary, the composer driver, and the compose wiring are unchanged.
- The move to `cardano-node-clients` and any new misbehaviour archetype are tracked under the roadmap epic (filed separately on top of this doc landing).

## Verification

`nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs build --strict` builds clean.