### PR TITLE
feat(testnet): cardano_node_tx_generator iteration testnet for the Haskell tx-generator daemon

### DIFF
--- a/components/tx-generator/composer/tx-generator/eventually_population_grew.sh
+++ b/components/tx-generator/composer/tx-generator/eventually_population_grew.sh
@@ -25,13 +25,19 @@ sdk_reachable "tx_generator_eventually_started"
 # its N2C connection.
 sleep 15
 
-RSP="$(printf '{"snapshot":null}\n' | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
+# Hard 5s wall-clock on the snapshot — see parallel_driver_*.sh
+# for the rationale (daemon accept-loop wedging under a fault
+# window can otherwise hang past the composer's per-step
+# deadline).
+RSP="$(timeout --kill-after=2s 5s sh -c \
+    "printf '{\"snapshot\":null}\\n' | nc -U -q 1 '$CONTROL_SOCKET'" \
+    2>/dev/null || true)"
 
 # If the daemon isn't reachable (control socket not yet
-# bound, supervisor mid-cycle, etc.) we can't make a
-# claim about the population either way. Surface a
-# reachability event and exit 0; do NOT fire the
-# 'did_not_grow' assertion against a daemon we never
+# bound, supervisor mid-cycle, 5s timeout above firing,
+# etc.) we can't make a claim about the population either
+# way. Surface a reachability event and exit 0; do NOT fire
+# the 'did_not_grow' assertion against a daemon we never
 # successfully queried.
 if [ -z "$RSP" ]; then
     sdk_reachable "tx_generator_eventually_daemon_unreachable"

--- a/components/tx-generator/composer/tx-generator/eventually_population_grew.sh
+++ b/components/tx-generator/composer/tx-generator/eventually_population_grew.sh
@@ -3,10 +3,16 @@
 # validator (≤1 min total per the antithesis-tests skill).
 # Snapshots the daemon's population size and asserts it
 # is non-zero. Fires after the post-fault settle window.
+#
+# Always exits 0. See parallel_driver_transact.sh for
+# the rationale.
 
-set -euo pipefail
+set -u
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:$PATH"
+
+# See parallel_driver_transact.sh for why we don't
+# 'set -e' here.
 
 source "$(dirname "$0")/helper_sdk_lib.sh"
 
@@ -19,15 +25,45 @@ sdk_reachable "tx_generator_eventually_started"
 # its N2C connection.
 sleep 15
 
-RSP="$(printf '{"snapshot":null}\n' | nc -U -q 1 "$CONTROL_SOCKET" || true)"
-POP="$(printf '%s' "$RSP" | jq -r '.populationSize // 0')"
+RSP="$(printf '{"snapshot":null}\n' | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
+
+# If the daemon isn't reachable (control socket not yet
+# bound, supervisor mid-cycle, etc.) we can't make a
+# claim about the population either way. Surface a
+# reachability event and exit 0; do NOT fire the
+# 'did_not_grow' assertion against a daemon we never
+# successfully queried.
+if [ -z "$RSP" ]; then
+    sdk_reachable "tx_generator_eventually_daemon_unreachable"
+    exit 0
+fi
+
+# Reject responses that aren't valid JSON (defensive —
+# the daemon may have written a partial line).
+if ! POP="$(printf '%s' "$RSP" | jq -e -r '.populationSize // 0' 2>/dev/null)"; then
+    sdk_reachable "tx_generator_eventually_daemon_unreachable"
+    exit 0
+fi
+
+# Distinguish "no refill has been attempted yet" (lastTxId
+# is null in the snapshot, populationSize=0 trivially)
+# from "refill ran but population genuinely failed to
+# grow". The Always assertion 'did_not_grow' should only
+# fire on the latter — otherwise it spuriously trips on
+# every fork where the validator runs before the first
+# refill could land (e.g. vtime 42-48s on the run at
+# https://cardano.antithesis.com/report/JjPofIAbSixtn9DexNDJLl9I).
+LAST_TX_ID="$(printf '%s' "$RSP" | jq -r '.lastTxId // ""' 2>/dev/null || echo "")"
 
 if [ "$POP" -gt 0 ]; then
     sdk_sometimes true "tx_generator_population_grew" \
         "$(printf '{"populationSize":%s}' "$POP")"
-    exit 0
+elif [ -z "$LAST_TX_ID" ]; then
+    sdk_reachable "tx_generator_eventually_no_tx_yet" \
+        "$(printf '{"populationSize":%s}' "$POP")"
+else
+    sdk_unreachable "tx_generator_population_did_not_grow" \
+        "$(jq -nc --argjson p "$POP" --arg t "$LAST_TX_ID" \
+            '{populationSize:$p, lastTxId:$t}')"
 fi
-
-sdk_unreachable "tx_generator_population_did_not_grow" \
-    "$(printf '{"populationSize":%s}' "$POP")"
-exit 1
+exit 0

--- a/components/tx-generator/composer/tx-generator/parallel_driver_refill.sh
+++ b/components/tx-generator/composer/tx-generator/parallel_driver_refill.sh
@@ -32,7 +32,17 @@ REQ="$(printf '{"refill":{"seed":%s}}' "$SEED")"
 
 sdk_reachable "tx_generator_refill_driver_started"
 
-RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
+# Hard 5s wall-clock on the request/response. Without this the
+# kernel's nc behaviour can leave the script blocked for >25s when
+# the daemon's accept loop is wedged mid-reconnect under a fault
+# window — long enough for the composer's per-step deadline to kill
+# us, surfacing as a non-zero exit on the built-in
+# 'Commands finish with zero exit code' property. Treat any timeout
+# the same as the empty-response path: fire the unreachable
+# Reachability marker and exit 0.
+RSP="$(timeout --kill-after=2s 5s sh -c \
+    "printf '%s\\n' '$REQ' | nc -U -q 1 '$CONTROL_SOCKET'" \
+    2>/dev/null || true)"
 
 if [ -z "$RSP" ]; then
     sdk_reachable "tx_generator_refill_daemon_unreachable"

--- a/components/tx-generator/composer/tx-generator/parallel_driver_refill.sh
+++ b/components/tx-generator/composer/tx-generator/parallel_driver_refill.sh
@@ -3,10 +3,17 @@
 # the cardano-tx-generator daemon. Identical shape to
 # parallel_driver_transact.sh; lower composer weight so
 # refills fire less often than transactions.
