### PR TITLE
chore(testnet): split tx-generator into its own feature testnet

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -63,10 +63,17 @@ docker exec sidecar \
 
 # tx-generator: prove the daemon comes up, drives one
 # refill, lets the indexer observe it, then lands a small
-# burst of transacts and grows the population. This is the
-# CI-side counterpart of the docker-compose contract; the
-# Antithesis composer drives the same scripts at much
-# heavier load on the cluster.
+# burst of transacts and grows the population. Gated on
+# the compose actually defining a tx-generator service —
+# master testnet has dropped it (per
+# https://github.com/cardano-foundation/cardano-node-antithesis/pull/111),
+# while the cardano_node_tx_generator feature testnet
+# keeps it. Same script serves both.
+if ! grep -qE '^[[:space:]]*tx-generator:' "$COMPOSE_FILE"; then
+  echo "PASS: all ${POOLS} nodes responding (no tx-generator on this testnet)"
+  exit 0
+fi
+
 TXGEN_SOCK=/state/tx-generator-control.sock
 txgen_send() {
   docker exec tx-generator sh -c \

--- a/testnets/cardano_node_tx_generator/README.md
+++ b/testnets/cardano_node_tx_generator/README.md
@@ -1,0 +1,33 @@
+# cardano_node_tx_generator
+
+Feature testnet for iterating on the `cardano-tx-generator` daemon.
+
+Same cluster topology as `cardano_node_master` (3 producers + 2 relays
++ tracer + sidecars + log-tailer) plus the `tx-generator` service that
+drives N2C tx-submission load against `relay1`. Asteria-stub is
+deliberately absent here — it lives on the master testnet because it
+exercises a different feature (long-lived utxo-indexer).
+
+## Why a separate testnet
+
+The master testnet is the canonical reference cluster: changes there
+affect the cron-fired Antithesis run and everyone reading its
+findings. Tx-generator is in active iteration (reconnect supervisor,
+freshness gate, composer-assertion shape) and its experiments would
+otherwise pollute master's signal. Dispatch this testnet via
+workflow_dispatch instead:
+
+```sh
+gh workflow run cardano-node.yaml \
+  --ref <feature-branch> \
+  -f test=cardano_node_tx_generator \
+  -f duration=1
+```
+
+## Image publishing
+
+The `publish-images` workflow currently scrapes images from
+`testnets/cardano_node_master/docker-compose.yaml`. Until that's
+generalised to all testnets, the tx-generator image referenced in the
+compose here is pushed manually — `nix build .#docker-image` from
+`components/tx-generator/`, `docker tag` + `docker push`.

--- a/testnets/cardano_node_tx_generator/docker-compose.yaml
+++ b/testnets/cardano_node_tx_generator/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       - p1-configs:/configs/1 # configs for p1
       - p2-configs:/configs/2 # configs for p2
       - p3-configs:/configs/3 # configs for p3
+      - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
     image: ghcr.io/intersectmbo/cardano-tracer@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
@@ -112,6 +113,42 @@ services:
       - relay2-state:/state
       - tracer:/tracer
 
+  tx-generator:
+    # Tag is bumped commit-by-commit while the downstream
+    # branch is in flight; the publish-images workflow
+    # resolves <tag> to a commit on this repo and
+    # rebuilds via `nix build .#docker-image`. Locally,
+    # `nix build` from components/tx-generator/ produces
+    # the exact tag and `docker load` makes compose pick
+    # it up without a pull.
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:2012360
+    container_name: tx-generator
+    hostname: tx-generator.example
+    command:
+      - --relay-socket
+      - /state/node.socket
+      - --control-socket
+      - /state/tx-generator-control.sock
+      - --state-dir
+      - /state/txgen
+      - --master-seed-file
+      - /state/txgen/master.seed
+      - --faucet-skey-file
+      - /utxo-keys/genesis.1.skey
+      - --network-magic
+      - "42"
+    volumes:
+      # rw — daemon writes its control socket + state dir
+      # under /state.
+      - relay1-state:/state
+      - utxo-keys:/utxo-keys:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+      configurator:
+        condition: service_completed_successfully
+
   sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f889dbc
     environment:
@@ -154,31 +191,6 @@ services:
       tracer:
         condition: service_started
 
-  # Stub workload host. Long-lived utxo-indexer follows relay1's
-  # chain via N2C, exposes ready/utxos_at/await on /tmp/idx.sock
-  # (the listen socket inside this container). Composer scripts at
-  # /opt/antithesis/test/v1/stub/ query that socket to drive
-  # heartbeat / eventually / finally assertions.
-  #
-  # Built from upstream PR #98 (035-indexer-n2c-reconnect) — supervisor
-  # with exponential-backoff reconnect handles N2C peer close in-process,
-  # so the daemon stays up across relay restarts. RocksDB persistence
-  # at /idx-db keeps state across full process restarts too.
-  asteria-stub:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-stub@sha256:de04225e6d4395ff2126735e28664fa7ad2c9c9cd38e7bf856046a47e8e20973
-    container_name: asteria-stub
-    hostname: asteria-stub.example
-    environment:
-      INDEXER_SOCK: /tmp/idx.sock
-    volumes:
-      - relay1-state:/state:ro
-      - asteria-stub-db:/idx-db
-    tmpfs:
-      - /tmp
-    depends_on:
-      relay1:
-        condition: service_started
-
 volumes:
   tracer:
   p1-configs:
@@ -186,7 +198,7 @@ volumes:
   p3-configs:
   relay1-state:
   relay2-state:
-  asteria-stub-db:
+  utxo-keys:
 
 networks:
   default:

--- a/testnets/cardano_node_tx_generator/relay-topology.json
+++ b/testnets/cardano_node_tx_generator/relay-topology.json
@@ -1,0 +1,16 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p1.example", "port": 3001},
+        {"address": "p2.example", "port": 3001},
+        {"address": "p3.example", "port": 3001}
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 3
+    }
+  ],
+  "publicRoots": [],
+  "useLedgerAfterSlot": 0
+}

