### PR TITLE
chore(testnet): disable tx-generator in cardano_node_master

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -61,6 +61,16 @@ echo "Checking sidecar convergence command..."
 docker exec sidecar \
   /opt/antithesis/test/v1/convergence/eventually_converged.sh
 
+# tx-generator probes are conditional on the service being present in
+# the resolved compose. The service is parked in some testnets (see
+# tx-generator.disabled.yaml) — when it isn't part of the running
+# cluster we skip the probes rather than fail the smoke test.
+if ! docker compose -f "$COMPOSE_FILE" config --services | grep -qx tx-generator; then
+  echo "SKIP: tx-generator not in compose for testnet ${TESTNET}, skipping tx-generator probes"
+  echo "PASS: all ${POOLS} nodes responding"
+  exit 0
+fi
+
 # tx-generator: prove the daemon comes up, drives one
 # refill, lets the indexer observe it, then lands a small
 # burst of transacts and grows the population. This is the

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -113,41 +113,46 @@ services:
       - relay2-state:/state
       - tracer:/tracer
 
-  tx-generator:
-    # Tag is bumped commit-by-commit while the downstream
-    # branch is in flight; the publish-images workflow
-    # resolves <tag> to a commit on this repo and
-    # rebuilds via `nix build .#docker-image`. Locally,
-    # `nix build` from components/tx-generator/ produces
-    # the exact tag and `docker load` makes compose pick
-    # it up without a pull.
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:2012360
-    container_name: tx-generator
-    hostname: tx-generator.example
-    command:
-      - --relay-socket
-      - /state/node.socket
-      - --control-socket
-      - /state/tx-generator-control.sock
-      - --state-dir
-      - /state/txgen
-      - --master-seed-file
-      - /state/txgen/master.seed
-      - --faucet-skey-file
-      - /utxo-keys/genesis.1.skey
-      - --network-magic
-      - "42"
-    volumes:
-      # rw — daemon writes its control socket + state dir
-      # under /state.
-      - relay1-state:/state
-      - utxo-keys:/utxo-keys:ro
-    restart: always
-    depends_on:
-      relay1:
-        condition: service_started
-      configurator:
-        condition: service_completed_successfully
+  # tx-generator service is parked in tx-generator.disabled.yaml.
+  # It used to drive ADA transfers via N2C against relay1 and was
+  # removed from this compose so the main testnet runs without a
+  # synthetic transaction load. Restore from the parked file when
+  # reintroducing the daemon.
+  # tx-generator:
+  #   # Tag is bumped commit-by-commit while the downstream
+  #   # branch is in flight; the publish-images workflow
+  #   # resolves <tag> to a commit on this repo and
+  #   # rebuilds via `nix build .#docker-image`. Locally,
+  #   # `nix build` from components/tx-generator/ produces
+  #   # the exact tag and `docker load` makes compose pick
+  #   # it up without a pull.
+  #   image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:2012360
+  #   container_name: tx-generator
+  #   hostname: tx-generator.example
+  #   command:
+  #     - --relay-socket
+  #     - /state/node.socket
+  #     - --control-socket
+  #     - /state/tx-generator-control.sock
+  #     - --state-dir
+  #     - /state/txgen
+  #     - --master-seed-file
+  #     - /state/txgen/master.seed
+  #     - --faucet-skey-file
+  #     - /utxo-keys/genesis.1.skey
+  #     - --network-magic
+  #     - "42"
+  #   volumes:
+  #     # rw — daemon writes its control socket + state dir
+  #     # under /state.
+  #     - relay1-state:/state
+  #     - utxo-keys:/utxo-keys:ro
+  #   restart: always
+  #   depends_on:
+  #     relay1:
+  #       condition: service_started
+  #     configurator:
+  #       condition: service_completed_successfully
 
   sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f889dbc