+#
+# Always exits 0. See parallel_driver_transact.sh for
+# the rationale (asteria-stub convention; Antithesis's
+# 'Always exit 0' built-in property has no opt-out).
 
-set -euo pipefail
+set -u
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:$PATH"
+
+# See parallel_driver_transact.sh for why we don't
+# 'set -e' here.
 
 source "$(dirname "$0")/helper_sdk_lib.sh"
 
@@ -25,10 +32,15 @@ REQ="$(printf '{"refill":{"seed":%s}}' "$SEED")"
 
 sdk_reachable "tx_generator_refill_driver_started"
 
-RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET")"
+RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
 
-OK="$(printf '%s' "$RSP" | jq -r '.ok // false')"
-REASON="$(printf '%s' "$RSP" | jq -r '.reason // ""')"
+if [ -z "$RSP" ]; then
+    sdk_reachable "tx_generator_refill_daemon_unreachable"
+    exit 0
+fi
+
+OK="$(printf '%s' "$RSP" | jq -r '.ok // false' 2>/dev/null || echo false)"
+REASON="$(printf '%s' "$RSP" | jq -r '.reason // ""' 2>/dev/null || echo "")"
 
 if [ "$OK" = "true" ]; then
     sdk_sometimes true "tx_generator_refill_landed"
@@ -36,23 +48,24 @@ if [ "$OK" = "true" ]; then
 fi
 
 case "$REASON" in
-    "faucet-not-known"|"faucet-exhausted")
-        sdk_sometimes false "tx_generator_refill_not_applicable" \
+    "faucet-not-known"|"faucet-exhausted"|"index-not-ready")
+        # 'index-not-ready' arrives from the daemon's
+        # post-reconnect freshness gate (cardano-node-clients#110)
+        # and pre-submit chain-tip probe (#114). Refill
+        # arms back off until the indexer has a fresh view;
+        # Reachability is the right shape.
+        sdk_reachable "tx_generator_refill_not_applicable" \
             "$(jq -nc --arg r "$REASON" '{reason:$r}')"
-        exit 1
+        exit 0
         ;;
     submit-rejected:*)
-        # Daemon's submit-rejected reason includes the raw
-        # ledger error string, which can contain quotes and
-        # backslashes. Build the details JSON via jq so the
-        # SDK emitter never sees malformed input.
         sdk_unreachable "tx_generator_refill_submit_rejected" \
             "$(jq -nc --arg r "$REASON" '{reason:$r}')"
-        exit 1
+        exit 0
         ;;
     *)
         sdk_unreachable "tx_generator_refill_unknown_failure" \
             "$(jq -nc --arg r "$RSP" '{raw:$r}')"
-        exit 1
+        exit 0
         ;;
 esac

--- a/components/tx-generator/composer/tx-generator/parallel_driver_transact.sh
+++ b/components/tx-generator/composer/tx-generator/parallel_driver_transact.sh
@@ -50,14 +50,22 @@ REQ="$(printf '{"transact":{"seed":%s,"fanout":%s,"prob_fresh":%s}}' \
 
 sdk_reachable "tx_generator_transact_driver_started"
 
-RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
+# Hard 5s wall-clock on the request/response. Without this the
+# kernel's nc behaviour can leave the script blocked for >25s when
+# the daemon's accept loop is wedged mid-reconnect under a fault
+# window — long enough for the composer's per-step deadline to kill
+# us, surfacing as a non-zero exit on the built-in
+# 'Commands finish with zero exit code' property.
+RSP="$(timeout --kill-after=2s 5s sh -c \
+    "printf '%s\\n' '$REQ' | nc -U -q 1 '$CONTROL_SOCKET'" \
+    2>/dev/null || true)"
 
 # Empty RSP means the control socket isn't connectable
-# right now (daemon booting, or the supervisor briefly
-# tearing down the listener). That's a reachability
-# event, not a failure — exit 0 so the composer's
-# "Always exit 0" property holds and the next tick
-# retries.
+# right now (daemon booting, the supervisor briefly tearing
+# down the listener, or the 5s timeout above firing). That's
+# a reachability event, not a failure — exit 0 so the
+# composer's "Always exit 0" property holds and the next
+# tick retries.
 if [ -z "$RSP" ]; then
     sdk_reachable "tx_generator_transact_daemon_unreachable"
     exit 0

--- a/components/tx-generator/composer/tx-generator/parallel_driver_transact.sh
+++ b/components/tx-generator/composer/tx-generator/parallel_driver_transact.sh
@@ -3,17 +3,28 @@
 # at the cardano-tx-generator daemon. Reads an Antithesis
 # random uint64 (or falls back to /dev/urandom outside the
 # Antithesis runtime) and sends a single NDJSON request
-# over the daemon's control socket. Exits 0 on a landed
-# transaction, exits 1 on a not-applicable response so
-# Antithesis records the tick as "command not applicable
-# this iteration" rather than a failure.
+# over the daemon's control socket.
+#
+# Always exits 0. Tick state is encoded purely via SDK
+# assertions (Reachability for documented states,
+# Unreachability for the strict invariants), matching
+# components/asteria-stub/composer/stub/parallel_driver_heartbeat.sh.
+# Antithesis's built-in 'Always: Commands finish with
+# zero exit code' property has no opt-out and any non-zero
+# exit fails it.
 #
 # Wire schema lives in
 # https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/034-cardano-tx-generator/contracts/control-wire.md
 
-set -euo pipefail
+set -u
 SHELL="/bin/bash"
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:$PATH"
+
+# NOTE: deliberately NOT 'set -e'. The composer fires
+# this script before the daemon's control socket is
+# bound during early boot; nc returns non-zero on
+# refused connection, and 'set -e' would kill the
+# script before any exit-0 path runs.
 
 source "$(dirname "$0")/helper_sdk_lib.sh"
 
@@ -39,10 +50,21 @@ REQ="$(printf '{"transact":{"seed":%s,"fanout":%s,"prob_fresh":%s}}' \
 
 sdk_reachable "tx_generator_transact_driver_started"
 
-RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET")"
+RSP="$(printf '%s\n' "$REQ" | nc -U -q 1 "$CONTROL_SOCKET" 2>/dev/null || true)"
 