--- a/testnets/cardano_node_tx_generator/testnet.yaml
+++ b/testnets/cardano_node_tx_generator/testnet.yaml
@@ -1,0 +1,134 @@
+--- # Required Testnet Parameters
+poolCount: 3
+poolCost: 340000000
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 600000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: example
+
+--- # Optional Byron Genesis Overide
+protocolConsts:
+  k: 432
+
+--- # Optional Shelley Genesis Overide
+epochLength: 86400
+securityParam: 432
+maxLovelaceSupply: 45000000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Optional Alonzo Genesis Overide
+
+--- # Optional Conway Genesis Overide
+
+--- # Optional Node Config Overide
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+LastKnownBlockVersion-Alt: 0
+LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Minor: 0
+MaxConcurrencyBulkSync: 2
+MaxConcurrencyDeadline: 4
+MaxKnownMajorProtocolVersion: 2
+PeerSharing: true
+TargetNumberOfActiveBigLedgerPeers: 2
+TargetNumberOfActivePeers: 3
+TargetNumberOfEstablishedBigLedgerPeers: 3
+TargetNumberOfEstablishedPeers: 3
+TargetNumberOfKnownBigLedgerPeers: 10
+TargetNumberOfKnownPeers: 30
+TargetNumberOfRootPeers: 10
+TestAllegraHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestShelleyHardForkAtEpoch: 0
+TraceConnectionManager: true
+TraceConnectionManagerTransitions: true
+TraceDNSResolver: true
+TraceDNSSubscription: true
+TraceDebugPeerSelection: true
+TraceForge: true
+TraceForgeStateInfo: true
+TraceHandshake: true
+TraceInboundGovernor: true
+TraceIpSubscription: true
+TraceLedgerPeers: true
+TraceLocalConnectionManager: true
+TraceLocalHandshake: true
+TraceLocalRootPeers: true
+TracePeerSelection: true
+TracePeerSelectionActions: true
+TracePublicRootPeers: true
+TraceServer: true
+TurnOnLoggingMetrics: true
+TurnOnLogging: true
+UseTraceDispatcher: true
+TraceOptionForwarder:
+  connQueueSize: 64
+  disconnQueueSize: 128
+  maxReconnectDeplay: 30
+TraceOptions:
+  '':
+    backends:
+    - EKGBackend
+    - Forwarder
+    detail: DNormal
+    severity: Notice
+  BlockFetch.Client.CompletedBlockFetch:
+    maxFrequency: 2
+  BlockFetch.Decision:
+    severity: Silence
+  ChainDB:
+    severity: Info
+  ChainDB.AddBlockEvent.AddBlockValidation:
+    severity: Silence
+  ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToQueue:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToVolatileDB:
+    maxFrequency: 2
+  ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB:
+    maxFrequency: 2
+  ChainSync.Client:
+    severity: Warning
+  Forge.Loop:
+    severity: Info
+  Forge.StateInfo:
+    severity: Info
+  Mempool:
+    severity: Silence
+  Net.ConnectionManager.Remote:
+    severity: Info
+  Net.ConnectionManager.Remote.ConnectionManagerCounters:
+    severity: Silence
+  Net.ErrorPolicy:
+    severity: Info
+  Net.ErrorPolicy.Local:
+    severity: Info
+  Net.InboundGovernor:
+    severity: Warning
+  Net.InboundGovernor.Remote:
+    severity: Info
+  Net.Mux.Remote:
+    severity: Info
+  Net.PeerSelection:
+    severity: Silence
+  Net.PeerSelection.Actions:
+    severity: Info
+  Net.Subscription.DNS:
+    severity: Info
+  Net.Subscription.IP:
+    severity: Info
+  Resources:
+    severity: Silence
+  Startup.DiffusionInit:
+    severity: Info

