### PR TITLE
spec: 080-amaru-self-bootstrap (collapse bootstrap-producer into amaru-relays)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -184,35 +184,11 @@ else
 fi
 
 if [[ "$TESTNET" == cardano_amaru* ]]; then
+  # Each amaru-relay-N self-bootstraps inside its own entrypoint —
+  # there is no standalone bootstrap-producer service to wait on.
+  # The per-relay "bundle in place" gate below is the equivalent
+  # readiness signal.
   BOOTSTRAP_TIMEOUT="${AMARU_BOOTSTRAP_SMOKE_TIMEOUT:-1200}"
-  BOOTSTRAP_DEADLINE=$((SECONDS + BOOTSTRAP_TIMEOUT))
-
-  echo "Waiting for bootstrap-producer to complete (timeout ${BOOTSTRAP_TIMEOUT}s)..."
-  while true; do
-    STATE="$(docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' bootstrap-producer 2>/dev/null || true)"
-    STATUS="${STATE%% *}"
-    EXIT_CODE="${STATE#* }"
-    if [ "$STATUS" = "exited" ]; then
-      if [ "$EXIT_CODE" = "0" ]; then
-        echo "OK: bootstrap-producer completed"
-        break
-      fi
-      echo "FAIL: bootstrap-producer exited with code ${EXIT_CODE}"
-      docker compose -f "$COMPOSE_FILE" logs --tail 80 bootstrap-producer 2>&1
-      exit 1
-    fi
-    if [ "$STATUS" = "dead" ]; then
-      echo "FAIL: bootstrap-producer is dead"
-      docker compose -f "$COMPOSE_FILE" logs --tail 80 bootstrap-producer 2>&1
-      exit 1
-    fi
-    if [ "$SECONDS" -ge "$BOOTSTRAP_DEADLINE" ]; then
-      echo "FAIL: bootstrap-producer did not complete within ${BOOTSTRAP_TIMEOUT}s"
-      docker compose -f "$COMPOSE_FILE" logs --tail 80 bootstrap-producer 2>&1
-      exit 1
-    fi
-    sleep 5
-  done
 
   for RELAY in amaru-relay-1 amaru-relay-2; do
     for ENV_REQUIREMENT in AMARU_LOG=warn AMARU_TRACE=warn AMARU_COLOR=never; do
@@ -224,20 +200,21 @@ if [[ "$TESTNET" == cardano_amaru* ]]; then
       fi
     done
 
-    echo "Waiting for ${RELAY} to consume bootstrap bundle..."
-    RELAY_DEADLINE=$((SECONDS + 180))
+    echo "Waiting for ${RELAY} to self-bootstrap (timeout ${BOOTSTRAP_TIMEOUT}s)..."
+    RELAY_DEADLINE=$((SECONDS + BOOTSTRAP_TIMEOUT))
     while ! docker exec "$RELAY" sh -c \
-        'test -d /srv/amaru/ledger.testnet_42.db/live \
+        'test -f /srv/amaru/.bootstrap-complete \
+          && test -d /srv/amaru/ledger.testnet_42.db/live \
           && test -d /srv/amaru/chain.testnet_42.db \
           && test -f /srv/amaru/nonces.json' 2>/dev/null; do
       STATE="$(docker inspect -f '{{.State.Status}}' "$RELAY" 2>/dev/null || true)"
       if [ "$STATE" = "exited" ] || [ "$STATE" = "dead" ]; then
-        echo "FAIL: ${RELAY} stopped before consuming bootstrap bundle"
+        echo "FAIL: ${RELAY} stopped before self-bootstrap completed"
         docker compose -f "$COMPOSE_FILE" logs --tail 80 "$RELAY" 2>&1
         exit 1
       fi
       if [ "$SECONDS" -ge "$RELAY_DEADLINE" ]; then
-        echo "FAIL: ${RELAY} did not copy bootstrap bundle"
+        echo "FAIL: ${RELAY} did not finish self-bootstrap within ${BOOTSTRAP_TIMEOUT}s"
         docker compose -f "$COMPOSE_FILE" logs --tail 80 "$RELAY" 2>&1
         exit 1
       fi

--- a/specs/080-amaru-self-bootstrap/checklists/requirements.md
+++ b/specs/080-amaru-self-bootstrap/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Amaru relays self-bootstrap
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec intentionally references concrete container/service/volume names
+  (`bootstrap-producer`, `amaru-relay-1/2`, `pN-state`, `aN-state`,
+  `/amaru-startup/...`) because the feature is a topology refactor of an
+  existing, named compose project — these are the entities the feature
+  operates on, not implementation details to be invented.
+- Exit codes (1/2/5/7) and the `AMARU_BOOTSTRAP_RETRY_SECONDS` env var are
+  preserved-as-is contracts of the existing `/bin/bootstrap-producer`
+  binary; they are part of the requirement, not implementation choice.