--- a/testnets/cardano_node_master/tx-generator.disabled.yaml
+++ b/testnets/cardano_node_master/tx-generator.disabled.yaml
@@ -1,0 +1,50 @@
+# Parked tx-generator service. Removed from docker-compose.yaml in
+# this branch but kept here so the service definition survives and
+# can be restored verbatim when the daemon is reintroduced.
+#
+# This file is a compose override fragment, not a standalone compose:
+# tx-generator depends on relay1 which lives in docker-compose.yaml.
+#
+# To run with tx-generator re-enabled (without editing compose):
+#   docker compose -f docker-compose.yaml -f tx-generator.disabled.yaml up
+#
+# To restore permanently: paste the `tx-generator:` block back into
+# docker-compose.yaml under `services:` and delete the parked marker
+# block + this file.
+
+services:
+  tx-generator:
+    # Tag is bumped commit-by-commit while the downstream
+    # branch is in flight; the publish-images workflow
+    # resolves <tag> to a commit on this repo and
+    # rebuilds via `nix build .#docker-image`. Locally,
+    # `nix build` from components/tx-generator/ produces
+    # the exact tag and `docker load` makes compose pick
+    # it up without a pull.
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:2012360
+    container_name: tx-generator
+    hostname: tx-generator.example
+    command:
+      - --relay-socket
+      - /state/node.socket
+      - --control-socket
+      - /state/tx-generator-control.sock
+      - --state-dir
+      - /state/txgen
+      - --master-seed-file
+      - /state/txgen/master.seed
+      - --faucet-skey-file
+      - /utxo-keys/genesis.1.skey
+      - --network-magic
+      - "42"
+    volumes:
+      # rw — daemon writes its control socket + state dir
+      # under /state.
+      - relay1-state:/state
+      - utxo-keys:/utxo-keys:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+      configurator:
+        condition: service_completed_successfully


### PR DESCRIPTION
## Summary

Disable the `tx-generator` service in the main testnet (`testnets/cardano_node_master/`) without losing the definition, and gate the smoke-test probes so they skip when the service is parked.

- **`docker-compose.yaml`** — the `tx-generator:` block is commented out in place. A 4-line marker at the top of the block points readers at the parked file. The unrelated `utxo-keys` volume + the configurator's mount of it are left intact (write-only for now) — easy to restore the daemon without re-stitching anything.
- **`testnets/cardano_node_master/tx-generator.disabled.yaml`** (new) — the original service definition, byte-for-byte, packaged as a compose override fragment.
- **`scripts/smoke-test.sh`** — early-exit before the tx-generator probes when `tx-generator` is not in `docker compose config --services`. All probe code is preserved verbatim; the script is now a no-op for parked-service testnets and full-coverage for testnets where the service is still wired in.

## How to re-enable tx-generator

```bash
INTERNAL_NETWORK=false docker compose \
  -f testnets/cardano_node_master/docker-compose.yaml \
  -f testnets/cardano_node_master/tx-generator.disabled.yaml \
  up
```

Or paste the block from the parked file back into `docker-compose.yaml` and delete `tx-generator.disabled.yaml`.

Smoke-test gate behaviour, verified locally:

| Compose layering | gate outcome |
|---|---|
| `-f docker-compose.yaml` (current branch default) | `tx-generator` absent → probes skipped, smoke passes |
| `-f docker-compose.yaml -f tx-generator.disabled.yaml` | `tx-generator` present → probes run as before |

## Known follow-ups (out of scope for this PR)

- **Antithesis composer scripts** under `components/*/composer/` may still drive tx-generator. Untouched here.
- **Docs** (`docs/testnets/cardano-node-master.md`, `docs/index.md`) still list tx-generator as a service. Untouched here.

## Test plan

- [ ] CI compose smoke-test runs and passes (probes are skipped because tx-generator is parked)
- [ ] `docker compose -f docker-compose.yaml config` parses and lists the expected services without `tx-generator`
- [ ] `docker compose -f docker-compose.yaml -f tx-generator.disabled.yaml config` restores `tx-generator` cleanly