### PR TITLE
chore(master): remove asteria-stub from cardano_node_master testnet

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -196,31 +196,6 @@ services:
       tracer:
         condition: service_started
 
-  # Stub workload host. Long-lived utxo-indexer follows relay1's
-  # chain via N2C, exposes ready/utxos_at/await on /tmp/idx.sock
-  # (the listen socket inside this container). Composer scripts at
-  # /opt/antithesis/test/v1/stub/ query that socket to drive
-  # heartbeat / eventually / finally assertions.
-  #
-  # Built from upstream PR #98 (035-indexer-n2c-reconnect) — supervisor
-  # with exponential-backoff reconnect handles N2C peer close in-process,
-  # so the daemon stays up across relay restarts. RocksDB persistence
-  # at /idx-db keeps state across full process restarts too.
-  asteria-stub:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-stub@sha256:de04225e6d4395ff2126735e28664fa7ad2c9c9cd38e7bf856046a47e8e20973
-    container_name: asteria-stub
-    hostname: asteria-stub.example
-    environment:
-      INDEXER_SOCK: /tmp/idx.sock
-    volumes:
-      - relay1-state:/state:ro
-      - asteria-stub-db:/idx-db
-    tmpfs:
-      - /tmp
-    depends_on:
-      relay1:
-        condition: service_started
-
 volumes:
   tracer:
   p1-configs:
@@ -229,7 +204,6 @@ volumes:
   relay1-state:
   relay2-state:
   utxo-keys:
-  asteria-stub-db:
 
 networks:
   default:


### PR DESCRIPTION
## Summary

Removes the `asteria-stub` service (and `asteria-stub-db` volume) from `testnets/cardano_node_master/docker-compose.yaml`.

## Why

The stub's composer assertions have been failing on every recent main-HEAD run:

- **try 1 of `d78c7b1b`** ([report](https://cardano.antithesis.com/report/Tqu4AJtAiE-xL3VUjOHd7Z5T/MD7OvJUcQSeHYlyDWYT8Ha7vB1QoRhjUr449nFFR2d4.html)): 4 new findings — 1 from `stub/finally_alive.sh`, 3 unrelated.
- **try 2 of `d78c7b1b`** ([report](https://cardano.antithesis.com/report/mnPwvhcc1zlF5sCLrWIDj3l6/Ay97AqonNV7A74eafuM9UnDOioujkiPvmm5jMsE3VG0.html)): 5 new findings — 2 from `stub/{finally,eventually}_alive.sh`, 3 unrelated.

asteria-stub belongs in feature testnets, not on the master integration testnet. The other 3 findings (chain-sync flaky_chain_sync, convergence finally_tips_agree, all-tips-reachable) are real regressions and will get separate tickets.

## Scope

- `components/asteria-stub/` is left untouched — the image and its composer scripts stay in the repo for the dedicated testnets that consume them.
- Only the master testnet's docker-compose service entry + volume are removed. Antithesis composer scripts under `/opt/antithesis/test/v1/stub/` only ship inside the asteria-stub image, so removing the container removes them from composer scope automatically.

## Test plan

- [ ] 1h Antithesis run dispatched against this branch — confirm 0 `stub/*` findings, only the 3 known non-asteria findings persist.
- [ ] Then merge.