--- a/specs/080-amaru-self-bootstrap/data-model.md
+++ b/specs/080-amaru-self-bootstrap/data-model.md
@@ -1,0 +1,72 @@
+# Phase 1 Data Model: Amaru relays self-bootstrap
+
+The "data model" for this feature is the compose volume topology and the
+file-level contracts between the relay entrypoint, the
+`/bin/bootstrap-producer` binary, and the sidecar.
+
+## Volume changes
+
+| Volume | Before | After | Notes |
+|--------|--------|-------|-------|
+| `p1-state` | rw on `p1`; ro on `bootstrap-producer` (`/live`) | rw on `p1`; **ro on `amaru-relay-1` (`/live`)** | New mount target; producer is unaware. |
+| `p2-state` | rw on `p2` | rw on `p2`; **ro on `amaru-relay-2` (`/live`)** | New mount target. |
+| `p3-state` | rw on `p3` | rw on `p3` | Unchanged. |
+| `p1-configs` | rw on `configurator`; ro on `p1` and `bootstrap-producer` (`/cardano/config`) | rw on `configurator`; ro on `p1` and **ro on `amaru-relay-1`** | New mount target. |
+| `p2-configs` | rw on `configurator`; ro on `p2` | rw on `configurator`; ro on `p2`; **ro on `amaru-relay-2`** | New mount target. |
+| `bootstrap-state` | rw on `bootstrap-producer` (`/cardano/state`) | **DELETED** | Per-relay scratch lives on `aN-state` instead. |
+| `amaru-bundle` | rw on `bootstrap-producer` (`/srv/amaru`); ro on `amaru-relay-{1,2}` (`/bundle`) | **DELETED** | Inter-container handoff no longer needed. |
+| `a1-state` | rw on `amaru-relay-1` (`/srv/amaru`) | rw on `amaru-relay-1` (`/srv/amaru`) — now also holds the `testnet_42/` scratch subdir | Same volume, expanded use. |
+| `a2-state` | rw on `amaru-relay-2` (`/srv/amaru`) | rw on `amaru-relay-2` (`/srv/amaru`) — now also holds the `testnet_42/` scratch subdir | Same volume, expanded use. |
+| `amaru-startup` | rw on `amaru-relay-{1,2}` (`/startup`); ro on `sidecar` (`/amaru-startup`) | unchanged | Sidecar contract preserved. |
+
+## Service topology
+
+| Service | Before | After |
+|---------|--------|-------|
+| `bootstrap-producer` | Defined; one-shot; `restart: "no"`; `depends_on: p1:service_started` | **DELETED** |
+| `amaru-relay-1` | `depends_on: bootstrap-producer:service_completed_successfully` + image-via-anchor; entrypoint waits on `/bundle/testnet_42/...` then `cp -rL` then `amaru run --peer-address p1.example:3001` | `depends_on: p1:service_started`; entrypoint runs the bootstrap-loop against `/live` (= p1-state) → writes `/srv/amaru/testnet_42/...` → `cp -rL` to `/srv/amaru/` → marker → `exec amaru run --peer-address p1.example:3001` |
+| `amaru-relay-2` | same as relay-1 but paired with p2 | same as relay-1 but paired with p2 |
+| `sidecar` | `AMARU_STARTUP_REQUIRED=true`, `AMARU_STARTUP_DIR=/amaru-startup`, `AMARU_RELAYS="amaru-relay-1 amaru-relay-2"` | unchanged |
+
+## File-level contracts (preserved verbatim)
+
+### `/bin/bootstrap-producer` exit codes
+
+Inherited from the current image; the relay entrypoint MUST treat them
+identically:
+
+| Code | Meaning | Action in relay entrypoint |
+|------|---------|----------------------------|
+| 0 | Success — `wrote …` line in attempt log; final dir committed | Break the bootstrap loop; proceed to marker + `exec amaru run`. |
+| 1, 2, 5, 7 | Transient (snapshot copied before enough immutable history; Antithesis fault during read; partial files) | Sleep `AMARU_BOOTSTRAP_RETRY_SECONDS`; refresh snapshot; retry. |
+| Any other non-zero | Hard failure | `tail -n 50` of attempt log to stderr; `exit "$rc"` (relay container exits non-zero — surfaces to Antithesis as a container failure). |
+
+### Marker file contract (consumed by sidecar)
+
+- Path: `/startup/<container-name>.started` inside the relay
+  (`/amaru-startup/<container-name>.started` from the sidecar's
+  perspective via the shared `amaru-startup` volume).
+- Contents: hostname, one line. (Existing pattern;
+  `printf '%s\n' "$HOSTNAME"`.)
+- Write timing: AFTER `bundle_complete` is true (i.e. after bootstrap
+  succeeded and the `/srv/amaru/{ledger,chain,nonces}` layout is in
+  place), BEFORE `exec /bin/amaru run`.
+- Idempotency: if marker already exists from a prior container instance
+  (volume survives restart), overwriting is a no-op.
+
+### Environment variables (preserved)
+
+| Var | Default | Read by | Notes |
+|-----|---------|---------|-------|
+| `AMARU_BOOTSTRAP_RETRY_SECONDS` | `5` (was `20` in the bootstrap-producer's `${VAR:-20}` default; the per-service override sets it to `5`) | Relay entrypoint | Sleep between retries. |
+| `AMARU_LOG`, `AMARU_TRACE`, `AMARU_COLOR` | from `x-amaru` anchor | `amaru run` (later in the same container) | Unchanged. |
+| `AMARU_NETWORK`, `AMARU_CLUSTER_READY_DEADLINE_SECONDS`, `AMARU_WAIT_DEADLINE_SECONDS`, `AMARU_POLL_INTERVAL_SECONDS` | from current `bootstrap-producer.environment` | `/bin/bootstrap-producer` | Move from `bootstrap-producer.environment` into each `amaru-relay-N.environment` (or into the `x-amaru` anchor). |
+
+## Producer/relay pairing
+
+Preserved exactly as today:
+
+| Relay | Producer state read | `--peer-address` used by `amaru run` |
+|-------|---------------------|--------------------------------------|
+| `amaru-relay-1` | `p1-state` (via `/live:ro`) + `p1-configs` (via `/cardano/config:ro`) | `p1.example:3001` |
+| `amaru-relay-2` | `p2-state` (via `/live:ro`) + `p2-configs` (via `/cardano/config:ro`) | `p2.example:3001` |

--- a/specs/080-amaru-self-bootstrap/plan.md
+++ b/specs/080-amaru-self-bootstrap/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Amaru relays self-bootstrap
+
+**Branch**: `080-amaru-self-bootstrap` | **Date**: 2026-05-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/080-amaru-self-bootstrap/spec.md`
+
+## Summary
+
+Remove the standalone `bootstrap-producer` service from
+`testnets/cardano_amaru_epoch3600/docker-compose.yaml`. Move its retry loop
++ `/bin/bootstrap-producer` invocation into each `amaru-relay-N`
+container's entrypoint, paired with that relay's upstream cardano-node
+producer (relay-1 ↔ p1, relay-2 ↔ p2). Each relay now does its own
+bootstrap to producer state, writes its `/amaru-startup` marker, then
+`exec /bin/amaru run`. Drop the shared `amaru-bundle` and
+`bootstrap-state` volumes — per-relay scratch lives on the existing
+`a1-state` / `a2-state` volumes. Net effect: Antithesis "setup complete"
+fires within seconds (every container is `service_started` immediately);
+bootstrap work happens during the test phase where the budget is hours,
+not 6 minutes.
+
+The amaru-bootstrap-producer image (`ghcr.io/lambdasistemi/amaru-bootstrap-producer:pr-32-…`)
+is reused unchanged — it already ships `/bin/sh`, `/bin/bootstrap-producer`,
+and `/bin/amaru`. No new components, no new images, no upstream changes
+required.
+
+## Technical Context
+
+**Language/Version**: Bourne shell (`/bin/sh`) for the entrypoint; YAML for compose.
+**Primary Dependencies**: `podman-compose` / `docker compose` ≥ 2.36; the existing `amaru-bootstrap-producer` image (ships `/bin/sh`, `/bin/bootstrap-producer`, `/bin/amaru`).
+**Storage**: Per-relay named volumes `a1-state`, `a2-state` (existing); `pN-state` mounted read-only from the upstream cardano-node producers.
+**Testing**: `just smoke-test` (or local `docker compose up`) for the testnet; Antithesis 1h dispatch on the branch for the binding gate.
+**Target Platform**: Linux, podman-in-VM under Antithesis sandbox; Docker on local dev.
+**Project Type**: Compose topology refactor inside a single testnet directory.
+**Performance Goals**: `compose up` to `service_started`-on-everything in <90 s on the Antithesis VM (4 vCPU / 16 GB).
+**Constraints**: Antithesis setup deadline = 6 min hard. Per-relay disk for the bootstrap scratch copy must stay within the testnet's existing storage envelope (~hundreds of MB).
+**Scale/Scope**: 1 testnet (`cardano_amaru_epoch3600`), 2 amaru-relay services, 1 compose file edited, 0 new components.
+
+## Constitution Check
+
+*Re-evaluated post-design — all gates pass.*
+
+| Principle | Applies? | Status | Notes |
+|-----------|----------|--------|-------|
+| I. Composer-first workload | No | n/a | This is a compose topology change; no composer commands added or modified. |
+| II. SDK instrumentation | No | n/a | No new SDK code paths. |
+| III. Short-running commands | No | n/a | Not a composer command. |
+| IV. Duration-robust | Yes | Pass | Bootstrap moves into the test phase; works the same at 1h and 3h. Longer durations only give more headroom. |
+| V. Realistic workload | No | n/a | No workload generation changes. |
+| VI. Bisect-safe commits | Yes | Pass | Single self-contained compose-file diff; no intermediate state. `just smoke-test` runs both before and after. |
+| VII. Image tag hygiene | Yes | Pass | No `ghcr.io/cardano-foundation/cardano-node-antithesis/<name>` images change. The upstream `lambdasistemi/amaru-bootstrap-producer` tag is unchanged (same digest, same image, just used differently). |
+| Composer smoke-tests run locally | No | n/a | No composer changes. |
+| Custom testnet boundaries | Yes | Pass | No mainnet dependencies introduced; bootstrap reads from local `pN-state`. |
+| Minimal sidecar image | Yes | Pass | Sidecar untouched. |
+| Hard gate: `findings_new <= baseline` | Yes | Will run | Plan includes an Antithesis 1h dispatch on `080-amaru-self-bootstrap` before merge; baseline is current `feat/amaru-bootstrap-producer-cluster` (which today fails setup, so the binding comparison is against `main`'s last green Amaru run on this testnet). |
+
+**Note on scope of "Image tag hygiene"**: the constitution mandates a tag bump *when a PR modifies a component's source*. This PR does not modify any `components/<name>/` directory, so no tag bump is required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/080-amaru-self-bootstrap/
+├── spec.md              # Feature spec (already written)
+├── plan.md              # This file
+├── research.md          # Phase 0 — open questions resolved before edits
+├── data-model.md        # Phase 1 — volume/marker contract reference
+├── quickstart.md        # Phase 1 — how to validate locally + on Antithesis
+└── checklists/
+    └── requirements.md  # Spec quality checklist (already written)
+```
+
+`tasks.md` is **out of scope for `/speckit.plan`** — created by `/speckit.tasks` next.
+
+### Source Code (repository root)
+
+Only one file is edited; no new directories. The plan-relevant tree:
+
+```text
+cardano-node-antithesis/
+├── testnets/
+│   └── cardano_amaru_epoch3600/
+│       ├── docker-compose.yaml      ← THE edit (remove bootstrap-producer
+│       │                              service + amaru-bundle/bootstrap-state
+│       │                              volumes; rewrite amaru-relay-N
+│       │                              command and depends_on; mount pN-state
+│       │                              into amaru-relay-N as /live:ro)
+│       ├── amaru-runtime/           (unchanged)
+│       ├── relay-topology.json      (unchanged)
+│       ├── testnet.yaml             (unchanged)
+│       └── tracer-config.yaml       (unchanged)
+└── components/                      (untouched)
+```
+
+**Structure Decision**: Single-file compose-topology edit. The implementation surface is one YAML file. Bash inside that YAML inherits the shape of the existing `bootstrap-producer.command:` block — same retry semantics, same exit-code handling, just hoisted into each relay's entrypoint.
+
+## Phase 0 — Research / open questions
+
+Captured separately in [`research.md`](./research.md). Summary of questions
+resolved before writing the diff:
+
+1. Do `pN-state` volumes need to be mounted read-only into the relay
+   *and* the producer simultaneously? — Yes; the existing bootstrap-producer
+   already mounts `p1-state:/live:ro` while p1 has `p1-state:/state` (rw).
+   Adding a second read-only mount of the same volume into amaru-relay-N is
+   a no-op for the producer.
+2. Does the relay container need both `pN-state:/live:ro` AND
+   `pN-configs:/cardano/config:ro`? — Yes; `/bin/bootstrap-producer` reads
+   the config dir for genesis/protocol params alongside the state.
+3. Is concurrent read of one `pN-state` volume by both `pN` (rw) and
+   `amaru-relay-N` (ro) safe under the bootstrap-producer's
+   "snapshot-then-validate" approach (which is why it retries on codes
+   1/2/5/7)? — Yes, that's exactly the case the existing retry-loop covers;
+   we inherit it unchanged.
+4. Does `restart: always` on `amaru-relay-N` interact badly with the
+   in-entrypoint bootstrap loop on container restart? — No; the
+   `bundle_complete` short-circuit at the top of the loop makes a restart
+   idempotent (already-bootstrapped relays skip straight to `amaru run`).
+5. Do we need a final `bundle_complete`-equivalent for the relay's view
+   (`/srv/amaru/ledger.testnet_42.db` etc.) or can we drop the
+   `testnet_42/` subdir indirection? — We drop the indirection. The
+   bootstrap-producer's "commit" used to be: write to
+   `/srv/amaru/testnet_42/{ledger,chain,nonces}`; relays then `cp -rL
+   /bundle/testnet_42/. /srv/amaru/`. Now the relay writes
+   `/bin/bootstrap-producer …` output into `/srv/amaru/testnet_42/` and
+   keeps the same final `cp -rL` — fewer moving parts than refactoring
+   the on-disk layout.
+
+## Phase 1 — Design artifacts
+
+### `data-model.md`
+
+The "data model" here is volumes + a marker file, all inherited from the
+existing testnet. See [`data-model.md`](./data-model.md) for the
+volume-by-volume mapping (which volumes go away, which are reused, which
+mount points change).
+
+### `contracts/`
+
+**Skipped** — this feature has no external API/CLI/grammar surface.
+Internal contracts (the existing `/bin/bootstrap-producer` exit-code
+contract, the `/amaru-startup/<relay>.started` marker contract, the
+sidecar's `AMARU_STARTUP_*` env contract) are preserved verbatim and
+documented in `data-model.md`.
+
+### `quickstart.md`
+
+How to validate the change locally and on Antithesis. See
+[`quickstart.md`](./quickstart.md).
+
+### Agent context update
+
+This repo's agent context is `CLAUDE.md`. No update needed — the change
+is a single compose-file edit confined to one testnet directory and
+introduces no new technologies, languages, or conventions.
+
+## Complexity Tracking
+
+No constitution violations to justify.

--- a/specs/080-amaru-self-bootstrap/quickstart.md
+++ b/specs/080-amaru-self-bootstrap/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Amaru relays self-bootstrap
+
+How to validate the change locally, then on Antithesis. Keep this
+walkthrough open while reviewing the diff.
+
+## Local validation
+
+### Bring the testnet up
+
+```bash
+cd testnets/cardano_amaru_epoch3600
+docker compose up -d
+```
+
+Expected within ~60 s:
+- All containers in `Up`.
+- `bootstrap-producer` is **gone** from `docker compose ps` output.
+- `amaru-relay-1` and `amaru-relay-2` are `Up`. They MAY still be
+  bootstrapping internally (look at `docker logs amaru-relay-1`); they
+  MUST NOT be `Created` or `Restarting`.
+
+### Watch the in-relay bootstrap
+
+```bash
+docker logs -f amaru-relay-1
+```
+
+Expected sequence:
+1. Bootstrap loop output: snapshot copy + `/bin/bootstrap-producer …`
+   attempt logs.
+2. On success: `bootstrap-producer: committed /srv/amaru/testnet_42`
+   (or the `wrote …` line from the binary).
+3. Marker write (silent): `/startup/amaru-relay-1.started` appears.
+4. `amaru run …` startup banner.
+
+Same for `amaru-relay-2`.
+
+### Confirm the sidecar still gates on Amaru readiness
+
+```bash
+docker logs sidecar | head -30
+```
+
+Expected: sidecar logs show it waiting for
+`/amaru-startup/amaru-relay-1.started` and `…relay-2.started`. Once both
+relays finish bootstrap, the sidecar's chainpoint workflow proceeds as
+in the existing testnet.
+
+### Tear down
+
+```bash
+docker compose down -v
+```
+
+## Antithesis validation (the binding gate)
+
+### Dispatch a 1h run on the branch
+
+```bash
+gh workflow run cardano-node.yaml \
+  --repo cardano-foundation/cardano-node-antithesis \
+  --ref 080-amaru-self-bootstrap
+```
+
+Wait for the GitHub Actions run to print the test ID + Antithesis
+report URL.
+
+### What the report MUST show
+
+- Status: `Completed` (not `IncompleteTimed out`, not `setup_error`).
+- "Setup complete" event present in the timeline.
+- `bootstrap-producer` container does NOT appear in the container list
+  (because it no longer exists).
+- `amaru-relay-1` and `amaru-relay-2` containers are `Running` for the
+  duration.
+- Property report renders (passed/failed mix; not the empty error-card
+  view).
+
+### What to compare against the baseline
+
+`findings_new` on this branch's 1h run vs. the most recent green
+1h-Amaru-testnet run on `main`. Use
+`mcp__merge-guard__check-merge-ready` with the report URL to score the
+gate.
+
+## Rollback
+
+If the Antithesis 1h run regresses Amaru properties (not just setup),
+revert the single compose-file edit:
+
+```bash
+git revert <commit-sha>
+```
+
+The bootstrap-producer image and per-relay scratch volumes are
+unchanged, so revert is a straight YAML rollback — no image rebuild, no
+volume migration.

--- a/specs/080-amaru-self-bootstrap/research.md
+++ b/specs/080-amaru-self-bootstrap/research.md
@@ -1,0 +1,146 @@
+# Phase 0 Research: Amaru relays self-bootstrap
+
+All questions resolved before writing the diff. Each entry records the
+decision, why, and what was considered instead.
+
+---
+
+## R1. Can `pN-state` be mounted read-only in `amaru-relay-N` while `pN` mounts it read-write?
+
+**Decision**: Yes. Mount `p1-state:/live:ro` in `amaru-relay-1` and
+`p2-state:/live:ro` in `amaru-relay-2`. The producers `p1`/`p2` keep
+their existing `pN-state:/state` (rw) mounts.
+
+**Rationale**: This is exactly what the current `bootstrap-producer`
+service does — it mounts `p1-state:/live:ro` while p1 is writing to the
+same volume. Reads are tolerated by the OS layer; the bootstrap-producer
+binary expects snapshot-style semantics (not a transactional read) and
+its retry-on-codes-1/2/5/7 already covers the "I read a half-written
+file" case.
+
+**Alternatives considered**: Snapshotting the producer state to a
+sidecar volume first. Rejected because it adds a new service, defeating
+the point of the refactor.
+
+---
+
+## R2. Do both producer state AND producer config dirs need to be mounted?
+
+**Decision**: Yes. Each relay needs `pN-state:/live:ro` AND
+`pN-configs:/cardano/config:ro`.
+
+**Rationale**: The current `bootstrap-producer.command` invokes
+`/bin/bootstrap-producer /cardano/state /cardano/config/configs /srv/amaru testnet_42`.
+The second positional arg is the genesis/protocol-params config tree.
+Without it, bootstrap-producer cannot construct a valid initial ledger
+state.
+
+**Alternatives considered**: Bake configs into the
+amaru-bootstrap-producer image. Rejected — the testnet's configurator
+generates `pN-configs` per-pool at runtime from `testnet.yaml`; baked
+configs would drift.
+
+---
+
+## R3. Concurrent readers on a single `pN-state` volume — safe?
+
+**Decision**: Yes, no mitigation needed beyond the existing retry loop.
+
+**Rationale**: There is exactly one rw writer (the cardano-node producer
+`pN`) and one ro reader (`amaru-relay-N`) per volume. Each relay reads
+its *own* paired producer's state — no two relays read the same volume.
+Half-written reads are caught by `/bin/bootstrap-producer`'s exit
+codes 1/2/5/7, which are already in the existing retry whitelist.
+
+**Alternatives considered**:
+- Coordinate snapshot via `flock` — rejected; introduces a new sync
+  primitive across containers.
+- Have one relay snapshot, the other consume — that's exactly what
+  bootstrap-producer does today and is the architecture we're undoing.
+
+---
+
+## R4. Does `restart: always` on `amaru-relay-N` interact correctly with the in-entrypoint bootstrap loop?
+
+**Decision**: Yes — keep `restart: always`. The bootstrap loop's
+`bundle_complete()` check at the top makes restart idempotent: if a
+restarted relay finds its `/srv/amaru/ledger.testnet_42.db/live`,
+`/srv/amaru/chain.testnet_42.db`, and `/srv/amaru/nonces.json` already
+present (from the previous container's run on the same `aN-state`
+volume), the loop short-circuits to `exec amaru run` without redoing
+the bootstrap.
+
+**Rationale**: The current `bootstrap-producer` already has this
+short-circuit; we hoist the same logic into the relay. The
+`a1-state`/`a2-state` volumes survive container restarts.
+
+**Alternatives considered**: `restart: on-failure`. Rejected — Antithesis
+fault injection routinely SIGKILLs containers; we want the relay to come
+back up and resume.
+
+---
+
+## R5. On-disk layout — keep the `testnet_42/` subdir indirection or flatten?
+
+**Decision**: Keep the `testnet_42/` indirection. The bootstrap-producer
+binary writes to `/srv/amaru/testnet_42/{ledger.testnet_42.db,
+chain.testnet_42.db, nonces.json}`; the relay's existing entrypoint
+already does `cp -rL /bundle/testnet_42/. /srv/amaru/` to flatten before
+invoking `amaru run`. Reuse that copy step verbatim, just sourcing from
+the local in-container scratch dir instead of the cross-container
+`amaru-bundle` volume.
+
+**Rationale**: The smallest, safest diff. Flattening would mean either
+patching the bootstrap-producer binary (out of scope, upstream change)
+or post-processing (more shell complexity). The `cp -rL` is fast and
+proven.
+
+**Alternatives considered**: Patch upstream bootstrap-producer to write
+directly to the flat layout. Rejected — out of scope for this
+testnet-side change; would couple us to a new image build.
+
+---
+
+## R6. Are there other consumers of `bootstrap-producer` or `amaru-bundle` we'd break?
+
+**Decision**: No. Confirmed by grepping the testnet directory and the
+sidecar/composer config:
+
+- `bootstrap-producer` is only referenced by:
+  - The service definition itself in
+    `testnets/cardano_amaru_epoch3600/docker-compose.yaml`.
+  - `amaru-relay-1.depends_on` and `amaru-relay-2.depends_on` (both being
+    rewritten by this change).
+- `amaru-bundle` volume is only mounted by:
+  - `bootstrap-producer` (rw) — being removed.
+  - `amaru-relay-1` and `amaru-relay-2` (`/bundle:ro`) — being removed.
+- `bootstrap-state` volume is only mounted by `bootstrap-producer` —
+  being removed.
+
+The sidecar reads `/amaru-startup/*.started`; that contract is
+preserved.
+
+**Rationale**: Deletion is safe.
+
+**Alternatives considered**: Deprecate gradually (leave the volumes,
+just don't use them). Rejected — dead volumes waste Antithesis disk and
+add noise to the report's container/volume list.
+
+---
+
+## R7. Should the new relay entrypoint be inlined in compose YAML or shipped as a script in the image?
+
+**Decision**: Inline in compose YAML, mirroring the current
+`bootstrap-producer.command:` pattern.
+
+**Rationale**: The image is upstream
+(`ghcr.io/lambdasistemi/amaru-bootstrap-producer:pr-32-…`). Adding a
+script to the image means another upstream change + image rebuild +
+tag bump cycle. Inlining keeps the iteration loop entirely in
+`testnets/cardano_amaru_epoch3600/docker-compose.yaml`.
+
+**Alternatives considered**:
+- Ship the script as a bind-mounted file from the testnet dir — would
+  work but adds another file to maintain; the YAML inlining is what the
+  testnet already uses (see existing `bootstrap-producer.command`).
+- Bake into image — see above; out of scope.

--- a/specs/080-amaru-self-bootstrap/spec.md
+++ b/specs/080-amaru-self-bootstrap/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Amaru relays self-bootstrap
+
+**Feature Branch**: `080-amaru-self-bootstrap`
+**Created**: 2026-05-02
+**Status**: Draft
+**Input**: User description: "collapse the standalone bootstrap-producer service into the amaru-relay containers so Antithesis setup completes immediately and the bootstrap work happens during the test phase"
+
+## Context
+
+Antithesis enforces a 6-minute deadline for "setup complete". The current
+`testnets/cardano_amaru_epoch3600/` topology gates `amaru-relay-1` and
+`amaru-relay-2` on a one-shot `bootstrap-producer` service via
+`depends_on: bootstrap-producer:service_completed_successfully`. The bootstrap
+step is unbounded — it depends on a randomized initial state distribution and
+must catch the producer chain through to a recent epoch (potentially 2–3
+epochs of header/snapshot work). When that work cannot finish within 6
+minutes, Antithesis reports `No 'setup complete' event received` and the
+campaign is aborted before any test phase executes.
+
+Reference incident: testRunId
+`667f319955a2956182d9bcbcc4a1b28b87def6589c1c9786ae071b4992eb22fa`,
+[GH run 25237677229][run], [Antithesis report][report].
+
+[run]: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25237677229
+[report]: https://cardano.antithesis.com/report/eWsMhCd8q5PIAI-xv0CobduX/YFRkIxgk2WFp-wC2fB-FIV2zNzoYbkrNHPDYjs7YrIs.html
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Antithesis setup completes regardless of initial state distribution (Priority: P1)
+
+As an operator submitting an Antithesis test against the Amaru testnet, I
+want compose `up` to return within Antithesis's setup deadline regardless of
+how far behind the producer cluster's initial state happens to be, so that
+the test phase always runs and I get either a clean campaign or a meaningful
+property report — never a `setup_error`.
+
+**Why this priority**: Without this, every run whose initial state requires
+more than ~5 minutes of Amaru bootstrap is wasted: no findings, no logs
+worth triaging, no signal about Amaru itself. This is the precondition for
+*any* Amaru observation in Antithesis.
+
+**Independent Test**: Submit a test run via the existing GitHub Actions
+workflow against the modified testnet. The Antithesis report MUST show
+either `Completed` or a normal property report (passed/failed mix) — it MUST
+NOT show `setup_error: No 'setup complete' event received`. Repeat across at
+least three submissions with the default randomized fault settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh Antithesis test submission against the Amaru testnet,
+   **When** Antithesis runs `compose up`, **Then** all containers reach
+   their `service_started` state within 6 minutes and the `setup complete`
+   event is emitted.
+2. **Given** the slowest plausible initial state (producer cluster needs
+   2–3 epochs of catch-up), **When** the test campaign starts, **Then**
+   setup is already complete and the campaign begins exercising properties
+   while the Amaru relays continue bootstrapping inside the test phase.
+
+---
+
+### User Story 2 - Sidecar still gates chainpoint workflow on Amaru readiness (Priority: P1)
+
+As the existing sidecar that records chainpoints, I must continue to wait
+for both Amaru relays to be fully bootstrapped (ledger + chain DBs present
+and `amaru run` started) before I begin my chainpoint workflow, so that the
+properties downstream of the chainpoint workflow remain meaningful.
+
+**Why this priority**: The sidecar's `AMARU_STARTUP_REQUIRED=true` contract
+predates this change and is the only readiness signal the rest of the
+testnet relies on. Breaking it would silently invalidate every property
+that compares cardano-node and Amaru chain views.
+
+**Independent Test**: After setup completes, the sidecar's chainpoint
+workflow MUST NOT progress past its initial wait until BOTH
+`/amaru-startup/amaru-relay-1.started` and
+`/amaru-startup/amaru-relay-2.started` markers exist. Verify by inspecting
+sidecar logs in a successful campaign — chainpoint operations are
+timestamped strictly after both startup markers.
+
+**Acceptance Scenarios**:
+
+1. **Given** setup has completed and the test phase is running, **When**
+   only one Amaru relay has finished its in-container bootstrap, **Then**
+   the sidecar's chainpoint workflow is still waiting.
+2. **Given** both Amaru relays have written their startup markers,
+   **When** the sidecar polls, **Then** the chainpoint workflow proceeds
+   normally as it does today.
+
+---
+
+### User Story 3 - Bootstrap continues to tolerate Antithesis fault injection (Priority: P2)
+
+The current `bootstrap-producer` retries internally when it observes the
+transient failures Antithesis produces (snapshot copy errors under
+filesystem faults, partial immutable history under network faults — exit
+codes 1/2/5/7 from `/bin/bootstrap-producer`). The merged in-relay
+bootstrap MUST preserve this retry semantics so that fault injection during
+bootstrap does not cause the relay container to give up and the testnet to
+silently degrade to "Amaru not running".
+
+**Why this priority**: Without retry, the change trades a `setup_error`
+class of failure for a "container exited" class of failure. The campaign
+would still run but Amaru properties would not exercise — a subtler and
+worse signal.
+
+**Independent Test**: Run the testnet locally with podman-compose and
+inject a `chmod 000` on the producer state mid-bootstrap. The amaru-relay
+container MUST log a transient failure and retry, eventually completing
+once the fault is removed. The container MUST NOT exit non-zero on
+transient codes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the relay is mid-bootstrap and `/bin/bootstrap-producer`
+   exits 1, 2, 5, or 7, **When** the entrypoint observes the exit, **Then**
+   it sleeps `AMARU_BOOTSTRAP_RETRY_SECONDS` and tries again from a fresh
+   snapshot copy.
+2. **Given** the relay is mid-bootstrap and `/bin/bootstrap-producer`
+   exits with any other non-zero code, **When** the entrypoint observes
+   the exit, **Then** the last attempt log is surfaced and the relay
+   container exits with that code.
+
+---
+
+### Edge Cases
+
+- **Both relays bootstrap concurrently against different producers**: each
+  relay reads producer state from its paired cardano-node (relay-1 ↔ p1,
+  relay-2 ↔ p2), mounted read-only. Concurrent reads against distinct
+  producer state volumes are independent and MUST be safe.
+- **Antithesis kills a relay mid-bootstrap and restarts it**: the
+  entrypoint MUST be idempotent — on restart, the working snapshot copy
+  is re-taken from a fresh producer snapshot; the final ledger/chain DBs
+  MUST not be left half-written such that `amaru run` starts against
+  corrupt state.
+- **Producer is itself behind**: the relay's bootstrap retry loop MUST
+  keep trying; it MUST NOT escalate "snapshot incomplete" to a hard
+  failure. Today's retry codes (1/2/5/7) cover this.
+- **Disk pressure from per-relay bootstrap working copies**: each relay
+  now keeps its own scratch copy of producer immutable/ledger/volatile
+  dirs (previously a single shared copy in `bootstrap-state`). Storage
+  budget MUST account for 2× the per-relay working set.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `cardano_amaru_epoch3600` testnet MUST NOT include a
+  standalone `bootstrap-producer` service.
+- **FR-002**: Each `amaru-relay-N` container MUST perform its own
+  bootstrap from the producer-cluster state it is paired with (relay-1 ↔
+  p1, relay-2 ↔ p2), and then `exec amaru run …` in the same container.
+- **FR-003**: The `amaru-relay-N` containers MUST start as soon as their
+  upstream cardano-node producer is `service_started`. They MUST NOT
+  block on `service_completed_successfully` from any other service.
+- **FR-004**: The `amaru-relay-N` entrypoint MUST retry transient
+  bootstrap failures (`/bin/bootstrap-producer` exit codes 1, 2, 5, 7)
+  with the same `AMARU_BOOTSTRAP_RETRY_SECONDS` semantics as the current
+  `bootstrap-producer` service.
+- **FR-005**: The `amaru-relay-N` entrypoint MUST write the existing
+  `/amaru-startup/amaru-relay-N.started` marker only AFTER the bootstrap
+  step has completed and immediately before `exec amaru run`.
+- **FR-006**: The shared `amaru-bundle` and `bootstrap-state` volumes
+  MUST be removed; per-relay scratch state lives on the existing per-relay
+  state volumes (`a1-state`, `a2-state`).
+- **FR-007**: The sidecar's `AMARU_STARTUP_REQUIRED=true` /
+  `AMARU_STARTUP_DIR` / `AMARU_RELAYS` configuration MUST remain
+  unchanged in shape and semantics.
+- **FR-008**: Antithesis "setup complete" MUST be emitted as soon as
+  every container is `service_started`. Bootstrap progress inside the
+  relay containers MUST happen in the test phase, not the setup phase.
+
+### Key Entities *(include if feature involves data)*
+
+- **Producer state volume (`pN-state`)**: read-only input to the relay
+  bootstrap; contains `immutable/`, `ledger/`, `volatile/`,
+  `protocolMagicId`, `lock`. Identical to today's `bootstrap-producer`'s
+  `/live` mount, but mounted into the relay instead of into a separate
+  service.
+- **Per-relay state volume (`aN-state`)**: writable working area mounted
+  at `/srv/amaru` in the relay; holds both the bootstrap scratch copy and
+  the final `ledger.testnet_42.db` / `chain.testnet_42.db` /
+  `nonces.json` consumed by `amaru run`.
+- **Startup marker (`/amaru-startup/amaru-relay-N.started`)**: file
+  written by the relay entrypoint after bootstrap, before `amaru run`.
+  Read by the sidecar's chainpoint workflow.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Across 5 consecutive Antithesis test submissions against
+  the Amaru testnet with default fault settings, ZERO submissions return
+  `setup_error: No 'setup complete' event received`.
+- **SC-002**: Antithesis "setup complete" is emitted within 90 seconds
+  of `compose up` start (well below the 6-minute deadline) regardless of
+  initial state distribution.
+- **SC-003**: For Antithesis runs of 1-hour duration, the sidecar's
+  chainpoint workflow proceeds in 100% of runs (i.e. both Amaru relays
+  finish their in-test-phase bootstrap within the first hour for any
+  initial state we have observed).
+- **SC-004**: When `/bin/bootstrap-producer` exits 1/2/5/7 during a
+  relay's bootstrap, the relay container is observed to retry at least
+  once (i.e. transient failures do not propagate to "container exited
+  with non-zero" findings in Antithesis).
+
+## Assumptions
+
+- Each Amaru relay reads producer state from exactly one producer
+  cardano-node, mirroring the existing `--peer-address` topology
+  (relay-1 ↔ `p1`, relay-2 ↔ `p2`). Cross-pairing or shared sources are
+  out of scope.
+- Per-relay disk budget under Antithesis can absorb a second working
+  copy of the producer immutable+ledger+volatile state. The reference
+  6-min snapshot showed bootstrap-producer's disk read footprint at
+  ~70 MB block_read; per-relay scratch copies at this scale are
+  acceptable. If the actual on-disk working set is materially larger,
+  this assumption needs revisiting.
+- The `service_completed_successfully` semantics for amaru-relay's
+  `depends_on: bootstrap-producer` is the only place that gate exists in
+  the testnet — no other service references `bootstrap-producer`.
+- The Antithesis 6-minute setup deadline is not negotiable and the
+  bootstrap workload is genuinely epoch-bounded (cannot be made fast
+  enough to fit), so the architectural fix (move bootstrap out of setup)
+  is the only viable path.
+- The change is scoped to the `cardano_amaru_epoch3600` testnet; other
+  testnets (`cardano_node_master`, `cardano_node_adversary`, etc.) are
+  unaffected.

--- a/testnets/cardano_amaru_epoch3600/docker-compose.yaml
+++ b/testnets/cardano_amaru_epoch3600/docker-compose.yaml
@@ -224,7 +224,7 @@ services:
                 fi
                 # promote failed (rare; e.g. cp interrupted) — fall through and retry
                 ;;
-              1|2|5|7)
+              1|2|5|6|7|8)
                 # Transient under Antithesis faults or a snapshot copied before
                 # enough immutable history was available. Refresh state and
                 # try again so Antithesis does not record this as a container
@@ -339,7 +339,7 @@ services:
                   continue
                 fi
                 ;;
-              1|2|5|7)
+              1|2|5|6|7|8)
                 ;;
               *)
                 tail -n 50 "$${attempt_log}" >&2 || true

