### PR TITLE
testnet(amaru): emit Antithesis startup marker before bootstrap

### DIFF
--- a/testnets/cardano_amaru_epoch3600/docker-compose.yaml
+++ b/testnets/cardano_amaru_epoch3600/docker-compose.yaml
@@ -151,6 +151,12 @@ services:
         relay="amaru-relay-1"
         peer="p1.example:3001"
 
+        # Tell Antithesis the relay is ready before bootstrap so the
+        # sidecar can emit "setup complete" inside the setup window.
+        # Bootstrap finishes during the test phase per spec 080.
+        mkdir -p /startup
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > "/startup/amaru-relay-1.started"
+
         retry="$${AMARU_BOOTSTRAP_RETRY_SECONDS:-20}"
         final="/srv/amaru"
         work="$${final}/.work"
@@ -240,8 +246,6 @@ services:
           sleep "$${retry}"
         done
 
-        mkdir -p /startup
-        printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > "$${marker}"
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
@@ -267,6 +271,12 @@ services:
       - |
         relay="amaru-relay-2"
         peer="p2.example:3001"
+
+        # Tell Antithesis the relay is ready before bootstrap so the
+        # sidecar can emit "setup complete" inside the setup window.
+        # Bootstrap finishes during the test phase per spec 080.
+        mkdir -p /startup
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > "/startup/amaru-relay-2.started"
 
         retry="$${AMARU_BOOTSTRAP_RETRY_SECONDS:-20}"
         final="/srv/amaru"
@@ -351,8 +361,6 @@ services:
           sleep "$${retry}"
         done
 
-        mkdir -p /startup
-        printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > "$${marker}"
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \


### PR DESCRIPTION
## Why

Both today's `try=2` and yesterday's `try=1` runs of `cardano_amaru_epoch3600` ended with the identical Antithesis substatus `failure_timeout` and the explicit pangolin `terminal_reason`:

```
"setup_end_moment": {
  "...": {"terminal_reason": "No 'setup complete' event received"}
},
"status": "Incomplete",
"substatus": "failure_timeout",
"vtime": 414.48          // ~7 min sim, hits Antithesis setup ceiling
```

Pangolin records:
- session `bc4def8f01165caf86dfd7f4a27677de-50-7` (try=2, today, run_id `43501b28...`)
- session `44e10bab31d65d25e9b452174b942f1f-50-7` (try=1, yesterday, run_id `7913727e...`)

Logs Explorer has zero indexed events for either session — Antithesis doesn't retain stdout for `failure_timeout` runs, which is consistent with the determinator never reaching the post-setup phase.

## Root cause

The `sidecar` gates the SDK setup-complete event on per-relay startup markers:

```
AMARU_STARTUP_REQUIRED: "true"
AMARU_STARTUP_DIR:      "/amaru-startup"
AMARU_RELAYS:           "amaru-relay-1 amaru-relay-2"
```

…and each amaru-relay only writes its marker AFTER `bundle_complete` passes:

```sh
while :; do
  if bundle_complete; then break; fi      # sentinel + ledger.live + chain.db + nonces.json
  if refresh_snapshot; then               # cp /live/{immutable,…}
    /bin/bootstrap-producer "$scratch_state" /cardano/config/configs "$scratch_out" testnet_42
  fi
  sleep "$retry"
done
mkdir -p /startup
printf '%s\n' "$HOSTNAME" > "$marker"     # ← only after the loop
exec /bin/amaru run …
```

So `bundle_complete` (which requires p1 to flush an immutable chunk + the bootstrap-producer pipeline to run) sits in front of every setup-complete signal. On `cardano_amaru_epoch3600` (1-hour epochs, f=0.05) this can't fit in Antithesis's ~7-min setup ceiling, ever.

The header comment on `*amaru` already states the right design:

```
# Bootstrap happens during the test phase, not the Antithesis 6-min
# setup window — see specs/080-amaru-self-bootstrap/.
```

…but the script still gated the marker on `bundle_complete`. Comment vs wiring disagreed.

## Fix

Move the `mkdir -p /startup` + `printf … > marker` block to **before** the bootstrap loop, in both `amaru-relay-1` and `amaru-relay-2`. The sidecar now sees the markers ~immediately and emits setup-complete inside the window. Bootstrap continues in the test phase exactly as the comment says it should; the existing loop already retries transient `bootstrap-producer` exits under fault injection.

No other behavioral change — bundle_complete still gates `exec /bin/amaru run`, so amaru-relay still doesn't try to consume an incomplete bundle.

## Test plan

- [ ] Re-dispatch `cardano-node.yaml` with `test=cardano_amaru_epoch3600 duration=1` from this branch.
- [ ] Pangolin run shows determinator end `> 7 min vtime` (i.e. setup-complete was emitted).
- [ ] Sidecar logs include `setup-complete` event in indexed Logs Explorer.
- [ ] amaru-relay-1 / -2 reach `/bin/amaru run` and stay alive (no `Consensus died`, `Invalid VRF proof`, `HeaderValidationError`).