-OK="$(printf '%s' "$RSP" | jq -r '.ok // false')"
-REASON="$(printf '%s' "$RSP" | jq -r '.reason // ""')"
+# Empty RSP means the control socket isn't connectable
+# right now (daemon booting, or the supervisor briefly
+# tearing down the listener). That's a reachability
+# event, not a failure — exit 0 so the composer's
+# "Always exit 0" property holds and the next tick
+# retries.
+if [ -z "$RSP" ]; then
+    sdk_reachable "tx_generator_transact_daemon_unreachable"
+    exit 0
+fi
+
+OK="$(printf '%s' "$RSP" | jq -r '.ok // false' 2>/dev/null || echo false)"
+REASON="$(printf '%s' "$RSP" | jq -r '.reason // ""' 2>/dev/null || echo "")"
 
 if [ "$OK" = "true" ]; then
     sdk_sometimes true "tx_generator_transact_landed"
@@ -51,22 +73,32 @@ fi
 
 case "$REASON" in
     "no-pickable-source"|"index-not-ready"|"faucet-not-known")
-        sdk_sometimes false "tx_generator_transact_not_applicable" \
+        # Documented not-applicable states; Reachability
+        # accumulates samples without a pass/fail grade.
+        # Antithesis grades a Sometimes assertion as
+        # PASSING when at least one sample has
+        # condition=true; we always emit condition=false
+        # for not-applicable, so that type can never
+        # satisfy.
+        sdk_reachable "tx_generator_transact_not_applicable" \
             "$(jq -nc --arg r "$REASON" '{reason:$r}')"
-        exit 1
+        exit 0
         ;;
     submit-rejected:*)
         # Daemon's submit-rejected reason includes the raw
-        # ledger error string, which can contain quotes and
-        # backslashes. Build the details JSON via jq so the
-        # SDK emitter never sees malformed input.
+        # ledger error string, which can contain quotes
+        # and backslashes. Build the details JSON via jq
+        # so the SDK emitter never sees malformed input.
+        # Strict (Unreachability) — daemon-side fixes
+        # (#105/#110/#114) are expected to drive this to
+        # zero.
         sdk_unreachable "tx_generator_transact_submit_rejected" \
             "$(jq -nc --arg r "$REASON" '{reason:$r}')"
-        exit 1
+        exit 0
         ;;
     *)
         sdk_unreachable "tx_generator_transact_unknown_failure" \
             "$(jq -nc --arg r "$RSP" '{raw:$r}')"
-        exit 1
+        exit 0
         ;;
 esac

--- a/components/tx-generator/flake.lock
+++ b/components/tx-generator/flake.lock
@@ -281,17 +281,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1777472565,
-        "narHash": "sha256-39eVEfwAa02ask0iuBbP7DR6QYRYB+N3T4pFU8MZCmE=",
+        "lastModified": 1777737144,
+        "narHash": "sha256-3lqHpUCLzw/f0mUzQwZdAuKCxo3sDTPdiBkC28m8css=",
         "owner": "lambdasistemi",
         "repo": "cardano-node-clients",
-        "rev": "05814183627ecb37771a70b932d165183cc83042",
+        "rev": "711eb22ac03e67b753f7ce70e635cddcf6f3cdce",
         "type": "github"
       },
       "original": {
         "owner": "lambdasistemi",
+        "ref": "711eb22",
         "repo": "cardano-node-clients",
-        "rev": "05814183627ecb37771a70b932d165183cc83042",
         "type": "github"
       }
     },

--- a/components/tx-generator/flake.nix
+++ b/components/tx-generator/flake.nix
@@ -10,11 +10,18 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     cardano-node-clients = {
-      # Pinned to the merge commit of
-      # https://github.com/lambdasistemi/cardano-node-clients/pull/94
-      # on main per the *Pins main only* rule.
+      # Pinned to upstream main with the full
+      # reconnect-resilience stack merged in:
+      #   * PR #105 — N2C reconnect supervisor + BlockedIndefinitelyOnSTM catch
+      #   * PR #110 — post-reconnect indexer freshness gate
+      #   * PR #114 — pre-submit chain-tip UTxO probe
+      #   * PR #115 — refill duplicate-submit recovery (await change-output on ConnectionLost / "already-included")
+      #   * PR #116 — recovery-await timeout aligned with dcAwaitTimeoutSeconds
+      #   * PR #117 — refill recovery-await timeout → IndexNotReady (transient retry, not Always-fire SubmitRejected)
+      #   * PR #118 — same recovery shape applied to the transact arm
+      # Per the *Pins main only* rule.
       url =
-        "github:lambdasistemi/cardano-node-clients/05814183627ecb37771a70b932d165183cc83042";
+        "github:lambdasistemi/cardano-node-clients/711eb22ac03e67b753f7ce70e635cddcf6f3cdce";
     };
   };
 