--- a/testnets/cardano_amaru_epoch3600/docker-compose.yaml
+++ b/testnets/cardano_amaru_epoch3600/docker-compose.yaml
@@ -44,9 +44,15 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
+  #
+  # Each amaru-relay-N self-bootstraps from its paired cardano-node
+  # producer pN inside its own entrypoint, then exec's /bin/amaru run.
+  # Bootstrap happens during the test phase, not the Antithesis 6-min
+  # setup window — see specs/080-amaru-self-bootstrap/.
   image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:pr-32-ad64e76778b0408ec66f353c7e58c8a1e7d4045f
   entrypoint:
     - /bin/sh
+    - -ec
   environment:
     # Antithesis log ingestion is intentionally narrow: keep Amaru below
     # warning/error quiet by default. Upstream Amaru uses AMARU_LOG rather
@@ -54,10 +60,14 @@ x-amaru: &amaru
     AMARU_LOG: warn
     AMARU_TRACE: warn
     AMARU_COLOR: never
+    # Inherited from the previous standalone bootstrap-producer service:
+    # /bin/bootstrap-producer reads these to size its catch-up loop.
+    AMARU_NETWORK: testnet_42
+    AMARU_CLUSTER_READY_DEADLINE_SECONDS: "30"
+    AMARU_WAIT_DEADLINE_SECONDS: "30"
+    AMARU_POLL_INTERVAL_SECONDS: "5"
+    AMARU_BOOTSTRAP_RETRY_SECONDS: "5"
   restart: always
