### PR TITLE
tools/antithesis-overview: parametric multi-run triage skill

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,87 @@
+# Multi-run overview
+
+Complement to [Triaging Antithesis reports](triage.md) and
+[Querying the Logs Explorer](query-logs.md). Those tools work on a
+single test-run at a time. This page covers the **morning-triage
+entry point**: turning the
+[cardano.antithesis.com](https://cardano.antithesis.com/) runs page
+into a clickable digest of the last N hours of runs for a given
+repo.
+
+The tool lives at
+[`tools/antithesis-overview/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/tools/antithesis-overview)
+in this repo. Its
+[README](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/antithesis-overview/README.md)
+is the detailed reference; this page summarises shape and when to
+reach for it.
+
+!!! warning "Workaround, not a supported API"
+    Antithesis does not currently publish a programmatic interface
+    for the runs index page. `tools/antithesis-overview/` is a
+    reverse-engineered Claude Code skill: it drives a real chromium
+    over CDP via the playwright MCP, scrapes rendered DOM, and
+    publishes the digest as a GitHub gist. Everything it does is
+    observable from a logged-in browser session — nothing is
+    privileged. The day Antithesis ship a runs API this skill
+    should be deleted.
+
+## When to use overview vs. triage vs. query-logs
+
+| Question | Tool |
+|---|---|
+| "What's going on in Antithesis for repo X over the last 48h?" | **`antithesis-overview`** (this page) |
+| "Why did this single assertion fail?" | [`antithesis-triage`](triage.md) |
+| "How many `sev:Warning` events came from source=p1 in run X?" | [`tools/query-logs/`](query-logs.md) |
+
+## Fast path
+
+```
+/antithesis-overview --repo cardano-foundation/cardano-node-antithesis --hours-back 48
+```
+
+Free-form arguments work too:
+
+```
+/antithesis-overview last 48h, focus on cardano-node-antithesis
+```
+
+The skill prints a single GitHub gist URL. Open it in a browser to
+read the digest with every link clickable.
+
+## Why a gist instead of terminal output
+
+Antithesis report URLs are 300–400 chars including the PASETO auth
+token, and break click-through in every terminal markdown renderer
+we've tried. Even short URLs like GitHub commit links wrap
+unpredictably inside table cells. Publishing the digest as a
+`gh gist --secret` and printing only the gist URL keeps the terminal
+clean and lets GitHub render the markdown server-side, where every
+link clicks.
+
+## Caveats
+
+- **PASETO tokens leak in gist content.** A secret gist is unlisted,
+  but anyone with the gist URL can read the embedded report URLs
+  for the token's ~9h lifetime. Don't post gist URLs to public
+  channels.
+- **The "Elapsed" column is misleading.** The runs page's "duration"
+  is started→completed elapsed time (queue + execution +
+  post-processing). The actual run wall-clock comes from the
+  report's metadata. The skill labels the column "Elapsed" with a
+  footnote.
+- **SSO cookies expire after ~9 hours.** Get a fresh one from a
+  logged-in browser when the skill returns 403.
+
+## Setup
+
+See the [tool README](https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/antithesis-overview/README.md#install-project-local)
+for installation. The short version: symlink
+`tools/antithesis-overview/` into `~/.claude/skills/` and the skill
+becomes discoverable in Claude Code.
+
+## Future work
+
+A scriptable CLI replacement is tracked in
+[#97](https://github.com/cardano-foundation/cardano-node-antithesis/issues/97).
+When that lands, this skill should defer to it for runs-listing and
+only use the browser for report-level drill-downs.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -74,6 +74,14 @@ When prompted, paste the decrypted Antithesis URL from `moog facts test-runs` or
 
 The skill walks through the report, extracts failing Sometimes/Always assertions and bug findings, and can download logs for a specific run.
 
+## Multi-run overview
+
+If you don't yet know which run to triage and want a digest of the
+last N hours across the repo's recent runs, see
+[Multi-run overview](overview.md). That tool lives at
+[`tools/antithesis-overview/`](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/tools/antithesis-overview)
+and publishes a clickable Markdown table as a GitHub gist.
+
 ## Searching indexed stdout
 
 Triage covers the report (assertion findings, bug listings). For the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Testnets:
       - testnets/index.md
       - Cardano Node Master: testnets/cardano-node-master.md
+  - Multi-run overview: overview.md
   - Triage: triage.md
   - Querying logs: query-logs.md
   - Contributing: contributing.md

--- a/tools/antithesis-overview/README.md
+++ b/tools/antithesis-overview/README.md
@@ -1,0 +1,143 @@
+# antithesis-overview
+
+> **Status: workaround, not a supported API.**
+> Antithesis does not currently publish a programmatic interface for
+> their runs index or report pages. This tool is a stopgap — a
+> reverse-engineered skill we use to make daily triage tractable. It
+> drives a real chromium over CDP via the playwright MCP, scrapes
+> rendered DOM, and never touches anything privileged. The day
+> Antithesis ship an API this directory should be deleted.
+
+A Claude Code skill that lists recent Antithesis runs for a given
+GitHub repo, presents a digest as a GitHub gist (with clickable
+report/commit links), and hands off to upstream `antithesis-triage`
+for per-report drill-down.
+
+## When to use this vs. the other tools
+
+| Question | Tool |
+|---|---|
+| "What's going on in Antithesis for repo X over the last 48h?" | **`antithesis-overview`** (this dir) |
+| "Why did this single assertion fail?" | [`antithesis-triage`](https://github.com/antithesishq/antithesis-skills) — parses one report HTML |
+| "How many `sev:Warning` events came from source=p1 in run X?" | [`tools/query-logs/`](../query-logs/) |
+
+This tool's job is the **morning-triage entry point**: turn the
+cardano.antithesis.com runs page into a clickable Markdown digest
+with a row per recent run, finding counts, and links to commits and
+report URLs. From there you pick which run to drill into.
+
+## Prerequisites
+
+- **Claude Code** — this is an [agent skill](https://www.anthropic.com/news/skills),
+  invoked via the Skill tool
+- **playwright MCP** configured in your Claude Code MCP servers (the
+  package is `@playwright/mcp` on npm). If you can't use playwright,
+  the upstream `antithesis-triage` skill works with `agent-browser`
+  instead — but `agent-browser` fails on NixOS, which is why this
+  skill exists
+- **`gh`** (GitHub CLI), authenticated — the digest is published as a
+  secret gist
+- **An Antithesis SSO session** — you complete the GitHub login once
+  per ~9h and paste the `__Host-antithesis_sso_session` cookie when
+  the skill asks for it
+
+## Install (project-local)
+
+The skill lives in this repo. To make it discoverable by Claude Code
+without copying it into your home directory, symlink it into your
+local `~/.claude/skills/` folder:
+
+```bash
+# from the repo root
+mkdir -p ~/.claude/skills
+ln -s "$(pwd)/tools/antithesis-overview" ~/.claude/skills/antithesis-overview
+```
+
+Restart Claude Code (or run `/refresh-skills` if your build supports
+it) and the `antithesis-overview` skill should appear in the skill
+list.
+
+## Install (one-off, no symlink)
+
+If you just want to try it once, point the skill's path explicitly
+when you ask Claude Code to run it. The SKILL.md uses
+`<this skill>/assets/...` placeholders that resolve to whatever
+Claude Code prints as `Base directory for this skill: ...`.
+
+## Usage
+
+```
+/antithesis-overview --repo cardano-foundation/cardano-node-antithesis --hours-back 48
+```
+
+Free-form arguments work too:
+
+```
+/antithesis-overview last 48h, focus on cardano-node-antithesis
+```
+
+### Parameters
+
+| flag | default | description |
+|---|---|---|
+| `--tenant <name>` | `cardano` (or `$ANTITHESIS_TENANT`) | URL becomes `https://<tenant>.antithesis.com` |
+| `--repo <owner/repo>` | **required** | GitHub repo to filter on, substring match |
+| `--hours-back <N>` | `48` | Cutoff for "recent" |
+| `--requester <name>` | none | Filter by webhook requester (e.g. `cfhal`) |
+| `--public` | secret | Make the gist public — search-indexed, NOT recommended for runs whose reports embed PASETO auth tokens |
+
+### What you get back
+
+A single GitHub gist URL printed to the terminal. Open it in a
+browser. The gist contains a Markdown table with one row per recent
+run:
+
+- **Commit** — clickable link to the GitHub commit
+- **Triage** — clickable link to the Antithesis report (PASETO auth
+  token embedded; valid for ~9h)
+- **Findings** — `new/ongoing/resolved/rare`, with `new` highlighted
+- **Suggested order of attack** — 2–4 candidates worth digging into
+
+### Caveats
+
+- **PASETO tokens leak in gist content.** A secret gist is
+  unlisted, but anyone who learns the gist URL can read every
+  embedded report URL for the duration of the token's ~9h lifetime.
+  Don't post gist URLs to public channels.
+- **The "Elapsed" column is misleading.** The runs page's "duration"
+  is started→completed elapsed time (queue + execution +
+  post-processing). Real run wall-clock is in
+  `getRunMetadata().wall_clock` inside the report. The skill labels
+  the column "Elapsed" and footnotes the distinction.
+- **Cookies expire after ~9 hours.** Get a fresh one from a
+  logged-in browser when the skill returns 403.
+
+## Files
+
+- [`SKILL.md`](SKILL.md) — Claude Code skill definition and workflow
+- [`assets/antithesis-overview.js`](assets/antithesis-overview.js) —
+  Logs index page parser (DOM scraping over `<a-row>` elements)
+- [`assets/antithesis-triage.js`](assets/antithesis-triage.js) —
+  Vendored from
+  [antithesishq/antithesis-skills](https://github.com/antithesishq/antithesis-skills)
+  v3.0.0. Used by the per-report drill-down flow. Update by
+  re-copying the upstream file and bumping the version note in the
+  SKILL.md frontmatter.
+
+## See also
+
+- [`docs/overview.md`](../../docs/overview.md) — user-facing guide,
+  rendered on the mkdocs site
+- [`docs/triage.md`](../../docs/triage.md) — single-report
+  drill-down flow
+- [`docs/query-logs.md`](../../docs/query-logs.md) — Logs Explorer
+  search
+
+## Future work
+
+Tracked in
+[#97](https://github.com/cardano-foundation/cardano-node-antithesis/issues/97):
+a real scriptable CLI tool with sqlite caching, daily digest
+generation, and no browser dependency. Once that lands, this skill
+should be deleted in favour of calling the CLI from a thin Claude
+wrapper.

--- a/tools/antithesis-overview/SKILL.md
+++ b/tools/antithesis-overview/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: antithesis-overview
+description: >
+  Parametric multi-run Antithesis triage entry point. Lists recent runs
+  for a given tenant + GitHub repo, presents a digest as a Markdown
+  GitHub gist, and hands off to antithesis-triage for per-report
+  drill-down. Use when the user asks "what's going on in Antithesis",
+  "summarize last N hours", or starts a triage session without a
+  specific report URL in hand.
+compatibility: Requires the playwright MCP (mcp__playwright__*) and the GitHub CLI (gh). Bundled antithesis-triage.js runtime version 3.0.0 (vendored from antithesishq/antithesis-skills).
+---
+
+# Antithesis Multi-Run Overview
+
+Entry-point skill for Antithesis triage. Answers "what happened
+recently?" before you commit to digging into a single report. Hands
+off to `antithesis-triage` for per-report drill-down once you've
+picked a target.
+
+## Parameters
+
+The skill takes a free-form argument string. Parse out:
+
+- **`--tenant <name>`** — e.g. `cardano`. URL becomes
+  `https://<tenant>.antithesis.com`. Default: `cardano`. Override
+  with `$ANTITHESIS_TENANT` if set.
+- **`--repo <owner/repo>`** — GitHub repo to filter on, e.g.
+  `cardano-foundation/cardano-node-antithesis`. **Required** — ask
+  the user if missing. Substring match on the row's
+  `repository.organization/repo`.
+- **`--hours-back <N>`** — default `48`.
+- **`--requester <name>`** — optional substring filter on the
+  webhook requester (e.g. `cfhal`, `saratomaz`).
+- **`--public`** — publish digest as a public gist instead of secret.
+  Default: secret. Public gists are search-indexed; do NOT use them
+  for runs whose reports embed PASETO auth tokens (which is all of
+  them, for at least 9 hours after generation).
+
+If invoked with bare arguments like
+`"last 48h, focus on cardano-node-antithesis"`, infer the repo from
+the most-specific GitHub-style token in the string.
+
+## When to use
+
+- "What's going on in Antithesis for repo X?"
+- "Any failures overnight?"
+- "Summarize the last 24/48h"
+- Morning triage where you don't yet know which run to look at
+- Comparing the most recent runs of one repo across attempts
+
+If the user hands you a single report URL and only wants that drilled
+into, skip this skill and load `antithesis-triage` directly.
+
+## Why playwright instead of agent-browser
+
+The official `antithesis-triage` skill (upstream) assumes
+`agent-browser`. On NixOS (and likely some other distros),
+`agent-browser` fails to install because `libglib-2.0` isn't on the
+linker path. This skill uses the playwright MCP (`mcp__playwright__*`)
+instead — same browser, different driver. The vendored
+`antithesis-triage.js` runtime is reused as-is.
+
+## Setup: SSO cookie
+
+Antithesis dashboards are gated by `__Host-antithesis_sso_session`.
+Cookies last ~9 hours and are bound to the user's GitHub team
+membership in the tenant's access team (e.g.
+`pragma-org/antithesis-access`).
+
+To prime the cookie when starting a session:
+
+1. Ask the user to paste the cookie value (they get it from a
+   logged-in browser via DevTools → Application → Cookies).
+2. Inject it into the playwright context BEFORE navigating to a
+   protected URL — the dashboard returns 403 for `/report/...` even
+   with a valid cookie if you fail the navigation order.
+
+```js
+// playwright context cookie injection — run via mcp__playwright__browser_run_code
+async (page) => {
+  await page.context().addCookies([{
+    name: '__Host-antithesis_sso_session',
+    value: '<paste from user>',
+    domain: '<tenant>.antithesis.com',
+    path: '/',
+    secure: true,
+    httpOnly: true,
+    sameSite: 'Lax',
+    expires: <unix-seconds-from-cookie-Expires>,
+  }]);
+}
+```
+
+After setting the cookie, navigate to `/home` first to land in the
+app context. Direct navigation to a `/report/...` URL with only the
+SSO cookie returns 403 even when authenticated — you need a session
+that the app has handed back to you. `/home` works; `/runs` works.
+
+If the cookie is expired or rejected, ask the user for a fresh one.
+
+## Workflow
+
+This skill is interview-driven. Don't assume what the user wants —
+ask, then act.
+
+### Step 1 — open the runs page
+
+```
+mcp__playwright__browser_navigate https://<tenant>.antithesis.com/runs
+mcp__playwright__browser_run_code:
+  await page.addScriptTag({ path: '<this skill>/assets/antithesis-triage.js' });
+  await page.evaluate(() => window.__antithesisTriage.runs.waitForReady());
+```
+
+`<this skill>` resolves to whatever Claude Code prints as
+`Base directory for this skill: ...` when the skill is invoked.
+
+### Step 2 — extract recent runs
+
+Inject `assets/antithesis-overview.js` after the triage runtime is
+loaded and call `getRecentRuns()`:
+
+```js
+mcp__playwright__browser_run_code:
+  await page.addScriptTag({ path: '<this skill>/assets/antithesis-overview.js' });
+  return await page.evaluate(() =>
+    window.__antithesisOverview.getRecentRuns({
+      hoursBack: <hoursBack>,
+      requester: <requester or null>,
+      repo: <repo>,
+      onlyWithFindings: false,
+    })
+  );
+```
+
+Returns an array of:
+
+```ts
+{
+  commit: string,            // 40-char SHA
+  commitShort: string,       // first 8 chars
+  commitUrl: string | null,  // https://github.com/<repo>/commit/<sha>
+  try: number,
+  testRunId: string,         // 64-char hex
+  requester: string,
+  repo: string,
+  directory: string,
+  startedLabel: string,      // "Today 9:52 AM" / "Yesterday 8:42 PM" / "Apr 28, 2026 …"
+  status: string,            // "Completed" / "In progress" / "Failed" / "Stopped"
+  duration: string,          // started→completed elapsed; see Pitfalls below
+  findings: { new, ongoing, resolved, rare } | null,
+  triageReportUrl: string | null,
+  exploreLogsUrl: string,
+}
+```
+
+`getRecentRuns` does not click anything; it parses the rows already
+rendered. The page renders the most recent ~20 runs by default,
+which covers ~2 days for active repos. If `hoursBack` exceeds what's
+rendered, the function returns what it has and notes truncation.
+
+### Step 3 — publish the digest as a GitHub gist
+
+**Do NOT dump the digest into the terminal.** Antithesis report URLs
+are 300–400 chars including the PASETO auth token and break
+click-through in every terminal markdown renderer we've tried. Even
+short URLs like GitHub commit links don't click reliably when
+embedded in markdown table cells inside a terminal.
+
+Instead, write the digest to a temp file as proper Markdown and
+publish it via `gh gist create --secret`. GitHub renders the
+markdown server-side, every link clicks correctly, and the terminal
+stays clean. The user opens the gist URL once and reads the digest
+in a browser.
+
+Workflow:
+
+1. Build the markdown locally — full table with proper Markdown
+   links in every cell:
+   - `Commit` cell: `[<commitShort>](<commitUrl>)`
+   - `Triage` cell: `[report](<triageReportUrl>)` — or
+     `[logs](<exploreLogsUrl>)` for in-progress runs
+   - Issue references: `[#NNN](https://github.com/<repo>/issues/NNN)`
+2. Write to `/tmp/antithesis-overview-<timestamp>.md`
+3. `gh gist create --filename antithesis-overview.md --desc "Antithesis overview — <repo>, last <N>h, <date>" /tmp/antithesis-overview-...md`
+   - Use `--secret` (the default) for runs containing private auth
+     tokens. Public gists are search-indexed.
+   - Caveat for the user: PASETO auth tokens have ~9h validity and
+     a gist secret-URL is shareable.
+4. Print **only** the gist URL to the terminal — nothing else.
+
+Required table columns:
+
+- `#` (1-based row index)
+- `When (UTC)` (startedLabel)
+- `Repo` (only when listing across multiple repos)
+- `Directory` (only when it varies)
+- `Commit` — Markdown link to GitHub commit
+- `Try`
+- `Requester` (drop when only one)
+- `Status`
+- `Elapsed` — labelled exactly that, with footnote ¹ when any row
+  has `> 4h` (because elapsed includes queue time, see Pitfalls)
+- `Findings (n/o/r/rr)` with non-zero `new` highlighted (`**N**` + 🚨)
+- `Triage` — Markdown link to the report (or logs if in progress)
+
+Below the table:
+
+- **Suggested order of attack** — 2–4 candidates with rationale,
+  each linking to its commit and report
+- **Already triaged** — runs whose findings already have GitHub
+  issues filed, link both
+
+### Step 4 — drill into a selected run
+
+The user opens the gist, picks a run, replies with `triage row N` or
+similar. Hand that report URL off to `antithesis-triage` (or its
+playwright-driven mirror) — its workflows expect you to be on
+`/report/...` with the runtime loaded.
+
+To navigate playwright there:
+
+```
+mcp__playwright__browser_navigate <triageReportUrl from row N>
+mcp__playwright__browser_run_code:
+  await page.addScriptTag({ path: '<this skill>/assets/antithesis-triage.js' });
+  await page.evaluate(() => window.__antithesisTriage.report.waitForReady());
+```
+
+From there, the upstream `antithesis-triage` skill workflow applies:
+`getPropertyExamples()`, `getExampleLogsUrl(name, idx)`, navigate to
+the logs URL, `prepareDownload(0)`, etc.
+
+### Step 5 — batch-download first failing example logs
+
+For each failed property in a triaged report, download the first
+failing example's `events.log` to
+`/tmp/antithesis-<short>-<prop>.log`. Mechanics:
+
+1. Use `report.getPropertyExamples()` to list failed properties
+2. For each failed property:
+   - Expand its container by `page.click` on
+     `:scope > .property > .property__expander-button` — JS
+     `.click()` does NOT trigger React's handler; you must dispatch
+     via playwright
+   - Pull the first example row's `a[href*='search']` href
+3. Navigate to that Logs Explorer URL, inject the runtime,
+   `await window.__antithesisTriage.logs.waitForReady()`,
+   `prepareDownload(0)`, then click
+   `a.sequence_printer_menu_button[data-triage-dl]` while listening
+   for the `download` event
+4. `download.saveAs(/tmp/...)`
+
+Use one short tag per property in the filename so multiple downloads
+don't overwrite each other.
+
+### Step 6 — close out
+
+Always summarize what was downloaded and where, even if the user
+didn't ask for a final summary. Pattern:
+
+```
+Downloaded:
+- /tmp/antithesis-<run1>-<prop1>.log (NN.M MB)
+- /tmp/antithesis-<run2>-<prop2>.log (NN.M MB)
+
+Open questions:
+- ...
+```
+
+## Pitfalls / lessons learned
+
+- **Terminals don't click long Markdown links inside tables.** Even
+  short ones (~80 chars like GitHub commit URLs) wrap unpredictably
+  inside a table cell and become un-clickable. The Antithesis
+  PASETO-bearing report URLs (~400 chars) are completely hopeless.
+  Solution: never render the digest to the terminal — publish it to
+  a `gh gist --secret` and print only the gist URL. This is
+  step 3 of the workflow, not optional.
+- **Elapsed vs wall_clock — they don't match.** The runs index
+  page's "duration" column is **started→completed elapsed time**,
+  which includes queue + execution + post-processing + triage. The
+  actual run wall-clock is in the report metadata (`wall_clock`
+  field on `getRunMetadata()`). Real example: a run that the runs
+  page showed as `9h 4m` had `wall_clock: 3h 7m` in its report.
+  **Never call the runs-page column "duration" or "wall_clock" in
+  user-facing output — use "elapsed" and footnote the distinction.**
+- **Runs row uses a custom `<a-row>` element**, not a regular
+  `<div>` or `<tr>`. The runtime's `rowsContainerCandidates()`
+  selects `a-row` first; if Antithesis ever changes this, fall back
+  to the div/li/tr scan that requires a single `testRunId` blob and
+  the action-text presence.
+- **`Triage results` and `Explore Logs` are anchors with hrefs in
+  the DOM** — the URLs include the auth token. Do not click and
+  capture via popup; just read `a.href` directly. (Disabled "Triage
+  results" for in-progress runs renders as `<a-button>` instead of
+  `<a>` and has no href.)
+- **403 on `/report/...`** even with valid SSO cookie: navigate to
+  `/home` first. The app-handed session token is only granted after
+  a page-level handshake.
+- **`.property` elements have empty `.property__details` until
+  expanded** — example rows are populated lazily on click. Don't
+  conclude "no rows" from a collapsed container.
+- **`element.click()` from the page eval does NOT trigger React
+  handlers** — use the playwright `page.click(selector)` or
+  `mcp__playwright__browser_click`.
+
+## Reference: existing related skills
+
+- `antithesis-triage` (upstream
+  [antithesishq/antithesis-skills](https://github.com/antithesishq/antithesis-skills))
+  — single-report drill-down. Hand off after Step 4.
+- `tools/query-logs/` (this repo) — Logs Explorer queries (cascade
+  detection, count failures). Use to validate hypotheses raised
+  during overview triage.
+
+## Future work
+
+A scriptable CLI replacement is tracked in
+[#97](https://github.com/cardano-foundation/cardano-node-antithesis/issues/97).
+When that lands, this skill should defer to it for runs-listing and
+only use the browser for report-level drill-downs. Until then,
+browser-driven is the only path.

--- a/tools/antithesis-overview/assets/antithesis-overview.js
+++ b/tools/antithesis-overview/assets/antithesis-overview.js
@@ -1,0 +1,368 @@
+// antithesis-overview runtime — depends on antithesis-triage.js being
+// loaded first (it provides window.__antithesisTriage). Adds a
+// window.__antithesisOverview namespace with multi-run helpers.
+//
+// Conventions match antithesis-triage.js:
+// - methods throw on error so the playwright eval call returns non-zero
+// - object shapes documented in the skill SKILL.md
+
+(function () {
+  function clean(text) {
+    return (text || "").replace(/\s+/g, " ").trim();
+  }
+
+  function abort(details) {
+    var msg =
+      typeof details === "string"
+        ? details
+        : (details && details.error) || JSON.stringify(details);
+    var err = new Error(msg);
+    err.details = details;
+    throw err;
+  }
+
+  // The runs page renders rows as JSON-blob-bearing divs. The blob is
+  // embedded in the row's full text and looks like:
+  //   cf - {"testRun":{"commitId":"...","try":N,"repository":{...},
+  //                    "requester":"...","directory":"..."},
+  //         "testRunId":"<hex>"}
+  // We extract these via regex over the row's textContent rather than
+  // hunting for specific class names — Antithesis ships UI changes
+  // frequently and class selectors break.
+
+  function parseRowMetadata(rowText) {
+    var m = rowText.match(
+      /\{\s*"testRun"\s*:\s*\{[^]*?"testRunId"\s*:\s*"([0-9a-f]+)"\s*\}/,
+    );
+    if (!m) return null;
+
+    var blob = m[0];
+    var testRunId = m[1];
+
+    function pull(key) {
+      var re = new RegExp('"' + key + '"\\s*:\\s*"([^"]+)"');
+      var hit = blob.match(re);
+      return hit ? hit[1] : null;
+    }
+
+    function pullInt(key) {
+      var re = new RegExp('"' + key + '"\\s*:\\s*(\\d+)');
+      var hit = blob.match(re);
+      return hit ? parseInt(hit[1], 10) : null;
+    }
+
+    var commit = pull("commitId");
+    var directory = pull("directory");
+    var requester = pull("requester");
+    var organization = pull("organization");
+    var repo = pull("repo");
+    var try_ = pullInt("try");
+
+    return {
+      commit: commit,
+      commitShort: commit ? commit.slice(0, 8) : null,
+      try: try_,
+      testRunId: testRunId,
+      requester: requester,
+      repo: organization && repo ? organization + "/" + repo : null,
+      directory: directory,
+    };
+  }
+
+  function parseStatusBlock(rowText) {
+    // Status is one of: "In progress", "Completed", "Failed", "Stopped"
+    var m = rowText.match(/(In progress|Completed|Failed|Stopped)/);
+    var status = m ? m[1] : null;
+
+    // Duration is "Nh Nm" or "NNm" — captured immediately after status
+    var dur = null;
+    if (m) {
+      var after = rowText.slice(m.index + m[0].length);
+      var d = after.match(/^\s*((?:\d+h\s*)?\d+m)/);
+      if (d) dur = d[1].trim();
+    }
+
+    return { status: status, duration: dur };
+  }
+
+  function parseFindings(rowText) {
+    // Either "----" (no triage) or four counts:
+    //   N new\nN ongoing\nN resolved\nN rare
+    if (/----/.test(rowText.replace(/N\s*new/, ""))) {
+      // crude: if there's no "N new" pattern, treat as no findings
+      var hasFindings = /\d+\s*new/.test(rowText);
+      if (!hasFindings) return null;
+    }
+
+    function pull(label) {
+      var re = new RegExp("(\\d+)\\s*" + label);
+      var hit = rowText.match(re);
+      return hit ? parseInt(hit[1], 10) : null;
+    }
+
+    var n = pull("new");
+    if (n === null) return null;
+
+    return {
+      new: n,
+      ongoing: pull("ongoing") || 0,
+      resolved: pull("resolved") || 0,
+      rare: pull("rare") || 0,
+    };
+  }
+
+  function parseStartedLabel(rowText) {
+    // e.g. "Today 9:52 AM", "Yesterday 8:42 PM", "Apr 28, 2026 8:43 PM"
+    var todayY = rowText.match(
+      /(Today|Yesterday)\s*(\d{1,2}:\d{2}\s*[AP]M)/,
+    );
+    if (todayY) return todayY[1] + " " + todayY[2];
+
+    var dated = rowText.match(
+      /([A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})\s*(\d{1,2}:\d{2}\s*[AP]M)/,
+    );
+    if (dated) return dated[1] + " " + dated[2];
+
+    return null;
+  }
+
+  // Convert a "Today HH:MM AM/PM" / "Yesterday HH:MM AM/PM" / "Mon DD,
+  // YYYY HH:MM AM/PM" label to a Date in the local browser timezone.
+  // Returns null if the label can't be parsed. Used only for
+  // hoursBack filtering — we don't surface this back to the user.
+  function labelToDate(label) {
+    if (!label) return null;
+    var now = new Date();
+
+    var m = label.match(/^(Today|Yesterday)\s+(\d{1,2}):(\d{2})\s*([AP]M)$/);
+    if (m) {
+      var d = new Date(now);
+      if (m[1] === "Yesterday") d.setDate(d.getDate() - 1);
+      var h = parseInt(m[2], 10) % 12;
+      if (m[4] === "PM") h += 12;
+      d.setHours(h, parseInt(m[3], 10), 0, 0);
+      return d;
+    }
+
+    var ym = label.match(
+      /^([A-Z][a-z]{2})\s+(\d{1,2}),\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*([AP]M)$/,
+    );
+    if (ym) {
+      var months = [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+      ];
+      var monIdx = months.indexOf(ym[1]);
+      if (monIdx < 0) return null;
+      var hh = parseInt(ym[4], 10) % 12;
+      if (ym[6] === "PM") hh += 12;
+      return new Date(
+        parseInt(ym[3], 10),
+        monIdx,
+        parseInt(ym[2], 10),
+        hh,
+        parseInt(ym[5], 10),
+        0,
+        0,
+      );
+    }
+
+    return null;
+  }
+
+  function rowsContainerCandidates() {
+    // Each runs row is rendered as an `<a-row>` custom element. It
+    // contains the row's JSON blob, status, duration, findings, and
+    // both action anchors ("Triage results" and "Explore Logs").
+    //
+    // We also fall back to scanning every div/li/tr in case the UI
+    // ever moves away from `<a-row>` — same heuristic: a single
+    // testRunId hit AND the action text.
+    var rows = Array.from(document.querySelectorAll("a-row"));
+    if (rows.length > 0) return rows;
+
+    var candidates = [];
+    var all = document.querySelectorAll("div, li, tr");
+    for (var i = 0; i < all.length; i++) {
+      var el = all[i];
+      var text = el.textContent || "";
+      if (!/"testRunId"\s*:/.test(text)) continue;
+      if (!/Explore Logs/.test(text)) continue;
+      var hits = (text.match(/"testRunId"/g) || []).length;
+      if (hits !== 1) continue;
+      candidates.push(el);
+    }
+    return candidates;
+  }
+
+  function findActionLink(rowEl, label) {
+    var anchors = rowEl.querySelectorAll("a");
+    for (var i = 0; i < anchors.length; i++) {
+      var t = anchors[i].textContent || "";
+      if (clean(t) === label || t.indexOf(label) >= 0) {
+        return anchors[i].href || null;
+      }
+    }
+    return null;
+  }
+
+  function findExploreLogsLink(rowEl) {
+    return findActionLink(rowEl, "Explore Logs");
+  }
+
+  function findTriageLink(rowEl) {
+    return findActionLink(rowEl, "Triage results");
+  }
+
+  function getRecentRuns(opts) {
+    opts = opts || {};
+    var hoursBack = typeof opts.hoursBack === "number" ? opts.hoursBack : 48;
+    var requesterFilter = opts.requester || null;
+    var repoFilter = opts.repo || null;
+    var onlyWithFindings = !!opts.onlyWithFindings;
+
+    var rows = rowsContainerCandidates();
+    if (rows.length === 0) {
+      abort({
+        error: "no run rows found — is the runs page loaded?",
+        url: location.href,
+      });
+    }
+
+    var cutoff = new Date(Date.now() - hoursBack * 3600 * 1000);
+    var out = [];
+
+    for (var i = 0; i < rows.length; i++) {
+      var row = rows[i];
+      var text = clean(row.textContent);
+
+      var meta = parseRowMetadata(text);
+      if (!meta) continue;
+
+      var statusBlock = parseStatusBlock(text);
+      var findings = parseFindings(text);
+      var startedLabel = parseStartedLabel(text);
+      var startedAt = labelToDate(startedLabel);
+
+      if (startedAt && startedAt < cutoff) continue;
+
+      if (requesterFilter && meta.requester) {
+        if (
+          meta.requester.toLowerCase().indexOf(requesterFilter.toLowerCase()) <
+          0
+        )
+          continue;
+      }
+
+      if (repoFilter && meta.repo) {
+        if (meta.repo.toLowerCase().indexOf(repoFilter.toLowerCase()) < 0)
+          continue;
+      }
+
+      if (onlyWithFindings && (!findings || findings.new === 0)) continue;
+
+      var commitUrl =
+        meta.repo && meta.commit
+          ? "https://github.com/" + meta.repo + "/commit/" + meta.commit
+          : null;
+
+      out.push({
+        commit: meta.commit,
+        commitShort: meta.commitShort,
+        commitUrl: commitUrl,
+        try: meta.try,
+        testRunId: meta.testRunId,
+        requester: meta.requester,
+        repo: meta.repo,
+        directory: meta.directory,
+        startedLabel: startedLabel,
+        status: statusBlock.status,
+        duration: statusBlock.duration,
+        findings: findings,
+        triageReportUrl: findTriageLink(row),
+        exploreLogsUrl: findExploreLogsLink(row),
+        rowIndex: i,
+      });
+    }
+
+    return {
+      hoursBack: hoursBack,
+      rowsAvailable: rows.length,
+      runs: out,
+      truncated: rows.length >= 20 && out.length === rows.length,
+    };
+  }
+
+  // Click "Triage results" for the row at rowIndex (as returned by
+  // getRecentRuns). Captures the new tab's URL after the click and
+  // returns it, then asks the caller to close the tab themselves —
+  // playwright manages tab lifecycle, not us.
+  //
+  // Returns the report URL synchronously by reading the button's
+  // associated link, OR throws if the button doesn't exist.
+  //
+  // The actual click → new-tab flow needs to happen in playwright
+  // (because eval'd JS can't observe new tabs reliably). Use this as
+  // a marker step: eval `prepareTriageButtonForRow(idx)` to get the
+  // button selector, then `await page.click(selector)` from
+  // playwright while listening for the popup event.
+  function prepareTriageButtonForRow(rowIndex) {
+    var rows = rowsContainerCandidates();
+    if (rowIndex < 0 || rowIndex >= rows.length) {
+      abort({
+        error: "row index out of range",
+        rowIndex: rowIndex,
+        available: rows.length,
+      });
+    }
+
+    var row = rows[rowIndex];
+    var btns = row.querySelectorAll("button");
+    var target = null;
+    for (var i = 0; i < btns.length; i++) {
+      if (clean(btns[i].textContent) === "Triage results") {
+        target = btns[i];
+        break;
+      }
+    }
+    if (!target) {
+      abort({
+        error: "no Triage results button on row — run may still be in progress",
+        rowIndex: rowIndex,
+      });
+    }
+
+    target.setAttribute("data-overview-triage-target", "1");
+    return {
+      rowIndex: rowIndex,
+      selector: '[data-overview-triage-target="1"]',
+    };
+  }
+
+  // Cleanup helper for after a triage button click sequence has
+  // resolved its tab — clears the marker.
+  function clearTriageMarkers() {
+    var marked = document.querySelectorAll("[data-overview-triage-target]");
+    for (var i = 0; i < marked.length; i++) {
+      marked[i].removeAttribute("data-overview-triage-target");
+    }
+    return { cleared: marked.length };
+  }
+
+  window.__antithesisOverview = {
+    __version: "1.0.0",
+    getRecentRuns: getRecentRuns,
+    prepareTriageButtonForRow: prepareTriageButtonForRow,
+    clearTriageMarkers: clearTriageMarkers,
+  };
+})();

--- a/tools/antithesis-overview/assets/antithesis-triage.js
+++ b/tools/antithesis-overview/assets/antithesis-triage.js
@@ -1,0 +1,1473 @@
+(function () {
+  var VERSION = "3.0.0";
+
+  function clean(text) {
+    return (text || "").replace(/\s+/g, " ").trim();
+  }
+
+  function wait(ms) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, ms);
+    });
+  }
+
+  function abort(details) {
+    var msg =
+      typeof details === "string"
+        ? details
+        : (details && details.error) || JSON.stringify(details);
+    var err = new Error(msg);
+    err.details = details;
+    throw err;
+  }
+
+  function isVisible(el) {
+    if (!el || typeof el.getBoundingClientRect !== "function") return false;
+
+    var rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
+
+    var style = window.getComputedStyle(el);
+    return style.display !== "none" && style.visibility !== "hidden";
+  }
+
+  function click(el) {
+    if (!el) return false;
+
+    ["pointerdown", "mousedown", "mouseup", "click"].forEach(function (type) {
+      el.dispatchEvent(
+        new MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          view: window,
+        }),
+      );
+    });
+
+    return true;
+  }
+
+  function ownText(el) {
+    if (!el) return "";
+
+    // Tooltip-heavy cells often mix labels and nested metadata; keep only direct text.
+    return clean(
+      Array.from(el.childNodes)
+        .filter(function (node) {
+          return node.nodeType === Node.TEXT_NODE;
+        })
+        .map(function (node) {
+          return node.textContent;
+        })
+        .join(" "),
+    );
+  }
+
+  function lastTextNode(el) {
+    if (!el) return "";
+
+    // Log rows append the visible value as the last text node after tooltip elements.
+    var nodes = el.childNodes;
+    for (var i = nodes.length - 1; i >= 0; i--) {
+      if (nodes[i].nodeType === Node.TEXT_NODE && clean(nodes[i].textContent)) {
+        return clean(nodes[i].textContent);
+      }
+    }
+
+    return "";
+  }
+
+  function lastText(el) {
+    var direct = lastTextNode(el);
+    if (direct) return direct;
+    // Only fall back to full textContent when no child elements exist;
+    // otherwise the tooltip label (e.g. "event.container") leaks through.
+    if (el && !el.querySelector("*")) return clean(el.textContent);
+    return "";
+  }
+
+  function parseItemCount(text) {
+    var matches = Array.from((text || "").matchAll(/(\d[\d,]*)\s*items?\b/gi));
+    return matches.length
+      ? Number(matches[matches.length - 1][1].replace(/,/g, ""))
+      : null;
+  }
+
+  function hasLoadingText(text) {
+    return /loading(?:\.\.\.)?/i.test(text || "");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error detection
+  // ---------------------------------------------------------------------------
+
+  function detectSetupError() {
+    // Setup-failure reports replace the normal Properties / Findings / Utilization
+    // sections with a single "Error" section whose heading is an <h3>.
+    var sections = document.querySelectorAll(".section_container.top_section");
+
+    for (var i = 0; i < sections.length; i++) {
+      var heading = sections[i].querySelector("h3");
+      if (!heading || clean(heading.textContent) !== "Error") continue;
+
+      var summary = sections[i].querySelector(".section_summary");
+      var content = sections[i].querySelector(".section_content");
+
+      // The validation error message lives in a <pre> inside the content area.
+      // Fall back to the full section text (trimmed) if no <pre> is found.
+      var pre = content && content.querySelector("pre");
+      var details = clean(
+        pre ? pre.textContent : content && content.textContent,
+      );
+
+      return {
+        type: "setup_error",
+        summary: clean(summary && summary.textContent),
+        details: details.length > 2000 ? details.substring(0, 2000) : details,
+      };
+    }
+
+    return null;
+  }
+
+  function detectRuntimeError() {
+    // Runtime errors render a prominent banner at the top of the page using the
+    // GeneralErrorNew component.  The rest of the report may partially load but
+    // one or more sections (typically Findings) will be stuck on "Loading...".
+    var el = document.querySelector(".GeneralErrorNew");
+    if (!el || !isVisible(el)) return null;
+
+    var title = el.querySelector(".GeneralErrorNew__title");
+    var text = el.querySelector(".GeneralErrorNew__text");
+    var details = clean(text && text.textContent);
+
+    return {
+      type: "runtime_error",
+      summary: clean(title && title.textContent) || "Error",
+      details: details.length > 2000 ? details.substring(0, 2000) : details,
+    };
+  }
+
+  function detectError() {
+    return detectSetupError() || detectRuntimeError() || null;
+  }
+
+  function requireReportPage() {
+    if (!/^\/report\//.test(window.location.pathname)) {
+      abort({ error: "expected main report view", url: window.location.href });
+    }
+
+    if (/\/findings?\//.test(window.location.hash)) {
+      abort({
+        error: "expected main report view, not finding hash route",
+        url: window.location.href,
+      });
+    }
+  }
+
+  function requireLogsPage() {
+    if (
+      window.location.pathname !== "/search" ||
+      !/[?&]get_logs=true\b/.test(window.location.search)
+    ) {
+      abort({
+        error: "expected selected-event logs view",
+        url: window.location.href,
+      });
+    }
+  }
+
+  function requireRunsPage() {
+    if (window.location.pathname !== "/runs") {
+      abort({ error: "expected runs page", url: window.location.href });
+    }
+  }
+
+  function findSectionByHeading(heading) {
+    return Array.from(document.querySelectorAll("section")).find(
+      function (section) {
+        var h = section.querySelector("h1, h2, h3, h4, h5, h6");
+        return clean(h && h.textContent) === heading;
+      },
+    );
+  }
+
+  function visibleCount(selector) {
+    return Array.from(document.querySelectorAll(selector)).filter(isVisible)
+      .length;
+  }
+
+  function sectionInfo(section) {
+    return {
+      exists: !!section,
+      text: clean(section && section.textContent),
+      hasLoadingText: hasLoadingText(section && section.textContent),
+    };
+  }
+
+  function sectionLooksLoaded(section) {
+    if (!section || !isVisible(section)) return false;
+
+    var text = clean(section.textContent);
+    return !!(text && !hasLoadingText(text));
+  }
+
+  function allPropertyContainers() {
+    return Array.from(document.querySelectorAll(".property-container"));
+  }
+
+  function visiblePropertyContainers() {
+    return allPropertyContainers().filter(isVisible);
+  }
+
+  function stateFromStatus(el) {
+    var classes = el ? el.className : "";
+    return classes.includes("_passed")
+      ? "passed"
+      : classes.includes("_failed")
+        ? "failed"
+        : classes.includes("_unfound")
+          ? "unfound"
+          : "unknown";
+  }
+
+  function containerStatus(container) {
+    return stateFromStatus(
+      container.querySelector(":scope > .property .property__status"),
+    );
+  }
+
+  function nameOf(container) {
+    var label = container.querySelector(
+      ":scope > .property .property__name_label",
+    );
+    return clean(label && label.textContent);
+  }
+
+  function directChildren(container) {
+    return container.querySelectorAll(
+      ":scope > .property__details > .property-container",
+    ).length;
+  }
+
+  function isLeaf(container) {
+    return directChildren(container) === 0;
+  }
+
+  function isGroup(container) {
+    return directChildren(container) > 0;
+  }
+
+  function isExpanded(container) {
+    return !!container.querySelector(
+      ":scope > .property .property__expander._expanded, :scope > .property__details._unfolded",
+    );
+  }
+
+  function expanderButton(container) {
+    return container.querySelector(
+      ":scope > .property .property__expander-button",
+    );
+  }
+
+  function groupPath(container) {
+    var path = [];
+    var parent = container.parentElement
+      ? container.parentElement.closest(".property-container")
+      : null;
+
+    while (parent) {
+      var name = nameOf(parent);
+      if (name) path.unshift(name);
+      parent = parent.parentElement
+        ? parent.parentElement.closest(".property-container")
+        : null;
+    }
+
+    return path;
+  }
+
+  function tabLabelText(tab) {
+    return clean(tab && tab.textContent).toLowerCase();
+  }
+
+  function tabByPattern(pattern) {
+    return Array.from(document.querySelectorAll("a-tab")).find(function (tab) {
+      return pattern.test(tabLabelText(tab));
+    });
+  }
+
+  function countFromTab(tab) {
+    var match = tabLabelText(tab).match(/(\d+)/);
+    return match ? Number(match[1]) : null;
+  }
+
+  async function waitForReady(checkFn, detailsFn, options) {
+    var timeoutMs =
+      options && typeof options.timeoutMs === "number"
+        ? options.timeoutMs
+        : 60000;
+    var intervalMs =
+      options && typeof options.intervalMs === "number"
+        ? options.intervalMs
+        : 1000;
+    var startedAt = Date.now();
+    var deadline = startedAt + timeoutMs;
+    var attempts = 0;
+
+    while (Date.now() <= deadline) {
+      attempts += 1;
+
+      if (checkFn()) {
+        return {
+          attempts: attempts,
+          waitedMs: Date.now() - startedAt,
+        };
+      }
+
+      if (Date.now() + intervalMs > deadline) break;
+      await wait(intervalMs);
+    }
+
+    abort({
+      error: "timed out waiting for page to be ready",
+      attempts: attempts,
+      waitedMs: Date.now() - startedAt,
+      details: detailsFn ? detailsFn() : null,
+    });
+  }
+
+  async function expandAllFindings() {
+    var sections = Array.from(
+      document.querySelectorAll("details.findings_section_details"),
+    );
+    var opened = 0;
+    sections.forEach(function (section) {
+      if (!section.open) {
+        section.open = true;
+        opened++;
+      }
+    });
+    if (opened > 0) await wait(300);
+  }
+
+  async function expandAllSections() {
+    var settleMs = 300;
+    var maxPasses = 10;
+
+    for (var pass = 0; pass < maxPasses; pass++) {
+      var collapsed = Array.from(
+        document.querySelectorAll(".section_container"),
+      ).filter(function (sc) {
+        var expander = sc.querySelector(
+          ":scope > .section_header .expander.section_expander",
+        );
+        return expander && !expander.classList.contains("_expanded");
+      });
+
+      if (collapsed.length === 0) break;
+
+      for (var i = 0; i < collapsed.length; i++) {
+        var btn = collapsed[i].querySelector(
+          ":scope > .section_header .section_title_button",
+        );
+        if (btn) click(btn);
+      }
+
+      await wait(settleMs);
+    }
+  }
+
+  async function expandAllProperties() {
+    requireReportPage();
+
+    // Expand all property containers in up to 32 passes (groups and leaves).
+    for (var i = 0; i < 32; i++) {
+      var changed = false;
+
+      document
+        .querySelectorAll(".property__expander-button")
+        .forEach(function (btn) {
+          var container = btn.closest(".property-container");
+          if (!container || !isVisible(container) || isExpanded(container))
+            return;
+          if (click(btn)) changed = true;
+        });
+
+      if (!changed) break;
+      await wait(250);
+    }
+  }
+
+  function exampleCounts(container) {
+    var text = clean(container.textContent);
+    var match = text.match(
+      /([\d,]+)\s+passing\s+example.*?([\d,]+)\s+failing\s+example/,
+    );
+    if (!match) return { passingCount: null, failingCount: null };
+    return { passingCount: match[1], failingCount: match[2] };
+  }
+
+  // Assumes leaf properties are already expanded (waitForReady expands all
+  // sections and properties on load). Pass/fail example counts are only
+  // present in the DOM after expansion.
+  function visibleLeafProperties(filterStatus) {
+    return visiblePropertyContainers()
+      .filter(function (container) {
+        if (!isLeaf(container) || !nameOf(container)) return false;
+        return !filterStatus || containerStatus(container) === filterStatus;
+      })
+      .map(function (container) {
+        var counts = exampleCounts(container);
+        return {
+          group: groupPath(container),
+          name: nameOf(container),
+          status: containerStatus(container),
+          passingCount: counts.passingCount,
+          failingCount: counts.failingCount,
+        };
+      });
+  }
+
+  function exampleRowElements(container) {
+    return container.querySelectorAll(
+      ":scope > .property__details .examples_table__row",
+    );
+  }
+
+  function examplesRows(container) {
+    return exampleRowElements(container).length;
+  }
+
+  function cleanLogOutput(text) {
+    return clean(text).replace(/^event\.output_text\s*/i, "");
+  }
+
+  function extractLogOutput(varyingPart) {
+    var output =
+      varyingPart && varyingPart.querySelector(".event__output_text");
+    var direct = cleanLogOutput(lastTextNode(output));
+    if (direct) return direct;
+    return cleanLogOutput(output && output.textContent);
+  }
+
+  function extractLogDirectText(varyingPart) {
+    return clean(
+      Array.from((varyingPart && varyingPart.childNodes) || [])
+        .filter(function (node) {
+          return node.nodeType === Node.TEXT_NODE;
+        })
+        .map(function (node) {
+          return node.textContent;
+        })
+        .join(" "),
+    );
+  }
+
+  function extractLogDetails(ev) {
+    // Assertion rows and regular log rows render their useful text differently.
+    var assertion = ev.querySelector(".sdk-assertion__meta");
+    var assertionText = clean(assertion && assertion.textContent);
+    if (assertionText) {
+      return {
+        assertionText: assertionText,
+        directText: "",
+        outputText: "",
+        text: assertionText,
+      };
+    }
+
+    var varyingPart = ev.querySelector(".event__varying-part");
+    var directText = extractLogDirectText(varyingPart);
+    var outputText = extractLogOutput(varyingPart);
+    var text = outputText || directText;
+
+    if (directText && outputText && directText !== outputText) {
+      text = directText + " | " + outputText;
+    }
+
+    return {
+      assertionText: "",
+      directText: directText,
+      outputText: outputText,
+      text: text,
+    };
+  }
+
+  function serializeLogEvent(ev) {
+    var details = extractLogDetails(ev);
+
+    return {
+      vtime: lastText(ev.querySelector(".event__vtime")),
+      container: lastText(ev.querySelector(".event__container")),
+      source: lastText(ev.querySelector(".event__source_name")),
+      text: details.text,
+      directText: details.directText,
+      outputText: details.outputText,
+      highlighted:
+        ev.classList.contains("_emphasized_blue") ||
+        ev.classList.contains("_emphasized"),
+    };
+  }
+
+  function errorSection() {
+    return findSectionByHeading("Error");
+  }
+
+  function inlineErrorLogWrappers() {
+    var section = errorSection();
+    if (!section) return [];
+
+    return Array.from(
+      section.querySelectorAll(".sequence_printer_wrapper"),
+    ).filter(isVisible);
+  }
+
+  function requireInlineErrorLogs() {
+    requireReportPage();
+
+    var err = detectError();
+    if (!err) {
+      abort({
+        error: "expected error report with inline logs",
+        url: window.location.href,
+      });
+    }
+
+    var wrappers = inlineErrorLogWrappers();
+    if (!wrappers.length) {
+      abort({
+        error: "no inline error log panes found",
+        errorType: err.type,
+        url: window.location.href,
+      });
+    }
+  }
+
+  function inlineErrorLogViews() {
+    return inlineErrorLogWrappers().map(function (wrapper, index) {
+      var counterEl = wrapper.querySelector(".sequence_toolbar__items-counter");
+      var counterText = clean(counterEl && counterEl.textContent);
+      var events = Array.from(wrapper.querySelectorAll(".event"));
+      var firstEvent = events.length ? serializeLogEvent(events[0]) : null;
+
+      return {
+        index: index,
+        itemCount: parseItemCount(counterText),
+        visibleEvents: events.filter(isVisible).length,
+        firstEvent: firstEvent,
+      };
+    });
+  }
+
+  function tooltipMap(tooltip) {
+    if (!tooltip) return {};
+
+    // Runs-page tooltips reuse a few DOM layouts; normalize them into key/value maps.
+    var out = {};
+    var rows = Array.from(tooltip.children);
+
+    if (rows.length === 1 && rows[0].children.length) {
+      rows = Array.from(rows[0].children);
+    }
+
+    rows.forEach(function (row) {
+      var keyEl =
+        row.querySelector(".runs_table_muted_tooltip_text") ||
+        row.querySelector(".runs_table_name_column_tooltip_key");
+      var valueEl = row.querySelector(".runs_table_tooltip_text");
+      var key = clean(keyEl && keyEl.textContent).replace(/:$/, "");
+      var value = clean(
+        valueEl
+          ? valueEl.textContent
+          : clean(row.textContent).replace(
+              clean(keyEl && keyEl.textContent),
+              "",
+            ),
+      );
+      var parsed = clean(row.textContent).match(/^([^:]+):\s*(.*)$/);
+
+      if (!key && parsed) key = clean(parsed[1]);
+      if (!value && parsed) value = clean(parsed[2]);
+      if (key) out[key] = value;
+    });
+
+    return out;
+  }
+
+  function pairMap(container) {
+    if (!container) return {};
+
+    // Utilization cells render as alternating key/value spans.
+    var spans = Array.from(container.querySelectorAll("span"));
+    var out = {};
+    for (var i = 0; i + 1 < spans.length; i += 2) {
+      var key = clean(spans[i].textContent).replace(/:$/, "");
+      var value = clean(spans[i + 1].textContent);
+      if (key) out[key] = value;
+    }
+    return out;
+  }
+
+  function findingsMap(container) {
+    if (!container) return {};
+
+    // Findings cells collapse badge text into single spans like "3 new".
+    var out = {};
+    Array.from(container.querySelectorAll("span")).forEach(function (span) {
+      var match = clean(span.textContent).match(/^(\S+)\s+(.+)$/);
+      if (match) out[match[2].toLowerCase()] = match[1];
+    });
+    return out;
+  }
+
+  function actionUrl(cell, label) {
+    var link = Array.from(cell.querySelectorAll("a")).find(function (anchor) {
+      return clean(anchor.textContent) === label;
+    });
+    return link ? link.href : null;
+  }
+
+  function parseRunRow(row) {
+    var nameCell = row.querySelector('[cell-identifier="name"]');
+    var creatorSource = row.querySelector('[cell-identifier="creator_source"]');
+    var creatorName = row.querySelector('[cell-identifier="creator_name"]');
+    var dateCell = row.querySelector('[cell-identifier="date"]');
+    var timeCell = row.querySelector('[cell-identifier="time"]');
+    var statusCell = row.querySelector('[cell-identifier="status"]');
+    var durationCell = row.querySelector('[cell-identifier="duration"]');
+    var findingsCell = row.querySelector(".runs_table_run_findings");
+    var utilizationCell = row.querySelector(".runs_table_utilization");
+    var actionCell = row.querySelector(
+      "a-cell.table_left_most_right_pinned_col",
+    );
+    var nameTooltip = nameCell
+      ? nameCell.closest("a-cell").querySelector("a-tooltip")
+      : null;
+    var creatorTooltip = creatorSource
+      ? creatorSource.closest("a-cell").querySelector("a-tooltip")
+      : null;
+    var nameMeta = tooltipMap(nameTooltip);
+    var creatorMeta = tooltipMap(creatorTooltip);
+
+    var nameMutedEl =
+      nameCell && nameCell.querySelector(".runs_table_muted_tooltip_text");
+    var nameTooltipTextEl =
+      nameCell && nameCell.querySelector(".runs_table_tooltip_text");
+
+    return {
+      name:
+        nameMeta.Name ||
+        clean(nameMutedEl && nameMutedEl.textContent) ||
+        clean(nameCell && nameCell.textContent),
+      description:
+        nameMeta.Description ||
+        clean(nameTooltipTextEl && nameTooltipTextEl.textContent),
+      creatorSource: clean(creatorSource && creatorSource.textContent),
+      creatorName:
+        ownText(creatorName && creatorName.querySelector("div")) ||
+        clean(creatorName && creatorName.textContent),
+      creatorCategory: creatorMeta.Category || "",
+      cadence: creatorMeta.Cadence || "",
+      commit: creatorMeta["Commit hash"] || "",
+      repository: creatorMeta.Repository || "",
+      date: clean(dateCell && dateCell.textContent),
+      time: clean(timeCell && timeCell.textContent),
+      status: clean(statusCell && statusCell.textContent),
+      duration: clean(durationCell && durationCell.textContent),
+      findings: findingsMap(findingsCell),
+      utilization: pairMap(utilizationCell),
+      triageUrl: actionCell ? actionUrl(actionCell, "Triage results") : null,
+      logsUrl: actionCell ? actionUrl(actionCell, "Explore Logs") : null,
+      hasTriageResults: !!(
+        actionCell && actionUrl(actionCell, "Triage results")
+      ),
+    };
+  }
+
+  function runKey(run) {
+    // Prefer stable URLs; fall back to visible row content for in-progress runs.
+    return (
+      run.triageUrl ||
+      run.logsUrl ||
+      [run.name, run.description, run.date, run.time].join(" | ")
+    );
+  }
+
+  function getAllProperties() {
+    requireReportPage();
+
+    var tab = tabByPattern(/\ball\b/);
+    var properties = visibleLeafProperties();
+    var counts = properties.reduce(function (acc, property) {
+      acc[property.status] = (acc[property.status] || 0) + 1;
+      return acc;
+    }, {});
+
+    return {
+      expectedCount: countFromTab(tab),
+      counts: counts,
+      properties: properties,
+    };
+  }
+
+  function parseExampleRow(row, index) {
+    var example = row.querySelector(".example_failing, .example_passing");
+    var timeCell = row.querySelectorAll("td")[1];
+
+    return {
+      index: index,
+      status: example ? example.className.replace("example_", "") : "",
+      time: timeCell && clean(timeCell.textContent),
+    };
+  }
+
+  function examplesForContainer(container) {
+    return Array.from(exampleRowElements(container)).map(function (row, i) {
+      return parseExampleRow(row, i);
+    });
+  }
+
+  function getExampleLogsUrl(propertyName, exampleIndex) {
+    requireReportPage();
+
+    var idx = typeof exampleIndex === "number" ? exampleIndex : 0;
+    var containers = visiblePropertyContainers();
+    var target = null;
+
+    for (var i = 0; i < containers.length; i++) {
+      var container = containers[i];
+      if (isGroup(container)) continue;
+      if (nameOf(container) === propertyName) {
+        target = container;
+        break;
+      }
+    }
+
+    if (!target) {
+      abort({ error: "property not found", propertyName: propertyName });
+    }
+
+    var rows = Array.from(exampleRowElements(target));
+
+    if (idx < 0 || idx >= rows.length) {
+      abort({
+        error: "example index out of range",
+        propertyName: propertyName,
+        exampleIndex: idx,
+        availableExamples: rows.length,
+      });
+    }
+
+    var row = rows[idx];
+    var link = row.querySelector("a[href*='search']");
+
+    return {
+      propertyName: propertyName,
+      exampleIndex: idx,
+      logsUrl: link ? link.href : null,
+    };
+  }
+
+  function getPropertyExamples() {
+    requireReportPage();
+
+    var properties = visiblePropertyContainers()
+      .filter(function (container) {
+        return (
+          !isGroup(container) &&
+          nameOf(container) &&
+          examplesRows(container) > 0
+        );
+      })
+      .map(function (container) {
+        return {
+          group: groupPath(container),
+          name: nameOf(container),
+          status: containerStatus(container),
+          examples: examplesForContainer(container),
+        };
+      });
+
+    return {
+      properties: properties,
+      totalExamples: properties.reduce(function (sum, property) {
+        return sum + property.examples.length;
+      }, 0),
+    };
+  }
+
+  var reportApi = {
+    loadingFinished: function () {
+      var titleEl = document.querySelector(".branded_title");
+      var metadataEl = document.querySelector(".branded_metadata");
+      var title = clean(titleEl && titleEl.textContent);
+      var metadata = clean(metadataEl && metadataEl.textContent);
+
+      // Error reports are "done loading" even though normal sections may be
+      // missing or stuck.  Require at least the title to have rendered so the
+      // runtime has something to extract.
+      if (detectError() && isVisible(titleEl) && title) {
+        return true;
+      }
+
+      var environmentSection = findSectionByHeading("Environment");
+      var utilizationSection = findSectionByHeading("Utilization");
+      var propertiesSection = document.querySelector(
+        "section.section_properties:not(.section_findings)",
+      );
+      var environmentImages = visibleCount(
+        ".presentation_environment__source_image",
+      );
+      var utilizationMetric = clean(
+        document.querySelector(".utilization-summary__metric") &&
+          document.querySelector(".utilization-summary__metric").textContent,
+      );
+      var propertyTabs = visibleCount("a-tab");
+      var propertyContainers = visibleCount(".property-container");
+      var propertiesText = clean(
+        propertiesSection && propertiesSection.textContent,
+      );
+      var findingsSection = document.querySelector("section.section_findings");
+      var findingsText = clean(findingsSection && findingsSection.textContent);
+      var findingsDetails =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll("details.findings_section_details")
+              .length
+          : 0;
+      var findingLinks =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll(
+              'a[href*="/finding/"], a[href*="/findings/"]',
+            ).length
+          : 0;
+      var findingToggles =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll(
+              'input[name="include_manual"], input[name="show_ongoing"]',
+            ).length
+          : 0;
+      var findingsLoadedText =
+        /no findings|show suppressions|show ongoing findings|open triage report for this run|look into all findings/i.test(
+          findingsText,
+        );
+      var environmentLoaded = !!(
+        environmentImages > 0 || sectionLooksLoaded(environmentSection)
+      );
+      var utilizationLoaded = !!(
+        utilizationMetric || sectionLooksLoaded(utilizationSection)
+      );
+      var propertiesLoaded = !!(
+        propertiesSection &&
+        isVisible(propertiesSection) &&
+        propertyTabs >= 2 &&
+        propertyContainers > 0 &&
+        !hasLoadingText(propertiesText)
+      );
+      var findingsLoaded =
+        !!findingsSection &&
+        isVisible(findingsSection) &&
+        !hasLoadingText(findingsText) &&
+        (findingsDetails > 0 ||
+          findingLinks > 0 ||
+          findingToggles >= 2 ||
+          findingsLoadedText);
+
+      return !!(
+        isVisible(titleEl) &&
+        isVisible(metadataEl) &&
+        title &&
+        metadata &&
+        environmentLoaded &&
+        utilizationLoaded &&
+        propertiesLoaded &&
+        findingsLoaded
+      );
+    },
+
+    sectionReadiness: function () {
+      requireReportPage();
+
+      var err = detectError();
+      var environmentSection = findSectionByHeading("Environment");
+      var utilizationSection = findSectionByHeading("Utilization");
+      var propertiesSection = document.querySelector(
+        "section.section_properties:not(.section_findings)",
+      );
+      var findingsSection = document.querySelector("section.section_findings");
+
+      var environmentImages = visibleCount(
+        ".presentation_environment__source_image",
+      );
+      var utilizationMetric = clean(
+        document.querySelector(".utilization-summary__metric") &&
+          document.querySelector(".utilization-summary__metric").textContent,
+      );
+      var propertyTabs = visibleCount("a-tab");
+      var propertyContainers = visibleCount(".property-container");
+      var propertiesText = clean(
+        propertiesSection && propertiesSection.textContent,
+      );
+      var findingsText = clean(findingsSection && findingsSection.textContent);
+      var findingsDetails =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll("details.findings_section_details")
+              .length
+          : 0;
+      var findingLinks =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll(
+              'a[href*="/finding/"], a[href*="/findings/"]',
+            ).length
+          : 0;
+      var findingToggles =
+        findingsSection && isVisible(findingsSection)
+          ? findingsSection.querySelectorAll(
+              'input[name="include_manual"], input[name="show_ongoing"]',
+            ).length
+          : 0;
+      var findingsLoadedText =
+        /no findings|show suppressions|show ongoing findings|open triage report for this run|look into all findings/i.test(
+          findingsText,
+        );
+
+      function status(loaded, section) {
+        if (loaded) return "ok";
+        if (err && section && hasLoadingText(section.textContent))
+          return "error";
+        if (err) return "error";
+        return "not_loaded";
+      }
+
+      var environmentLoaded = !!(
+        environmentImages > 0 || sectionLooksLoaded(environmentSection)
+      );
+      var utilizationLoaded = !!(
+        utilizationMetric || sectionLooksLoaded(utilizationSection)
+      );
+      var propertiesLoaded = !!(
+        propertiesSection &&
+        isVisible(propertiesSection) &&
+        propertyTabs >= 2 &&
+        propertyContainers > 0 &&
+        !hasLoadingText(propertiesText)
+      );
+      var findingsLoaded =
+        !!findingsSection &&
+        isVisible(findingsSection) &&
+        !hasLoadingText(findingsText) &&
+        (findingsDetails > 0 ||
+          findingLinks > 0 ||
+          findingToggles >= 2 ||
+          findingsLoadedText);
+
+      return {
+        environment: status(environmentLoaded, environmentSection),
+        utilization: status(utilizationLoaded, utilizationSection),
+        properties: status(propertiesLoaded, propertiesSection),
+        findings: status(findingsLoaded, findingsSection),
+      };
+    },
+
+    waitForReady: async function (options) {
+      var result = await waitForReady(
+        function () {
+          return reportApi.loadingFinished();
+        },
+        function () {
+          return reportApi.loadingStatus();
+        },
+        options,
+      );
+
+      var err = detectError();
+      if (err) result.error = err;
+
+      // Per-section status so agents know which methods will work.
+      var sectionStatus = reportApi.sectionReadiness();
+      result.sections = sectionStatus;
+
+      await expandAllSections();
+      if (sectionStatus.properties === "ok") await expandAllProperties();
+      if (sectionStatus.findings === "ok") await expandAllFindings();
+      return result;
+    },
+
+    loadingStatus: function () {
+      requireReportPage();
+
+      var environmentSection = findSectionByHeading("Environment");
+      var utilizationSection = findSectionByHeading("Utilization");
+      var propertiesSection = document.querySelector(
+        "section.section_properties:not(.section_findings)",
+      );
+      var findingsSection = document.querySelector("section.section_findings");
+      var titleEl = document.querySelector(".branded_title");
+      var metadataEl = document.querySelector(".branded_metadata");
+      var metricEl = document.querySelector(".utilization-summary__metric");
+
+      return {
+        title: clean(titleEl && titleEl.textContent),
+        metadata: clean(metadataEl && metadataEl.textContent),
+        readyState: document.readyState,
+        environmentImages: document.querySelectorAll(
+          ".presentation_environment__source_image",
+        ).length,
+        utilizationMetric: clean(metricEl && metricEl.textContent),
+        propertyTabs: document.querySelectorAll("a-tab").length,
+        propertyContainers: document.querySelectorAll(".property-container")
+          .length,
+        findingsDetails: findingsSection
+          ? findingsSection.querySelectorAll("details.findings_section_details")
+              .length
+          : 0,
+        findingLinks: findingsSection
+          ? findingsSection.querySelectorAll(
+              'a[href*="/finding/"], a[href*="/findings/"]',
+            ).length
+          : 0,
+        findingToggles: findingsSection
+          ? findingsSection.querySelectorAll(
+              'input[name="include_manual"], input[name="show_ongoing"]',
+            ).length
+          : 0,
+        findingsText: clean(findingsSection && findingsSection.textContent),
+        error: detectError(),
+        sections: {
+          environment: sectionInfo(environmentSection),
+          utilization: sectionInfo(utilizationSection),
+          properties: sectionInfo(propertiesSection),
+          findings: sectionInfo(findingsSection),
+        },
+      };
+    },
+
+    getError: function () {
+      requireReportPage();
+      return detectError();
+    },
+
+    getInlineErrorLogViews: function () {
+      requireInlineErrorLogs();
+      return inlineErrorLogViews();
+    },
+
+    getRunMetadata: function () {
+      requireReportPage();
+
+      var titleEl = document.querySelector(".branded_title");
+      var metadataEl = document.querySelector(".branded_metadata");
+      var title = clean(titleEl && titleEl.textContent);
+      var metadataText = clean(metadataEl && metadataEl.textContent);
+      var metadataMatch = metadataText.match(
+        /^Conducted on\s+(.+?)(?:\s*Source:\s*(.+))?$/,
+      );
+
+      var metricKeys = {
+        "Test hours": "test_hours",
+        "Wall clock": "wall_clock",
+      };
+      var metrics = document.querySelectorAll(".utilization-summary__metric");
+      var utilization = {};
+      metrics.forEach(function (m) {
+        var parts = clean(m.textContent).split(":");
+        if (parts.length !== 2) return;
+        var key = metricKeys[parts[0].trim()];
+        if (key) utilization[key] = parts[1].trim();
+      });
+
+      return {
+        title: title,
+        metadata: metadataText,
+        conductedOn: metadataMatch ? metadataMatch[1].trim() : "",
+        source:
+          metadataMatch && metadataMatch[2] ? metadataMatch[2].trim() : "",
+        test_hours: utilization.test_hours || null,
+        wall_clock: utilization.wall_clock || null,
+      };
+    },
+
+    getEnvironmentSourceImages: function () {
+      requireReportPage();
+
+      return Array.from(
+        document.querySelectorAll(".presentation_environment__source_image"),
+      ).map(function (img) {
+        var title = img.querySelector(".source_image__title");
+        var digest = img.querySelector(".click_to_copy_text_element");
+        return {
+          name: title
+            ? clean(title.childNodes[0] && title.childNodes[0].textContent)
+            : "",
+          digest: clean(digest && digest.textContent),
+        };
+      });
+    },
+
+    getFindingsGrouped: function () {
+      requireReportPage();
+
+      return Array.from(
+        document.querySelectorAll("details.findings_section_details"),
+      )
+        .map(function (section) {
+          var summaryEl = section.querySelector("summary");
+          var summary = clean(
+            (summaryEl && summaryEl.textContent) || section.textContent,
+          );
+          var dateMatch = summary.match(
+            /^[A-Z][a-z]{2} \d{2} [A-Z][a-z]{2,3} \d{2}:\d{2}/,
+          );
+          var date = dateMatch ? dateMatch[0] : "";
+
+          var findings = Array.from(
+            section.querySelectorAll(
+              "a.w_fit.anchor_remove-style.w_full.justify_start",
+            ),
+          )
+            .map(function (anchor) {
+              var text = clean(anchor.textContent)
+                .replace(/Look into this finding$/, "")
+                .trim();
+              var match = text.match(/^(new|resolved|rare\??)\s*(.+)$/i);
+              if (!match) return null;
+              return {
+                status: match[1].replace(/\?$/, "").toLowerCase(),
+                property: match[2].trim(),
+              };
+            })
+            .filter(Boolean);
+
+          return { date: date, findings: findings };
+        })
+        .filter(function (group) {
+          return group.date && group.findings.length > 0;
+        });
+    },
+
+    getAllProperties: getAllProperties,
+    getExampleLogsUrl: getExampleLogsUrl,
+    getPropertyExamples: getPropertyExamples,
+  };
+
+  var logsApi = {
+    loadingFinished: function () {
+      var wrapper = document.querySelector(".sequence_printer_wrapper");
+      var filterInput = document.querySelector(".sequence_filter__input");
+      var searchInput = document.querySelector(".sequence_search__input");
+      var counter = document.querySelector(".sequence_toolbar__items-counter");
+      var counterText = clean(counter && counter.textContent);
+      var visibleEvents = Array.from(
+        document.querySelectorAll(".event"),
+      ).filter(isVisible).length;
+      var hasItemCount = /(\d[\d,]*)\s*items?\b/i.test(counterText);
+      var inSelectedLogView =
+        /[?&]get_logs=true\b/.test(window.location.search) ||
+        /selected event log/i.test(clean(document.body.textContent));
+
+      return !!(
+        inSelectedLogView &&
+        isVisible(wrapper) &&
+        isVisible(filterInput) &&
+        isVisible(searchInput) &&
+        isVisible(counter) &&
+        visibleEvents > 0 &&
+        hasItemCount &&
+        !/loading logs/i.test(counterText)
+      );
+    },
+
+    loadingStatus: function () {
+      var counterEl = document.querySelector(
+        ".sequence_toolbar__items-counter",
+      );
+      return {
+        url: window.location.href,
+        wrapperVisible: isVisible(
+          document.querySelector(".sequence_printer_wrapper"),
+        ),
+        filterVisible: isVisible(
+          document.querySelector(".sequence_filter__input"),
+        ),
+        searchVisible: isVisible(
+          document.querySelector(".sequence_search__input"),
+        ),
+        counterVisible: isVisible(counterEl),
+        visibleEvents: Array.from(document.querySelectorAll(".event")).filter(
+          isVisible,
+        ).length,
+        itemCounter: clean(counterEl && counterEl.textContent),
+      };
+    },
+
+    waitForReady: async function (options) {
+      requireLogsPage();
+      return waitForReady(
+        function () {
+          return logsApi.loadingFinished();
+        },
+        function () {
+          return logsApi.loadingStatus();
+        },
+        options,
+      );
+    },
+
+    getLogViewers: function () {
+      var wrappers = document.querySelectorAll(".sequence_printer_wrapper");
+      return Array.from(wrappers).map(function (wrapper, i) {
+        var text = wrapper.textContent || "";
+        var itemMatch = text.match(/(\d[\d,]*)\s*items?\b/i);
+        var itemCount = itemMatch
+          ? Number(itemMatch[1].replace(/,/g, ""))
+          : null;
+        var prev = wrapper.previousElementSibling;
+        var label = prev ? clean(prev.textContent) : null;
+        var rect = wrapper.getBoundingClientRect();
+        return {
+          index: i,
+          label: label,
+          itemCount: itemCount,
+          visible: rect.width > 0 && rect.height > 0,
+        };
+      });
+    },
+
+    prepareDownload: function (format, index) {
+      var fmt = (format || "txt").toLowerCase();
+      var downloadMap = {
+        txt: "events.log",
+        json: "events.json",
+        csv: "events.csv",
+      };
+      var filename = downloadMap[fmt];
+      if (!filename) {
+        abort("unsupported format: " + format + "; use txt, json, or csv");
+      }
+
+      var wrappers = document.querySelectorAll(".sequence_printer_wrapper");
+      if (wrappers.length === 0) {
+        abort("no log viewers found on this page");
+      }
+
+      var idx = index != null ? index : 0;
+      if (idx < 0 || idx >= wrappers.length) {
+        abort(
+          "log viewer index " +
+            idx +
+            " out of range; page has " +
+            wrappers.length +
+            " viewer(s)",
+        );
+      }
+
+      var wrapper = wrappers[idx];
+
+      var link = wrapper.querySelector(
+        'a.sequence_printer_menu_button[download="' + filename + '"]',
+      );
+      if (!link) {
+        abort("download link not found for format: " + fmt);
+      }
+
+      // Force the shadow-root menu visible so agent-browser can click the link.
+      var aMenu = link.closest("a-menu");
+      var shadowMenu =
+        aMenu && aMenu.shadowRoot && aMenu.shadowRoot.querySelector("menu");
+      if (!shadowMenu) {
+        abort("shadow menu not found for download link in viewer " + idx);
+      }
+      shadowMenu.style.display = "flex";
+      shadowMenu.style.position = "fixed";
+      shadowMenu.style.top = "0";
+      shadowMenu.style.left = "0";
+      shadowMenu.style.zIndex = "99999";
+
+      // Clear any previous marker, then tag this link for agent-browser.
+      wrappers.forEach(function (w) {
+        var prev = w.querySelector("[data-triage-dl]");
+        if (prev) prev.removeAttribute("data-triage-dl");
+      });
+      link.setAttribute("data-triage-dl", "active");
+
+      var selector = "a.sequence_printer_menu_button[data-triage-dl]";
+      return { format: fmt, filename: filename, selector: selector };
+    },
+  };
+
+  var runsApi = {
+    loadingFinished: function () {
+      var scroller = document.querySelector(".vscroll");
+      if (!scroller) return false;
+
+      var rows = Array.from(document.querySelectorAll("a-row"));
+      if (rows.length === 0) return false;
+
+      var hasRenderedCells = rows.some(function (row) {
+        return row.querySelector("a-cell, [cell-identifier]");
+      });
+      if (!hasRenderedCells) return false;
+
+      // Cells exist structurally but may not have hydrated with data yet.
+      // Require at least one row with a non-empty name or status cell.
+      var hasPopulatedRow = rows.some(function (row) {
+        var name = row.querySelector('[cell-identifier="name"]');
+        var status = row.querySelector('[cell-identifier="status"]');
+        return (
+          (name && clean(name.textContent) !== "") ||
+          (status && clean(status.textContent) !== "")
+        );
+      });
+      if (!hasPopulatedRow) return false;
+
+      var hasVisibleLoadingIndicator = Array.from(
+        scroller.querySelectorAll("*"),
+      ).some(function (el) {
+        return (
+          isVisible(el) && /^Loading(?:\.\.\.)?$/.test(clean(el.textContent))
+        );
+      });
+
+      return !hasVisibleLoadingIndicator;
+    },
+
+    loadingStatus: function () {
+      var scroller = document.querySelector(".vscroll");
+      var rows = Array.from(document.querySelectorAll("a-row"));
+
+      return {
+        url: window.location.href,
+        hasScroller: !!scroller,
+        rows: rows.length,
+        hasRenderedCells: rows.some(function (row) {
+          return row.querySelector("a-cell, [cell-identifier]");
+        }),
+      };
+    },
+
+    waitForReady: async function (options) {
+      return waitForReady(
+        function () {
+          return runsApi.loadingFinished();
+        },
+        function () {
+          return runsApi.loadingStatus();
+        },
+        options,
+      );
+    },
+
+    /**
+     * getRecentRuns(options?)
+     *   options.status - optional status filter: "Starting", "In progress",
+     *                    "Completed", "Cancelled", or "Incomplete"
+     */
+    getRecentRuns: async function (options) {
+      requireRunsPage();
+      options = options || {};
+
+      var statusFilter = options.status || null;
+      var statusOption = null;
+
+      // Apply status filter if requested.
+      if (statusFilter) {
+        var allOptions = Array.from(
+          document.querySelectorAll('a-menu-item[role="option"]'),
+        );
+        statusOption = allOptions.find(function (o) {
+          return clean(o.textContent) === statusFilter;
+        });
+        if (!statusOption)
+          abort(
+            "status filter option '" +
+              statusFilter +
+              "' not found. Valid options: " +
+              allOptions
+                .map(function (o) {
+                  return clean(o.textContent);
+                })
+                .join(", "),
+          );
+        statusOption.click();
+        await wait(300);
+
+        // Wait for the filtered list to settle.
+        await runsApi.waitForReady({ timeoutMs: 10000 });
+      }
+
+      var scroller = document.querySelector(".vscroll");
+      if (!scroller) abort("runs scroller not found");
+
+      var runs = new Map();
+      var previousScrollTop = -1;
+      var stablePasses = 0;
+
+      // The runs table is virtualized, so walk the scroller and merge rendered rows.
+      for (var i = 0; i < 200; i++) {
+        Array.from(document.querySelectorAll("a-row")).forEach(function (row) {
+          var run = parseRunRow(row);
+          var key = runKey(run);
+          if (key) runs.set(key, run);
+        });
+
+        var maxScrollTop = Math.max(
+          0,
+          scroller.scrollHeight - scroller.clientHeight,
+        );
+        var nextScrollTop = Math.min(
+          maxScrollTop,
+          scroller.scrollTop +
+            Math.max(200, Math.floor(scroller.clientHeight * 0.8)),
+        );
+
+        if (
+          nextScrollTop === scroller.scrollTop ||
+          nextScrollTop === previousScrollTop
+        ) {
+          stablePasses += 1;
+          if (stablePasses >= 2) break;
+        } else {
+          stablePasses = 0;
+        }
+
+        previousScrollTop = scroller.scrollTop;
+        scroller.scrollTop = nextScrollTop;
+        scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+        await wait(100);
+      }
+
+      // Clear the status filter to leave the page in a clean state.
+      if (statusOption) {
+        statusOption.click();
+        await wait(100);
+      }
+
+      return {
+        count: runs.size,
+        runs: Array.from(runs.values()),
+      };
+    },
+  };
+
+  var api = {
+    __version: VERSION,
+    report: reportApi,
+    logs: logsApi,
+    runs: runsApi,
+    info: function () {
+      return {
+        version: VERSION,
+        description: "Antithesis triage runtime",
+        namespaces: {
+          report: Object.keys(reportApi).sort(),
+          logs: Object.keys(logsApi).sort(),
+          runs: Object.keys(runsApi).sort(),
+        },
+      };
+    },
+  };
+
+  window.__antithesisTriage = api;
+  return api.info();
+})();


### PR DESCRIPTION
## Summary

- New `tools/antithesis-overview/` directory: a Claude Code skill that lists recent Antithesis runs for a given GitHub repo and publishes a Markdown digest as a secret `gh gist` with clickable commit and report links.
- Parametric: `--tenant`, `--repo`, `--hours-back`, `--requester`. Anyone can clone, symlink `tools/antithesis-overview/` into `~/.claude/skills/`, and run `/antithesis-overview --repo <owner/repo>` against their own SUT.
- Layout mirrors `tools/query-logs/`: `SKILL.md` + `README.md` + `assets/`. Vendors `antithesis-triage.js` v3.0.0 from upstream [antithesishq/antithesis-skills](https://github.com/antithesishq/antithesis-skills) so the skill is self-standing.
- Adds `docs/overview.md` and threads it through `mkdocs.yml` + `docs/triage.md` cross-references.

## Why a gist instead of terminal output

Antithesis report URLs are 300–400 chars including the PASETO auth token. They break click-through in every terminal markdown renderer we tried, even when wrapped in markdown link syntax inside table cells. Even short URLs like GitHub commit links wrap unpredictably in cells. Publishing the digest as a `gh gist --secret` and printing only the gist URL keeps the terminal clean and lets GitHub render the markdown server-side, where every link clicks.

## What this is NOT

A real CLI tool. The browser-driven approach is a stopgap for the lack of an Antithesis runs API; tracked for replacement in #97.

## Test plan

- [ ] Symlink `tools/antithesis-overview` into `~/.claude/skills/` and confirm the skill appears in the Claude Code skill list
- [ ] Invoke against this repo with a fresh SSO cookie; verify a gist URL is printed
- [ ] Open the gist and confirm every Commit, Report, and Logs link clicks correctly
- [ ] Hand a returned report URL to `antithesis-triage` (upstream) and confirm the per-report drill-down still works