### PR TITLE
chore(testnet): remove adversary service from cardano_node_master

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -164,47 +164,6 @@ services:
     tmpfs:
       - /tmp
 
-  # cardano-adversary daemon: long-running NDJSON server on
-  # /state/adversary-control.sock. The composer script in this
-  # container's image talks to that socket via `nc -U`. Image
-  # is a thin wrapper around
-  # ghcr.io/lambdasistemi/cardano-node-clients/cardano-adversary
-  # that bakes the antithesis composer driver alongside the
-  # daemon binary.
-  adversary:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:cc628d5
-    container_name: adversary
-    hostname: adversary.example
-    command:
-      - --control-socket
-      - /state/adversary-control.sock
-      - --network-magic
-      - "42"
-      - --producer-port
-      - "3001"
-      - --producer-host
-      - p1.example
-      - --producer-host
-      - p2.example
-      - --producer-host
-      - p3.example
-      - --chain-points-file
-      - /tracer/chainPoints.log
-    volumes:
-      # Shared with relay1 — composer drivers exec into this
-      # container and talk to /state/adversary-control.sock.
-      - relay1-state:/state
-      # Read-only — tracer-sidecar writes chainPoints.log here.
-      - tracer:/tracer:ro
-    depends_on:
-      relay1:
-        condition: service_started
-      tracer-sidecar:
-        condition: service_started
-      configurator:
-        condition: service_completed_successfully
-    restart: always
-
   tracer-sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
     container_name: tracer-sidecar


### PR DESCRIPTION
## Why

Roll back the `adversary` service from the master testnet's compose until we can verify `findings_new ≤ baseline` on a feature branch with `workflow_dispatch --ref` *before* re-merging.

## What this PR does

- Removes the `adversary:` block from [`testnets/cardano_node_master/docker-compose.yaml`](https://github.com/cardano-foundation/cardano-node-antithesis/blob/chore/remove-adversary-from-master-testnet/testnets/cardano_node_master/docker-compose.yaml).
- Leaves `components/adversary/` and the wrapper-image flake intact, so:
  - The image keeps building and publishing under `ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:<sha>`.
  - The composer drivers stay in the tree.
  - We can re-add the service in a follow-up PR with one chunk of YAML; nothing else needs rebuilding.

## What lives on the daemon side (unchanged)

- `lambdasistemi/cardano-node-clients`: the `cardano-adversary` daemon, the spec at `specs/036-cardano-adversary/`, the `chain_sync_flap` endpoint, the GHCR image. None of this is reverted.

## Findings rationale

| Run | Commit | findings_new |
|---|---|---|
| Baseline scheduled cron | `dc512ad` (no adversary) | 9 |
| PR #99 manual dispatch | `60b2748` (adversary v1) | 8 |
| PR #104 manual dispatch | `67ab46a` (adversary + SDK assertions) | 13 |

PR #99 was an improvement vs baseline. PR #104 added 5 must-hit SDK reachable assertions that Antithesis didn't observe firing — exactly the +5 delta we see. The fix is to drop `must_hit: true` from the `sdk_reachable` calls in `helper_sdk_lib.sh`, or replace them with `sdk_sometimes`-only — one of those follow-up PRs.

## Process this PR demonstrates

Opened as **draft, branch pushed, no merge attempted**. Before this PR is dropped from draft, an Antithesis 1h run is dispatched against this branch:

```
gh workflow run "Antithesis on cardano-node testnet" \
  -R cardano-foundation/cardano-node-antithesis \
  --ref chore/remove-adversary-from-master-testnet \
  -f duration=1
```

If `findings_new` on the branch ≤ 9, the PR moves to ready-for-review and the user gets an explicit "merge or hold?" ask. Until then it stays draft.

## Roadmap context

- Issue: https://github.com/cardano-foundation/cardano-node-antithesis/issues/89 (epic)
- The adversary roadmap doc on main remains accurate at the daemon level.