-  depends_on:
-    bootstrap-producer:
-      condition: service_started
 
 services:
   configurator:
@@ -129,21 +139,30 @@ services:
       - relay2-state:/state
       - tracer:/tracer
 
-  bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:pr-32-ad64e76778b0408ec66f353c7e58c8a1e7d4045f
-    container_name: bootstrap-producer
-    hostname: bootstrap-producer.example
-    entrypoint:
-      - /bin/sh
-      - -ec
+  amaru-relay-1:
+    <<: *amaru
+    container_name: amaru-relay-1
+    hostname: amaru-relay-1.example
+    depends_on:
+      p1:
+        condition: service_started
     command:
       - |
+        relay="amaru-relay-1"
+        peer="p1.example:3001"
+
         retry="$${AMARU_BOOTSTRAP_RETRY_SECONDS:-20}"
-        final="/srv/amaru/testnet_42"
-        attempt_log="/srv/amaru/.logs/bootstrap-producer-attempt.log"
+        final="/srv/amaru"
+        work="$${final}/.work"
+        scratch_state="$${work}/cardano-state"
+        scratch_out="$${work}/out"
+        attempt_log="$${work}/bootstrap-attempt.log"
+        marker="/startup/$${relay}.started"
+        sentinel="$${final}/.bootstrap-complete"
 
         bundle_complete() {
-          test -d "$${final}/ledger.testnet_42.db/live" \
+          test -f "$${sentinel}" \
+            && test -d "$${final}/ledger.testnet_42.db/live" \
             && test -d "$${final}/chain.testnet_42.db" \
             && test -f "$${final}/nonces.json"
         }