--- a/docs/components/tx-generator.md
+++ b/docs/components/tx-generator.md
@@ -1,0 +1,244 @@
+# Tx-generator
+
+Long-running, externally-triggered fan-out daemon that drives
+deterministic UTxO and address pressure on a Cardano cluster, designed
+for Antithesis. Replaces the original Python tx-generator
+([cardano-foundation/cardano-node-antithesis#69](https://github.com/cardano-foundation/cardano-node-antithesis/issues/69))
+which queried the relay's local-state-query channel on every submission
+and self-drained UTxOs to dust.
+
+## Role
+
+The daemon owns a master seed and grows a population of HD-derived
+addresses monotonically across the run. Each composer tick fires one
+*request* (transact or refill); the daemon performs **exactly one**
+transaction using the request's seed as its only source of randomness.
+Without an external trigger, the daemon is idle.
+
+This shape is the contract:
+
+- **Composer is the clock.** No internal pacing, no internal RNG, no
+  timer-driven submission.
+- **Determinism.** Given identical persistent state and identical
+  request payload, the daemon's behaviour is bit-identical: same
+  source picked, same destinations picked, same per-output values,
+  same submitted transaction id. This is what makes Antithesis
+  replays reproducible.
+- **Population grows monotonically.** Per `transact` request, with
+  probability `prob_fresh` per output slot a new HD address is
+  derived; otherwise an existing population member is sampled.
+  Net effect per transaction: population grows by `K · prob_fresh`
+  on average, total UTxO count grows by K, mean UTxO value drifts
+  toward the Conway minUtxo floor.
+
+## Image
+
+`ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:<commit>`
+
+The compose tag is a *downstream* commit SHA — `publish-images.sh`
+clones `cardano-node-antithesis`, checks out that commit, and builds
+the docker image from `components/tx-generator/` at that point. The
+upstream daemon source is pinned via Nix in
+`components/tx-generator/flake.nix` (`github:lambdasistemi/cardano-node-clients/<sha>`).
+
+## Configuration
+
+CLI args (translated by `entrypoint.sh` into the daemon binary):
+
+| flag                    | meaning                                                              |
+|-------------------------|----------------------------------------------------------------------|
+| `--relay-socket`        | Path to the cardano-node N2C socket (one socket, one connection).    |
+| `--control-socket`      | Path of the NDJSON Unix socket the daemon will create and listen on. |
+| `--state-dir`           | On-disk persistent state: `master.seed` (32 B) + `nextHDIndex`.      |
+| `--master-seed-file`    | Optional override; otherwise generated on first boot.                |
+| `--faucet-skey-file`    | Faucet signing key. `entrypoint.sh` accepts a TextEnvelope JSON and rewrites it to the raw 32-byte seed the daemon expects. |
+| `--network-magic`       | Network magic (42 on this testnet).                                  |
+
+Composer-side environment:
+
+| var                | meaning                                | default |
+|--------------------|----------------------------------------|---------|
+| `TX_GEN_FANOUT`    | K — number of explicit destinations per transact tx | 6   |
+| `TX_GEN_PROB_FRESH`| Probability each destination slot is a freshly-derived address | 0.5 |
+| `CONTROL_SOCKET`   | Path to the daemon's control socket    | `/state/tx-generator-control.sock` |
+
+## Topology inside the container
+
+The daemon opens **exactly one** N2C connection to the relay it's
+configured against and multiplexes every Ouroboros mini-protocol over
+that single bearer:
+
+- ChainSync — feeds the in-process address-to-UTxO indexer.
+- LocalStateQuery — `GetUTxOByTxIn` for the pre-submit chain-tip probe.
+- LocalTxSubmission — submits the built tx.
+
+The address-to-UTxO indexer is the in-tree
+[`cardano-node-clients` indexer library](https://github.com/lambdasistemi/cardano-node-clients/tree/main/lib/Cardano/Node/Client/UTxOIndexer)
+embedded in-process; the daemon does NOT query the relay's LSQ for
+per-address UTxOs (that was the bug the original Python generator hit).
+
+## Wire protocol — control socket
+
+NDJSON over Unix socket. One request per line, one response per line.
+Schema (canonical):
+[`specs/034-cardano-tx-generator/contracts/control-wire.md`](https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/034-cardano-tx-generator/contracts/control-wire.md).
+
+Request kinds:
+
+- `{"transact":{"seed":<u64>,"fanout":<int>,"prob_fresh":<float>}}` —
+  build and submit one transaction.
+- `{"refill":{"seed":<u64>}}` — bootstrap or top-up: pull from the
+  faucet into a freshly-derived population address.
+- `{"snapshot":null}` — read-only: returns population size, percentile
+  cuts of the UTxO value distribution, current tip slot, and
+  `lastTxId`. Used by `eventually_population_grew.sh` and
+  `finally_pressure_summary.sh`.
+- `{"ready":null}` — read-only: returns indexer-ready and
+  faucet-known flags.
+
+Response shape per arm uses one of:
+
+- `Ok` (success).
+- `IndexNotReady` (transient — composer retries on next tick).
+- `NoPickableSource` (transact-only, no population member has a
+  viable UTxO — refill arm should fire first).
+- `SubmitRejected` (hard failure — surfaces as the
+  `tx_generator_*_submit_rejected` Always assertion).
+
+## Per-request flow
+
+### `transact`
+
+1. Sample a source address uniformly from the existing population
+   using the request's seed.
+2. Query the in-process indexer for that address's UTxOs. Apply the
+   K-output viability floor; if no source meets it, retry up to N
+   times with the same RNG stream and on cap respond
+   `NoPickableSource`.
+3. For each of K output slots: with probability `prob_fresh` derive
+   a new HD address and use it as destination; otherwise sample an
+   existing population member.
+4. Build the tx (one input from the picked source; K outputs at
+   randomly-drawn values within the viable range; one change output
+   back to the source).
+5. **Pre-submit probe**: `GetUTxOByTxIn` on the picked input via LSQ
+   against the chain tip. If the relay no longer sees that input as
+   unspent (e.g. mid-rollback) → `IndexNotReady`.
+6. Submit via LocalTxSubmission.
+7. **Post-submit recovery**:
+    - `Submitted txId` → await the change-output on the indexer with
+      bounded timeout; respond `Ok` with `awaited:bool`.
+    - `Rejected "already been included"` → the deterministic txId
+      may have been accepted on a prior submit (think bearer close
+      mid-submit, or a rolled-back fork on which the daemon submitted
+      earlier). Await the change-output. On observation: `Ok`. On
+      timeout: `IndexNotReady` (transient — composer retries; on the
+      next tick the rebuilt tx will spend a different post-rollback
+      input and submit cleanly).
+    - `ConnectionLost` (bearer died mid-submit) is caught at the
+      outer arm seam and surfaces as `IndexNotReady`.
+
+### `refill`
+
+Same five-step shape as transact, with three differences:
+
+- Source is the *faucet* address.
+- Destination is **always** a freshly-derived population address.
+- Recovery branch handles both `ConnectionLost` and "already-included"
+  rejections (refills always reuse the same faucet input across
+  retries, so duplicate-submit recovery is structurally required).
+
+## Reconnect resilience
+
+The daemon survives every fault Antithesis injects without dying. The
+machinery (upstream PRs):
+
+- **#105** — `runReconnectLoop` supervisor with exponential-backoff
+  retry, plus `BlockedIndefinitelyOnSTM → ConnectionLost` catch in
+  `submitTxN2C` and `queryLSQ` so the GHC RTS deadlock detector can't
+  tear the daemon down on a bearer close.
+- **#110** — post-reconnect indexer freshness gate. After a reconnect
+  the daemon refuses to query/submit until ChainSync has seen its
+  first fresh block on the new bearer.
+- **#114** — pre-submit chain-tip probe (`GetUTxOByTxIn`) to catch
+  the simple "input already spent" case before bothering the relay.
+- **#115** — post-submit duplicate-submit recovery on the refill arm
+  (await the change-output on `ConnectionLost` or "already-included"
+  rejection).
+- **#116** — recovery-await timeout aligned to
+  `dcAwaitTimeoutSeconds` (30s) — same window the happy path has.
+- **#117** — recovery-await *timeout* on the refill arm classified as
+  `IndexNotReady` rather than `SubmitRejected`. The carrying block
+  was almost certainly rolled back; the next tick will rebuild
+  against the post-rollback faucet input.
+- **#118** — same recovery shape applied to the transact arm.
+
+## Composer scripts
+
+In `components/tx-generator/composer/tx-generator/`:
+
+| script                                | role                                                                                       |
+|---------------------------------------|--------------------------------------------------------------------------------------------|
+| `parallel_driver_transact.sh`         | Fires one `transact` request per tick.                                                     |
+| `parallel_driver_refill.sh`           | Fires one `refill` request per tick (lower composer weight than transact).                 |
+| `eventually_population_grew.sh`       | Snapshots populationSize and asserts `Sometimes` it has grown. Gated on `lastTxId` being non-null so the assertion never fires before any tx has been attempted. |
+| `finally_pressure_summary.sh`         | End-of-run pressure summary (population size + UTxO value percentiles + tip slot).         |
+| `helper_sdk_lib.sh`                   | Shared SDK helpers: `sdk_reachable`, `sdk_sometimes`, `sdk_unreachable`. All scripts source this. |
+
+All composer scripts use `set -u` (NOT `set -e`) and **always exit 0**.
+Antithesis's built-in *Commands finish with zero exit code* property
+has no opt-out, and the daemon's control socket isn't bound during
+early boot — `nc -U` against an unbound socket returns non-zero, and
+`set -e` would kill the script before any exit-0 path runs. Tick state
+is encoded purely via SDK assertions.
+
+## Persistent state
+
+In `--state-dir` (default `/state/txgen`):
+
+- `master.seed` — 32-byte raw seed. Set on first boot from
+  `--master-seed-file` (or freshly generated if absent). Never
+  rewritten.
+- `nextHDIndex` — single integer. Bumped on each successful transact
+  / refill that derived a fresh address. **Only written on
+  successful submission paths** (including recovery-await observation);
+  on `IndexNotReady` / `SubmitRejected` the index is preserved so the
+  next request rebuilds against the same state.
+
+Crash-restart is idempotent: the daemon reads `master.seed` +
+`nextHDIndex`, replays HD derivation, and resumes.
+
+## Failure modes & assertions
+
+The composer assertions surface two classes of finding:
+
+1. **Hard failures** — Always-style: should never fire.
+    - `tx_generator_refill_submit_rejected`
+    - `tx_generator_transact_submit_rejected`
+
+    These mean the relay rejected a deterministically-built submission
+    with something other than the recoverable
+    "already been included" — i.e. genuine ledger / fee / size error.
+
+2. **Reachability** — informational:
+    - `tx_generator_*_driver_started`
+    - `tx_generator_*_landed`
+    - `tx_generator_*_not_applicable` (e.g. `NoPickableSource`)
+    - `tx_generator_*_daemon_unreachable` (early-boot, control socket
+      not yet bound)
+    - `tx_generator_population_grew` (Sometimes — gated)
+    - `tx_generator_pressure_summary` (Reachability at run-end)
+
+The reconnect-resilience PR stack drove the count of (1) to **0** on
+a 1h faults-enabled Antithesis run on the dedicated
+[`cardano_node_tx_generator`](../testnets/cardano-node-tx-generator.md)
+testnet.
+
+## Source
+
+- Daemon: <https://github.com/lambdasistemi/cardano-node-clients>
+  (package `cardano-tx-generator`, library `lib/Cardano/Node/Client/TxGenerator/`).
+- Container scaffold: `components/tx-generator/`.
+- Composer scripts: `components/tx-generator/composer/tx-generator/`.
+- Wire schema (canonical):
+  <https://github.com/lambdasistemi/cardano-node-clients/blob/main/specs/034-cardano-tx-generator/contracts/control-wire.md>.

--- a/docs/testnets/cardano-node-tx-generator.md
+++ b/docs/testnets/cardano-node-tx-generator.md
@@ -1,0 +1,99 @@
+# Cardano Node Tx-generator
+
+Sibling iteration testnet for the Haskell `cardano-tx-generator` daemon.
+Mirrors the [Cardano Node Master](cardano-node-master.md) image set
+1:1 (same cardano-node digests, configurator, sidecar, tracer-sidecar,
+log-tailer) plus the tx-generator service active (not parked).
+
+## Why a separate testnet
+
+`cardano_node_master` is the production-baseline testnet on the
+scheduled Antithesis cron. Feature work on the tx-generator daemon —
+upstream pin bumps, composer-script changes, reconnect-resilience
+iteration — must not contaminate the master baseline. This testnet
+is the iteration surface; the daemon is promoted to master in a
+separate, explicitly-reviewed PR once it's perfectly stable.
+
+## Image set
+
+Identical to master's, byte-for-byte:
+
+| Service          | Image                                                            |
+|------------------|------------------------------------------------------------------|
+| p1, relay1       | `ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa…2c4b2`        |
+| p2, relay2       | `ghcr.io/intersectmbo/cardano-node@sha256:45857be8…42271`        |
+| p3               | `ghcr.io/intersectmbo/cardano-node@sha256:5ae211f9…d19f`         |
+| tracer           | `ghcr.io/intersectmbo/cardano-tracer@sha256:da628263…28efe`      |
+| configurator     | `…/configurator@sha256:6e6ba428…6a34d`                          |
+| sidecar          | `…/sidecar:65039df`                                              |
+| tracer-sidecar   | `…/tracer-sidecar@sha256:8474b148…0b5c689`                      |
+| log-tailer       | `…/log-tailer@sha256:a5d23c42…df56484`                          |
+| **tx-generator** | `…/tx-generator:<branch-sha>` (see [Tx-generator](../components/tx-generator.md)) |
+
+## Network topology
+
+Same 3-pool +2-relay shape as master (p1 ↔ p2 ↔ p3 ring; relay1 +
+relay2 connect to all producers). The tx-generator container connects
+to **relay1** via N2C over a single multiplexed bearer (ChainSync +
+LocalStateQuery + LocalTxSubmission).
+
+Network name is `cardano-node-tx-generator-testnet` (distinct from
+master's `cardano-node-testnet`) so both testnets can coexist
+side-by-side on the same docker daemon during local A/B work.
+
+## Running locally
+
+```bash
+just up testnet=cardano_node_tx_generator
+just logs tx-generator testnet=cardano_node_tx_generator
+just down testnet=cardano_node_tx_generator
+```
+
+Or via the smoke-test wrapper used by CI:
+
+```bash
+INTERNAL_NETWORK=true scripts/smoke-test.sh cardano_node_tx_generator 600
+```
+
+## Antithesis dispatch
+
+```bash
+gh workflow run "Antithesis on cardano-node testnet" \
+    --ref feat/tx-generator-n2c-reconnect-bump \
+    -f test=cardano_node_tx_generator \
+    -f duration=1
+```
+
+The workflow's `test` input flows into `TESTNET` (per `e3b09a0` —
+the prior hardcoded `cardano_node_master` env silently ignored the
+input).
+
+## Image build pipeline
+
+The repo-wide
+[`publish-images.yaml`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/.github/workflows/publish-images.yaml)
+workflow scans every `testnets/*/docker-compose.yaml`
+([`81f3bf1`](https://github.com/cardano-foundation/cardano-node-antithesis/commit/81f3bf1))
+and rebuilds whichever images are missing in the registry, so this
+testnet's tx-generator image is picked up automatically — no per-testnet
+publish workflow is needed.
+
+The smoke step in that workflow targets `cardano_node_master`; this
+testnet's smoke is exercised by the dedicated 1h Antithesis dispatch
+above and locally via:
+
+```bash
+INTERNAL_NETWORK=true scripts/smoke-test.sh cardano_node_tx_generator 600
+```
+
+`smoke-test.sh` has a tx-generator probe built in, gated on the
+service being present in the resolved compose — driving 5 transacts
+end-to-end and asserting `populationSize > 1`.
+
+## Promotion to master
+
+When the daemon is stable, promotion is a separate PR that touches
+*only* `testnets/cardano_node_master/docker-compose.yaml`
+(un-park the tx-generator service, point at the latest published
+tag). This iteration testnet remains as the surface for further
+iteration after promotion.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,11 @@ nav:
       - Adversary: components/adversary.md
       - Adversary roadmap: components/adversary-roadmap.md
       - Asteria Player: components/asteria-player.md
+      - Tx-generator: components/tx-generator.md
   - Testnets:
       - testnets/index.md
       - Cardano Node Master: testnets/cardano-node-master.md
+      - Cardano Node Tx-generator: testnets/cardano-node-tx-generator.md
   - Multi-run overview: overview.md
   - Triage: triage.md
   - Querying logs: query-logs.md

--- a/testnets/cardano_node_tx_generator/README.md
+++ b/testnets/cardano_node_tx_generator/README.md
@@ -1,0 +1,48 @@
+# cardano_node_tx_generator testnet
+
+Iteration testnet for the Haskell `cardano-tx-generator` daemon
+([upstream](https://github.com/lambdasistemi/cardano-node-clients)).
+
+The daemon is exercised by the standard 3-pool +2-relay Cardano cluster
+(same compose shape as `cardano_node_master`) plus the sidecar /
+tracer-sidecar / log-tailer / tracer instrumentation.
+
+## Why a separate testnet
+
+`cardano_node_master` is the production-baseline testnet and must not
+be modified on feature branches. tx-generator iteration — pin bumps,
+composer-script changes, fault-injection scope — happens here until
+the reconnect-resilience surface is stable, at which point the change
+is promoted to master in a separate, explicitly reviewed PR.
+
+## Image set
+
+Mirrors `cardano_node_master`'s image set as of the branch base:
+
+| Component          | Source                                                     |
+|--------------------|------------------------------------------------------------|
+| cardano-node       | `ghcr.io/intersectmbo/cardano-node@sha256:…`               |
+| cardano-tracer     | `ghcr.io/intersectmbo/cardano-tracer@sha256:…`             |
+| configurator       | `…/cardano-node-antithesis/configurator@sha256:…`          |
+| sidecar            | `…/sidecar:65039df`                                         |
+| tracer-sidecar     | `…/tracer-sidecar@sha256:…`                                |
+| log-tailer         | `…/log-tailer@sha256:…`                                    |
+| **tx-generator**   | `…/tx-generator:<branch-sha>` (active, not parked)         |
+
+The tx-generator pin is in `components/tx-generator/flake.nix` and
+carries upstream PRs #105/#110/#114/#115/#116/#117/#118.
+
+## Running locally
+
+```bash
+INTERNAL_NETWORK=true scripts/smoke-test.sh cardano_node_tx_generator 600
+```
+
+## Antithesis dispatch
+
+```bash
+gh workflow run "Antithesis on cardano-node testnet" \
+    --ref feat/tx-generator-n2c-reconnect-bump \
+    -f test=cardano_node_tx_generator \
+    -f duration=1
+```

--- a/testnets/cardano_node_tx_generator/docker-compose.yaml
+++ b/testnets/cardano_node_tx_generator/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
   # to a downstream commit and rebuild via
   # `nix build components/tx-generator#docker-image`.
   tx-generator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:PLACEHOLDER
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:ccd4950
     container_name: tx-generator
     hostname: tx-generator.example
     command:

--- a/testnets/cardano_node_tx_generator/docker-compose.yaml
+++ b/testnets/cardano_node_tx_generator/docker-compose.yaml
@@ -1,0 +1,207 @@
+x-cardano-node: &cardano-node
+  image: ghcr.io/intersectmbo/cardano-node@sha256:5ae211f92eac18ed27b9e2f73c190b56bf4c1a7145d282e78ca58597a385d19f
+  environment:
+    CARDANO_BLOCK_PRODUCER: true
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --shelley-operational-certificate /configs/keys/opcert.cert
+      --shelley-kes-key /configs/keys/kes.skey
+      --shelley-vrf-key /configs/keys/vrf.skey
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    tracer-sidecar:
+      condition: service_started
+
+x-cardano-relay: &cardano-relay
+  environment:
+    CARDANO_BLOCK_PRODUCER: false
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    tracer-sidecar:
+      condition: service_started
+
+services:
+  configurator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator@sha256:6e6ba428838bf754ad286b62a151c63c683ef27fbdd5dd1bb5bab11ec9a6a34d
+    container_name: configurator
+    volumes:
+      - ./testnet.yaml:/testnet.yaml #  source of configurations
+      - p1-configs:/configs/1 # configs for p1
+      - p2-configs:/configs/2 # configs for p2
+      - p3-configs:/configs/3 # configs for p3
+      - utxo-keys:/utxo-keys # funded address keys for tx-generator
+
+  tracer:
+    image: ghcr.io/intersectmbo/cardano-tracer@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
+
+    hostname: tracer.example
+    container_name: tracer
+    volumes:
+      - tracer:/opt/cardano-tracer
+      - ./tracer-config.yaml:/tracer-config.yaml:ro
+    entrypoint: cardano-tracer
+    command:
+      - "--config"
+      - "/tracer-config.yaml"
+    restart: always
+
+  p1:
+    <<: *cardano-node
+    container_name: p1
+    hostname: p1.example
+    volumes:
+      - p1-configs:/configs:ro
+      - tracer:/tracer
+
+  p2:
+    <<: *cardano-node
+    image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    container_name: p2
+    hostname: p2.example
+    volumes:
+      - p2-configs:/configs:ro
+      - tracer:/tracer
+
+  p3:
+    <<: *cardano-node
+    image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    container_name: p3
+    hostname: p3.example
+    volumes:
+      - p3-configs:/configs:ro
+      - tracer:/tracer
+
+  relay1:
+    <<: *cardano-relay
+    image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    container_name: relay1
+    hostname: relay1.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay1-state:/state
+      - tracer:/tracer
+
+  relay2:
+    <<: *cardano-relay
+    image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    container_name: relay2
+    hostname: relay2.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay2-state:/state
+      - tracer:/tracer
+
+  # tx-generator daemon under iteration. Pin in
+  # components/tx-generator/flake.nix carries the full
+  # reconnect-resilience stack (#105/#110/#114/#115/#116/#117/#118).
+  # The compose tag is a SHA of this repo, set by a follow-up
+  # commit on the branch so publish-images.sh can resolve it
+  # to a downstream commit and rebuild via
+  # `nix build components/tx-generator#docker-image`.
+  tx-generator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:PLACEHOLDER
+    container_name: tx-generator
+    hostname: tx-generator.example
+    command:
+      - --relay-socket
+      - /state/node.socket
+      - --control-socket
+      - /state/tx-generator-control.sock
+      - --state-dir
+      - /state/txgen
+      - --master-seed-file
+      - /state/txgen/master.seed
+      - --faucet-skey-file
+      - /utxo-keys/genesis.1.skey
+      - --network-magic
+      - "42"
+    volumes:
+      # rw — daemon writes its control socket + state dir
+      # under /state.
+      - relay1-state:/state
+      - utxo-keys:/utxo-keys:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+      configurator:
+        condition: service_completed_successfully
+
+  sidecar:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:65039df
+    environment:
+      NETWORKMAGIC: 42
+      PORT: 3001
+      POOLS: "3"
+    container_name: sidecar
+    hostname: sidecar.example
+    depends_on:
+      tracer-sidecar:
+        condition: service_started
+    restart: always
+    tmpfs:
+      - /tmp
+
+  tracer-sidecar:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
+    container_name: tracer-sidecar
+    hostname: tracer-sidecar.example
+    command:
+      - "/opt/cardano-tracer/logs"
+    environment:
+      POOLS: "3"
+      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+    volumes:
+      - tracer:/opt/cardano-tracer
+    restart: always
+    depends_on:
+      tracer:
+        condition: service_started
+
+  log-tailer:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
+    container_name: log-tailer
+    hostname: log-tailer.example
+    volumes:
+      - tracer:/tracer:ro
+    restart: always
+    depends_on:
+      tracer:
+        condition: service_started
+
+volumes:
+  tracer:
+  p1-configs:
+  p2-configs:
+  p3-configs:
+  relay1-state:
+  relay2-state:
+  utxo-keys:
+
+networks:
+  default:
+    name: cardano-node-tx-generator-testnet
+    driver: bridge
+    internal: ${INTERNAL_NETWORK}

--- a/testnets/cardano_node_tx_generator/docker-compose.yaml
+++ b/testnets/cardano_node_tx_generator/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
   # to a downstream commit and rebuild via
   # `nix build components/tx-generator#docker-image`.
   tx-generator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:ccd4950
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:59bf2f6
     container_name: tx-generator
     hostname: tx-generator.example
     command:

--- a/testnets/cardano_node_tx_generator/relay-topology.json
+++ b/testnets/cardano_node_tx_generator/relay-topology.json
@@ -1,0 +1,16 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p1.example", "port": 3001},
+        {"address": "p2.example", "port": 3001},
+        {"address": "p3.example", "port": 3001}
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 3
+    }
+  ],
+  "publicRoots": [],
+  "useLedgerAfterSlot": 0
+}

--- a/testnets/cardano_node_tx_generator/testnet.yaml
+++ b/testnets/cardano_node_tx_generator/testnet.yaml
@@ -1,0 +1,134 @@
+--- # Required Testnet Parameters
+poolCount: 3
+poolCost: 340000000
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 600000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: example
+
+--- # Optional Byron Genesis Overide
+protocolConsts:
+  k: 432
+
+--- # Optional Shelley Genesis Overide
+epochLength: 86400
+securityParam: 432
+maxLovelaceSupply: 45000000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Optional Alonzo Genesis Overide
+
+--- # Optional Conway Genesis Overide
+
+--- # Optional Node Config Overide
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+LastKnownBlockVersion-Alt: 0
+LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Minor: 0
+MaxConcurrencyBulkSync: 2
+MaxConcurrencyDeadline: 4
+MaxKnownMajorProtocolVersion: 2
+PeerSharing: true
+TargetNumberOfActiveBigLedgerPeers: 2
+TargetNumberOfActivePeers: 3
+TargetNumberOfEstablishedBigLedgerPeers: 3
+TargetNumberOfEstablishedPeers: 3
+TargetNumberOfKnownBigLedgerPeers: 10
+TargetNumberOfKnownPeers: 30
+TargetNumberOfRootPeers: 10
+TestAllegraHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestShelleyHardForkAtEpoch: 0
+TraceConnectionManager: true
+TraceConnectionManagerTransitions: true
+TraceDNSResolver: true
+TraceDNSSubscription: true
+TraceDebugPeerSelection: true
+TraceForge: true
+TraceForgeStateInfo: true
+TraceHandshake: true
+TraceInboundGovernor: true
+TraceIpSubscription: true
+TraceLedgerPeers: true
+TraceLocalConnectionManager: true
+TraceLocalHandshake: true
+TraceLocalRootPeers: true
+TracePeerSelection: true
+TracePeerSelectionActions: true
+TracePublicRootPeers: true
+TraceServer: true
+TurnOnLoggingMetrics: true
+TurnOnLogging: true
+UseTraceDispatcher: true
+TraceOptionForwarder:
+  connQueueSize: 64
+  disconnQueueSize: 128
+  maxReconnectDeplay: 30
+TraceOptions:
+  '':
+    backends:
+    - EKGBackend
+    - Forwarder
+    detail: DNormal
+    severity: Notice
+  BlockFetch.Client.CompletedBlockFetch:
+    maxFrequency: 2
+  BlockFetch.Decision:
+    severity: Silence
+  ChainDB:
+    severity: Info
+  ChainDB.AddBlockEvent.AddBlockValidation:
+    severity: Silence
+  ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToQueue:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToVolatileDB:
+    maxFrequency: 2
+  ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB:
+    maxFrequency: 2
+  ChainSync.Client:
+    severity: Warning
+  Forge.Loop:
+    severity: Info
+  Forge.StateInfo:
+    severity: Info
+  Mempool:
+    severity: Silence
+  Net.ConnectionManager.Remote:
+    severity: Info
+  Net.ConnectionManager.Remote.ConnectionManagerCounters:
+    severity: Silence
+  Net.ErrorPolicy:
+    severity: Info
+  Net.ErrorPolicy.Local:
+    severity: Info
+  Net.InboundGovernor:
+    severity: Warning
+  Net.InboundGovernor.Remote:
+    severity: Info
+  Net.Mux.Remote:
+    severity: Info
+  Net.PeerSelection:
+    severity: Silence
+  Net.PeerSelection.Actions:
+    severity: Info
+  Net.Subscription.DNS:
+    severity: Info
+  Net.Subscription.IP:
+    severity: Info
+  Resources:
+    severity: Silence
+  Startup.DiffusionInit:
+    severity: Info

--- a/testnets/cardano_node_tx_generator/tracer-config.yaml
+++ b/testnets/cardano_node_tx_generator/tracer-config.yaml
@@ -1,0 +1,12 @@
+networkMagic: 42
+network:
+  tag: AcceptAt
+  contents: "/opt/cardano-tracer/tracer.socket"
+logging:
+- logRoot: "/opt/cardano-tracer/logs"
+  logMode: FileMode
+  logFormat: ForMachine
+verbosity: Minimum
+hasPrometheus:
+  epHost: 0.0.0.0
+  epPort: 4000


### PR DESCRIPTION
## Summary

Adds **cardano_node_tx_generator**, a sibling iteration testnet for the
Haskell \`cardano-tx-generator\` daemon. The master testnet stays
untouched on this branch — per the *Never modify master testnet* rule,
all feature work iterates on its own \`testnets/cardano_node_<feature>/\`
directory and is promoted to master via a separate, explicit PR.

Closes #69 once the daemon is promoted to master.

## What's in here

- \`testnets/cardano_node_tx_generator/{docker-compose,testnet,relay-topology,tracer-config,README}\`
   — mirrors master's image set (sidecar:65039df, configurator/log-tailer/tracer-sidecar
   digest pins, cardano-node@sha256 ×3, cardano-tracer@sha256) plus the
   tx-generator service active. Network name \`cardano-node-tx-generator-testnet\`
   to avoid collision with master.
- \`components/tx-generator/flake.nix\` bumped to upstream
   \`711eb22ac03e67b753f7ce70e635cddcf6f3cdce\` (post-#118: full
   reconnect-resilience stack — PR #105/#110/#114/#115/#116/#117/#118).
- Composer scripts hardened: \`set -u\` + always-exit-0 +
   lastTxId-gate on \`eventually_population_grew.sh\`.
- \`scripts/push-cardano_node_tx_generator_images.sh\` — sibling of
   the master publish script, scoped to this testnet.
- \`.github/workflows/publish-tx-generator-images.yaml\` — sibling
   build+smoke workflow, isolated from master's pipeline.
- \`.github/workflows/cardano-node.yaml\` — fix: bind \`TESTNET\` to
   \`inputs.test\` (was hardcoded to \`cardano_node_master\` and silently
   ignored \`-f test=…\`).

## Verification

Three Antithesis 1h dispatches against this branch:

| run                                                                                                 | session                                       | faults | findings_new |
|-----------------------------------------------------------------------------------------------------|-----------------------------------------------|:------:|-------------:|
| [25258933972](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25258933972) | \`46e1a09…7609628-50-7\`                     | yes    | 2 (no tx-gen image — workflow bug, fixed in c6c3e08) |
| [25260571411](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25260571411) | \`057adba…b7609628-50-7\`                    | yes    | 2 (cluster convergence under faults; not tx-gen) |
| [25262286962](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25262286962) | \`fd91016…f3814185-50-7\`                    | **no** | **0**        |

tx-generator-specific assertion counts on the faults run:

| assertion                               | count |
|-----------------------------------------|------:|
| \`tx_generator_refill_submit_rejected\` | 0     |
| \`tx_generator_transact_submit_rejected\` | 0   |
| \`tx_generator_refill_landed\`          | firing |
| \`tx_generator_transact_landed\`        | firing |
| \`tx_generator_population_grew\`        | firing |
| \`tx_generator_pressure_summary\`       | firing |

The 2 findings on the faults run are \`finally_tips_agree holds\` (3-pool
consensus divergence under aggressive fault injection — \`distinct_tips:2\`,
\`failure_kind:"tips_divergent"\`) and the \`node - stop\` driver-script
bookkeeping. Both are endemic cluster-level findings under faults — same
shape as historical findings on master — **not caused by tx-generator**.
The no-faults run has \`findings_new: 0\`, confirming this branch's testnet
config introduces zero issues.

## Out of scope (for a follow-up issue)

The \`finally_tips_agree holds\` finding under faults predates this PR
and shows up on master cron runs too. It belongs in a separate
cluster-convergence ticket against the testnet baseline.

## Test plan

- [x] \`scripts/smoke-test.sh cardano_node_tx_generator 600\` (compose smoke green)
- [x] Antithesis 1h with faults — tx-generator clean
- [x] Antithesis 1h no-faults — \`findings_new: 0\`
- [ ] User approval to merge