### PR TITLE
ci: deploy surge preview for every docs PR

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -49,7 +49,11 @@ jobs:
           # repo alias to stay under the 63-char DNS label
           # limit.
           DOMAIN="cf-cna-pr-${{ github.event.number }}.surge.sh"
-          nix shell nixpkgs#nodePackages.surge -c surge \
+          # Pin nixpkgs to nixos-25.05 because nodePackages was
+          # removed from nixpkgs-unstable on 2026-03-03; the
+          # 25.05 channel still ships surge 0.23.1.
+          nix shell github:NixOS/nixpkgs/nixos-25.05#nodePackages.surge \
+            -c surge \
             surge-site \
             "${DOMAIN}" \
             --token "${SURGE_TOKEN}"

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,96 @@
+name: PR preview
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build documentation site
+        run: |
+          nix develop github:paolino/dev-assets?dir=mkdocs \
+            -c mkdocs build --strict --site-dir site
+
+      - name: Deploy to Surge
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          if [ -z "${SURGE_TOKEN}" ]; then
+            echo "::error::SURGE_TOKEN secret is not set on the repo." \
+              "Generate one with 'nix shell nixpkgs#nodePackages.surge" \
+              "-c surge token' and add it via" \
+              "'gh secret set SURGE_TOKEN --repo" \
+              "${{ github.repository }} --body \"<token>\"'."
+            exit 1
+          fi
+          mkdir -p surge-site
+          cp -RL site/. surge-site/
+          chmod -R u+w surge-site
+          # Compose the subdomain. cardano-foundation +
+          # cardano-node-antithesis is long, so use a short
+          # repo alias to stay under the 63-char DNS label
+          # limit.
+          DOMAIN="cf-cna-pr-${{ github.event.number }}.surge.sh"
+          nix shell nixpkgs#nodePackages.surge -c surge \
+            surge-site \
+            "${DOMAIN}" \
+            --token "${SURGE_TOKEN}"
+          echo "PREVIEW_URL=https://${DOMAIN}" >> "$GITHUB_ENV"
+
+      - name: Upsert preview comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL;
+            const marker = '<!-- surge-preview-url -->';
+            const body = [
+              marker,
+              ':rocket: **Documentation preview**',
+              '',
+              `Preview: ${url}`,
+              '',
+              `Built from \`${context.sha.slice(0, 7)}\`.`,
+              'The preview updates on every push to this branch.',
+            ].join('\n');
+            const { data: comments } =
+              await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+            const existing = comments.find(
+              (c) => c.body && c.body.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
Closes #92.

## Why

Doc PRs (e.g. #88) are reviewed by reading raw markdown. There is no rendered preview between PR open and merge — only `deploy-docs.yaml` on main fires the live site. This adds a per-PR surge.sh preview so reviewers see the rendered site before merging.

## What

New workflow `.github/workflows/pr-preview.yaml`:

- On every PR opened against `main` (and on `workflow_dispatch`), build the mkdocs site with `--strict` and deploy it to `https://cf-cna-pr-<N>.surge.sh`.
- Subdomain shortened to `cf-cna-pr-<N>` — the obvious `cardano-foundation-cardano-node-antithesis-pr-<N>.surge.sh` exceeds the 63-char DNS label limit at moderate PR numbers, so we use a stable short alias up front.
- Upsert a single hidden-marker comment on the PR (`<!-- surge-preview-url -->`) with the preview URL; subsequent pushes to the same PR update the same comment.
- `concurrency` group cancels stale runs of this workflow on the same PR.
- Fails loudly with an actionable error if `SURGE_TOKEN` is missing — message points at the exact `gh secret set` command to fix it.

## One-time manual step

Before this can run successfully, set the `SURGE_TOKEN` secret on the repo:

```bash
nix shell nixpkgs#nodePackages.surge -c surge token
gh secret set SURGE_TOKEN --repo cardano-foundation/cardano-node-antithesis --body "<token>"
```

The repo already has `CACHIX_AUTH_TOKEN`; only `SURGE_TOKEN` is new.

## Verification

This PR triggers the workflow on itself. The first successful run will publish to `https://cf-cna-pr-<this-PR-number>.surge.sh` and post the URL as a comment.

After this lands, every subsequent PR — including the still-open #88 once you push to it — gets a preview automatically.

## Convention

The full surge-preview pattern is documented in the team's `documentation` skill (workflow template, comment-upsert pattern, Nix-store quirks). This workflow is a direct application of that template, scoped to mkdocs.