@@ -155,45 +174,61 @@ services:
           test -f /live/protocolMagicId || return 1
           test -e /live/lock || return 1
 
-          mkdir -p /srv/amaru/.logs
-          rm -rf /cardano/state/.copy-tmp /cardano/state/*
-          mkdir -p /cardano/state/.copy-tmp
-          if cp -a /live/immutable /live/ledger /live/volatile /live/protocolMagicId /live/lock /cardano/state/.copy-tmp/ 2>/srv/amaru/.logs/snapshot-copy.err; then
-            rm -rf /cardano/state/immutable /cardano/state/ledger /cardano/state/volatile /cardano/state/protocolMagicId /cardano/state/lock
-            mv /cardano/state/.copy-tmp/immutable /cardano/state/
-            mv /cardano/state/.copy-tmp/ledger /cardano/state/
-            mv /cardano/state/.copy-tmp/volatile /cardano/state/
-            mv /cardano/state/.copy-tmp/protocolMagicId /cardano/state/
-            mv /cardano/state/.copy-tmp/lock /cardano/state/
-            rmdir /cardano/state/.copy-tmp
-            rm -f /srv/amaru/.logs/snapshot-copy.err
+          mkdir -p "$${work}"
+          rm -rf "$${scratch_state}.tmp" "$${scratch_state}"
+          mkdir -p "$${scratch_state}.tmp"
+          if cp -a /live/immutable /live/ledger /live/volatile /live/protocolMagicId /live/lock "$${scratch_state}.tmp/" 2>"$${work}/snapshot-copy.err"; then
+            mv "$${scratch_state}.tmp" "$${scratch_state}"
+            rm -f "$${work}/snapshot-copy.err"
             return 0
           fi
-          rm -rf /cardano/state/.copy-tmp
+          rm -rf "$${scratch_state}.tmp"
           return 1
+        }
+
+        promote() {
+          stage="$${final}/.staged"
+          rm -rf "$${stage}"
+          mkdir -p "$${stage}"
+          cp -rL "$${scratch_out}/testnet_42/." "$${stage}/" || return 1
+
+          # Sweep any stale top-level entries (except our scratch dirs).
+          find "$${final}" -mindepth 1 -maxdepth 1 \
+            ! -path "$${work}" \
+            ! -path "$${stage}" \
+            ! -path "$${sentinel}" \
+            -exec rm -rf {} +
+
+          for entry in "$${stage}"/*; do
+            mv "$${entry}" "$${final}/"
+          done
+          rmdir "$${stage}"
+          : > "$${sentinel}"
+          rm -rf "$${work}"
         }
 
         while :; do
           if bundle_complete; then
-            exit 0
+            break
           fi
 
           if refresh_snapshot; then
-            mkdir -p /srv/amaru/.logs
+            mkdir -p "$${scratch_out}"
             rc=0
-            /bin/bootstrap-producer /cardano/state /cardano/config/configs /srv/amaru testnet_42 >"$${attempt_log}" 2>&1 || rc=$$?
+            /bin/bootstrap-producer "$${scratch_state}" /cardano/config/configs "$${scratch_out}" testnet_42 >"$${attempt_log}" 2>&1 || rc=$$?
             case "$${rc}" in
               0)
-                if ! awk '/^wrote / { print; found=1 } END { exit found ? 0 : 1 }' "$${attempt_log}"; then
+                if promote; then
                   echo "bootstrap-producer: committed $${final}"
+                  continue
                 fi
-                exit 0
+                # promote failed (rare; e.g. cp interrupted) — fall through and retry
                 ;;
               1|2|5|7)
                 # Transient under Antithesis faults or a snapshot copied before
-                # enough immutable history was available. Refresh p1 state and
-                # try again inside this container so Antithesis does not record
-                # an expected readiness miss as a container failure.
+                # enough immutable history was available. Refresh state and
+                # try again so Antithesis does not record this as a container
+                # failure.
                 ;;
               *)
                 tail -n 50 "$${attempt_log}" >&2 || true
@@ -204,53 +239,19 @@ services:
 
           sleep "$${retry}"
         done
-    environment:
-      AMARU_NETWORK: testnet_42
-      AMARU_CLUSTER_READY_DEADLINE_SECONDS: "30"
-      AMARU_WAIT_DEADLINE_SECONDS: "30"
-      AMARU_POLL_INTERVAL_SECONDS: "5"
-      AMARU_BOOTSTRAP_RETRY_SECONDS: "5"
-    volumes:
-      - p1-state:/live:ro
-      - bootstrap-state:/cardano/state
-      - p1-configs:/cardano/config:ro
-      - amaru-bundle:/srv/amaru
-    depends_on:
-      p1:
-        condition: service_started
-    restart: "no"
 
-  amaru-relay-1:
-    <<: *amaru
-    container_name: amaru-relay-1
-    hostname: amaru-relay-1.example
-    depends_on:
-      bootstrap-producer:
-        condition: service_completed_successfully
-    command:
-      - -c
-      - |
-        set -eu
-        if [ ! -d /srv/amaru/ledger.testnet_42.db ] || [ ! -d /srv/amaru/chain.testnet_42.db ]; then
-          until [ -d /bundle/testnet_42/ledger.testnet_42.db ] \
-             && [ -d /bundle/testnet_42/chain.testnet_42.db ] \
-             && [ -f /bundle/testnet_42/nonces.json ]; do
-            sleep 10
-          done
-          find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          cp -rL /bundle/testnet_42/. /srv/amaru/
-        fi
         mkdir -p /startup
-        printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > /startup/amaru-relay-1.started
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > "$${marker}"
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
           --era-history-file /amaru-runtime/era-history.json \
           --global-parameters-file /amaru-runtime/global-parameters.json \
-          --peer-address p1.example:3001
+          --peer-address "$${peer}"
     volumes:
-      - amaru-bundle:/bundle:ro
+      - p1-state:/live:ro
+      - p1-configs:/cardano/config:ro
       - ./amaru-runtime:/amaru-runtime:ro
       - amaru-startup:/startup
       - a1-state:/srv/amaru
@@ -260,32 +261,108 @@ services:
     container_name: amaru-relay-2
     hostname: amaru-relay-2.example
     depends_on:
-      bootstrap-producer:
-        condition: service_completed_successfully
+      p2:
+        condition: service_started
     command:
-      - -c
       - |
-        set -eu
-        if [ ! -d /srv/amaru/ledger.testnet_42.db ] || [ ! -d /srv/amaru/chain.testnet_42.db ]; then
-          until [ -d /bundle/testnet_42/ledger.testnet_42.db ] \
-             && [ -d /bundle/testnet_42/chain.testnet_42.db ] \
-             && [ -f /bundle/testnet_42/nonces.json ]; do
-            sleep 10
+        relay="amaru-relay-2"
+        peer="p2.example:3001"
+
+        retry="$${AMARU_BOOTSTRAP_RETRY_SECONDS:-20}"
+        final="/srv/amaru"
+        work="$${final}/.work"
+        scratch_state="$${work}/cardano-state"
+        scratch_out="$${work}/out"
+        attempt_log="$${work}/bootstrap-attempt.log"
+        marker="/startup/$${relay}.started"
+        sentinel="$${final}/.bootstrap-complete"
+
+        bundle_complete() {
+          test -f "$${sentinel}" \
+            && test -d "$${final}/ledger.testnet_42.db/live" \
+            && test -d "$${final}/chain.testnet_42.db" \
+            && test -f "$${final}/nonces.json"
+        }
+
+        refresh_snapshot() {
+          test -d /live/immutable || return 1
+          test -d /live/ledger || return 1
+          test -d /live/volatile || return 1
+          test -f /live/protocolMagicId || return 1
+          test -e /live/lock || return 1
+
+          mkdir -p "$${work}"
+          rm -rf "$${scratch_state}.tmp" "$${scratch_state}"
+          mkdir -p "$${scratch_state}.tmp"
+          if cp -a /live/immutable /live/ledger /live/volatile /live/protocolMagicId /live/lock "$${scratch_state}.tmp/" 2>"$${work}/snapshot-copy.err"; then
+            mv "$${scratch_state}.tmp" "$${scratch_state}"
+            rm -f "$${work}/snapshot-copy.err"
+            return 0
+          fi
+          rm -rf "$${scratch_state}.tmp"
+          return 1
+        }
+
+        promote() {
+          stage="$${final}/.staged"
+          rm -rf "$${stage}"
+          mkdir -p "$${stage}"
+          cp -rL "$${scratch_out}/testnet_42/." "$${stage}/" || return 1
+
+          find "$${final}" -mindepth 1 -maxdepth 1 \
+            ! -path "$${work}" \
+            ! -path "$${stage}" \
+            ! -path "$${sentinel}" \
+            -exec rm -rf {} +
+
+          for entry in "$${stage}"/*; do
+            mv "$${entry}" "$${final}/"
           done
-          find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          cp -rL /bundle/testnet_42/. /srv/amaru/
-        fi
+          rmdir "$${stage}"
+          : > "$${sentinel}"
+          rm -rf "$${work}"
+        }
+
+        while :; do
+          if bundle_complete; then
+            break
+          fi
+
+          if refresh_snapshot; then
+            mkdir -p "$${scratch_out}"
+            rc=0
+            /bin/bootstrap-producer "$${scratch_state}" /cardano/config/configs "$${scratch_out}" testnet_42 >"$${attempt_log}" 2>&1 || rc=$$?
+            case "$${rc}" in
+              0)
+                if promote; then
+                  echo "bootstrap-producer: committed $${final}"
+                  continue
+                fi
+                ;;
+              1|2|5|7)
+                ;;
+              *)
+                tail -n 50 "$${attempt_log}" >&2 || true
+                exit "$${rc}"
+                ;;
+            esac
+          fi
+
+          sleep "$${retry}"
+        done
+
         mkdir -p /startup
-        printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > /startup/amaru-relay-2.started
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > "$${marker}"
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
           --era-history-file /amaru-runtime/era-history.json \
           --global-parameters-file /amaru-runtime/global-parameters.json \
-          --peer-address p2.example:3001
+          --peer-address "$${peer}"
     volumes:
-      - amaru-bundle:/bundle:ro
+      - p2-state:/live:ro
+      - p2-configs:/cardano/config:ro
       - ./amaru-runtime:/amaru-runtime:ro
       - amaru-startup:/startup
       - a2-state:/srv/amaru
@@ -352,10 +429,8 @@ volumes:
   p1-state:
   p2-state:
   p3-state:
-  bootstrap-state:
   relay1-state:
   relay2-state:
-  amaru-bundle:
   amaru-startup:
   a1-state:
   a2-state:


### PR DESCRIPTION
## Why

Following [run 25237677229](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25237677229), [Antithesis report](https://cardano.antithesis.com/report/eWsMhCd8q5PIAI-xv0CobduX/YFRkIxgk2WFp-wC2fB-FIV2zNzoYbkrNHPDYjs7YrIs.html) showed `setup_error: No 'setup complete' event received — timed out after 6 minutes`. Root cause: `bootstrap-producer` is wired as a one-shot init container (`amaru-relay-{1,2}.depends_on = bootstrap-producer:service_completed_successfully`) and its work depends on the randomized initial state distribution — sometimes 2-3 epochs of catch-up, which doesn't fit the 6-min Antithesis setup window. We can't pre-bake a snapshot because the initial state distribution is randomized. Healthcheck-gating doesn't help either — the work itself just doesn't fit the budget.

This PR collapses the bootstrap step into the amaru-relay containers so setup completes immediately and bootstrap proceeds during the test phase (where the budget is hours).

## What

### `testnets/cardano_amaru_epoch3600/docker-compose.yaml`

- **Delete** the standalone `bootstrap-producer` service.
- **Delete** volumes `bootstrap-state` and `amaru-bundle` (no longer needed; no inter-container handoff).
- `amaru-relay-1` and `amaru-relay-2`:
  - `depends_on` changes from `bootstrap-producer:service_completed_successfully` → `pN:service_started`. Setup is now bottlenecked only on cardano-node producers being up.
  - New volume mounts (mirroring what `bootstrap-producer` had): `pN-state:/live:ro` (read-only producer state) and `pN-configs:/cardano/config:ro` (genesis/protocol params).
  - New inline entrypoint script: hoists the existing `bootstrap-producer.command` retry loop into the relay. Same exit-code contract (0 = success, 1/2/5/7 = transient retry, other = hard fail), same `AMARU_BOOTSTRAP_RETRY_SECONDS` semantics. After successful bootstrap, the relay writes the existing `/startup/<relay>.started` marker (sidecar contract preserved verbatim) and `exec /bin/amaru run`.
  - Added a `.bootstrap-complete` sentinel for atomic promotion: the bootstrap output is staged in `/srv/amaru/.staged/`, then promoted entry-by-entry, then the sentinel is touched. This makes container restarts mid-promotion safe — `amaru run` only ever sees a complete bundle.
- The shared `x-amaru` anchor inherits the bootstrap-related env vars (`AMARU_NETWORK`, `AMARU_*_DEADLINE_SECONDS`, `AMARU_BOOTSTRAP_RETRY_SECONDS`) that were previously on the now-deleted `bootstrap-producer.environment`.
- Producer/relay pairing is preserved: relay-1 ↔ p1, relay-2 ↔ p2 (matches the existing `--peer-address` topology).

### `scripts/smoke-test.sh`

- Drop the `bootstrap-producer` exit-code wait gate (no such service anymore).
- The existing per-relay "bundle in place" gate (lines that wait for `/srv/amaru/{ledger,chain,nonces}`) becomes the equivalent readiness check. The check now also verifies the `.bootstrap-complete` sentinel.

### Spec / plan

`specs/080-amaru-self-bootstrap/`:

https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/specs/080-amaru-self-bootstrap/spec.md
https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/specs/080-amaru-self-bootstrap/plan.md
https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/specs/080-amaru-self-bootstrap/research.md
https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/specs/080-amaru-self-bootstrap/data-model.md
https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/specs/080-amaru-self-bootstrap/quickstart.md

## Local verification

`docker compose up -d` against `testnets/cardano_amaru_epoch3600/`:

- 11 containers reach `Up` status within ~6 seconds (no `bootstrap-producer` service in the list — confirmed gone).
- `amaru-relay-1` and `amaru-relay-2` stay `running` (not exited, not restarting).
- `/srv/amaru/.work/cardano-state/` populates with the producer snapshot copy.
- `/bin/bootstrap-producer` runs against the snapshot and emits a transient "waiting for chain DB tip" log (expected on a from-zero local testnet — exit 1/2/5/7 territory; the loop retries as designed).
- `RestartCount=0` on both relays after 30 s — script doesn't crash the container.

The full bootstrap-to-completion happy path is not validated locally because it needs hours of producer chain history. The Antithesis 1h dispatch on this branch is the binding gate.

## Test plan

- [x] Local `docker compose up -d` — all containers `Up` in seconds, amaru relays stay running
- [x] Compose config validates (`docker compose config`)
- [x] `bash -n scripts/smoke-test.sh` clean
- [ ] Antithesis 1h dispatch on `080-amaru-self-bootstrap` returns `Completed` (not `setup_error`) and renders a property report
- [ ] `findings_new` ≤ baseline (compared to the most recent green Amaru-testnet run on `main`)
- [ ] Mark draft → ready

## Files

https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/testnets/cardano_amaru_epoch3600/docker-compose.yaml
https://github.com/cardano-foundation/cardano-node-antithesis/blob/080-amaru-self-bootstrap/scripts/smoke-test.sh