### PR TITLE
chore(master): bump sidecar to 65039df — fix #115 (orphan flaky_chain_sync probe)

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -155,7 +155,7 @@ services:
   #       condition: service_completed_successfully
 
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:f889dbc
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:65039df
     environment:
       NETWORKMAGIC: 42
       PORT: 3001


### PR DESCRIPTION
## Summary

Bumps `sidecar` in `testnets/cardano_node_master/docker-compose.yaml` from tag `f889dbc` to `65039df`.

## Why

[#115](https://github.com/cardano-foundation/cardano-node-antithesis/issues/115) — `chain-sync-client/parallel_driver_flaky_chain_sync.sh` exits non-zero on every recent main run.

Diagnosis (decoded from the failing example's `event_desc` blob):

```
command_return_code: 1
command_runtime: 0.0031502246856689453
additional_stderr: ""
additional_stdout: ""
```

The script bails in **3 ms with empty stderr** — it can't even reach the adversary control socket, because `parallel_driver_flaky_chain_sync.sh` was an adversary-driver probe that talks to `/state/adversary-control.sock`, and adversary was removed from `cardano_node_master` in [#109](https://github.com/cardano-foundation/cardano-node-antithesis/pull/109).

The script was later moved out of `components/sidecar/composer/` into `components/adversary/composer/` (commit [`65039df`](https://github.com/cardano-foundation/cardano-node-antithesis/commit/65039df)), but the master compose pin still references the older sidecar tag `f889dbc`, which was built **before** that move. So the orphan script is still baked into the running sidecar image and discovered by Antithesis composer auto-discovery.

Bumping the pin to `65039df` rebuilds sidecar at the post-removal commit. Verified against the registry tree: `git ls-tree -r 65039df:components/sidecar/composer/` no longer contains `chain-sync-client/`.

## Build plan

`scripts/push-cardano_node_master_images.sh` reads the compose, resolves `sidecar:65039df` → commit `65039df`, builds with nix at that commit, and pushes both `:65039df` and `:<full-sha>` tags. So no manual image build is needed — the publish-images CI on this PR's push will materialize the tag.

## Test plan

- [ ] `publish-images` CI succeeds and publishes `sidecar:65039df`
- [ ] 1h Antithesis run dispatched on this branch shows `chain-sync-client/parallel_driver_flaky_chain_sync.sh` no longer in the failed-properties list
- [ ] Then merge

Closes #115.