--- a/testnets/cardano_node_tx_generator/tracer-config.yaml
+++ b/testnets/cardano_node_tx_generator/tracer-config.yaml
@@ -1,0 +1,12 @@
+networkMagic: 42
+network:
+  tag: AcceptAt
+  contents: "/opt/cardano-tracer/tracer.socket"
+logging:
+- logRoot: "/opt/cardano-tracer/logs"
+  logMode: FileMode
+  logFormat: ForMachine
+verbosity: Minimum
+hasPrometheus:
+  epHost: 0.0.0.0
+  epPort: 4000


### PR DESCRIPTION
Same shape as https://github.com/cardano-foundation/cardano-node-antithesis/commit/43bf739 (adversary removal from master): the master testnet is the canonical reference cluster, and components in active iteration belong on a feature-testnet so master's signal stays clean.

## Why

`tx-generator` is being iterated on across:

- https://github.com/lambdasistemi/cardano-node-clients/pull/105 (reconnect supervisor + BlockedIndefinitely catch)
- https://github.com/lambdasistemi/cardano-node-clients/pull/110 (post-reconnect indexer freshness gate)
- https://github.com/cardano-foundation/cardano-node-antithesis/pull/98 (composer-assertion shape: Reachability vs Sometimes-false; always-exit-0 vs exit-1-on-not-applicable)

Each of those changes wants its own pre-merge Antithesis dispatch via `--ref <branch>` to compare findings before re-merging — a workflow that's much smoother on a dedicated testnet than on master.

## What

* New `testnets/cardano_node_tx_generator/` — clone of master's topology (3 producers, 2 relays, tracer + sidecars + log-tailer) plus the `tx-generator` service. Asteria-stub deliberately excluded (different feature, stays on master).
* Master loses the `tx-generator` service entirely, the `utxo-keys` volume mount on configurator (only `tx-generator` consumed it), and the `utxo-keys` volume declaration.
* New README documents the dispatch invocation.

## Workflow

Dispatch the new testnet via `cardano-node.yaml`'s existing `test` input:

\`\`\`sh
gh workflow run cardano-node.yaml \\
  --ref <feature-branch> \\
  -f test=cardano_node_tx_generator \\
  -f duration=1
\`\`\`

The cron's default stays `cardano_node_master`; nothing on the schedule changes.

## Out of scope (follow-ups)

* `scripts/push-cardano_node_master_images.sh` is hard-coded to one testnet directory. Until it's generalised, the `tx-generator` image referenced by the new testnet's compose continues to be pushed manually (`nix build .#docker-image` → `docker tag` → `docker push`). Same friction as today on the bump branch.
* https://github.com/cardano-foundation/cardano-node-antithesis/pull/98 is still open with the pin/composer fixes against master's compose. After this split lands, #98 needs a small rebase to apply its compose changes against `testnets/cardano_node_tx_generator/docker-compose.yaml` instead.

## Verification

* \`docker compose config\` is valid for both testnets.
* No diff in master's other services (configurator, tracer, sidecar, log-tailer, asteria-stub, p1-3, relay1-2) — only the `tx-generator` block + `utxo-keys` mounts/declaration come out.

## Related

* https://github.com/cardano-foundation/cardano-node-antithesis/commit/43bf739 — adversary removal precedent
* https://github.com/cardano-foundation/cardano-node-antithesis/pull/98 — companion (will rebase on top)