### PR TITLE
docs(asteria): why it's on master + how to add to other testnets

### DIFF
--- a/docs/components/asteria-player.md
+++ b/docs/components/asteria-player.md
@@ -8,6 +8,106 @@ against contention between players.
 
 This component is part of the phase-1 gatherer feature ([#56][issue-56]).
 
+## Adding asteria-game to a testnet
+
+Drop the asteria-game container into any testnet's
+`docker-compose.yaml` to give Antithesis a real workload generator on
+top of an idle Cardano cluster. The container bundles a long-lived
+utxo-indexer plus three short-lived binaries fired by composer
+scripts (bootstrap, player, invariant) — see
+[the why-it's-here section in the master testnet doc][master-why]
+for the rationale.
+
+### Pre-requisites
+
+The host testnet must already have:
+
+- A relay that block producers connect to, e.g. `relay1`, with a
+  named volume mounted at `/state` so the asteria-game container
+  can read its node socket. The master testnet uses
+  `relay1-state:/state`.
+- A `utxo-keys` named volume populated by the configurator with
+  the genesis wallet skeys (the bootstrap binary needs them to
+  sign the deploy tx).
+- A network magic of `42`. Other magics are not currently wired —
+  `NETWORK_MAGIC` is hard-coded in the player's compose env.
+
+### Compose block
+
+Add this service block under `services:` at the bottom of your
+`docker-compose.yaml`:
+
+```yaml
+  asteria-game:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:<tag>
+    container_name: asteria-game
+    hostname: asteria-game.example
+    environment:
+      INDEXER_SOCK: /tmp/idx.sock
+      CARDANO_NODE_SOCKET_PATH: /state/node.socket
+      NETWORK_MAGIC: "42"
+    volumes:
+      - relay1-state:/state:ro            # read-only N2C socket
+      - utxo-keys:/utxo-keys:ro           # genesis skeys for bootstrap
+      - asteria-game-db:/idx-db           # RocksDB persistence
+      - asteria-deploy:/asteria-deploy    # per-deploy seed TxIn
+    tmpfs:
+      - /tmp                              # holds /tmp/idx.sock
+    depends_on:
+      relay1:
+        condition: service_started
+```
+
+Then declare the two new named volumes under the top-level
+`volumes:` block:
+
+```yaml
+volumes:
+  # … existing volumes …
+  asteria-game-db:
+  asteria-deploy:
+```
+
+`<tag>` is a 7-char short SHA from a commit on this repo. The
+`publish-images` workflow rebuilds the image and pushes
+`asteria-game:<short-sha>` whenever a commit touches
+`components/asteria-game/`. Pick the tag from any green
+`publish-images` run on `main`, or use the digest pinned by master
+in [`testnets/cardano_node_master/docker-compose.yaml`][master-compose].
+
+The composer scripts that drive the binaries are baked into the
+image at build time at `/opt/antithesis/test/v1/stub/` —
+nothing extra to mount. The Antithesis composer mounts that path
+into its execution sandbox automatically when the test runs.
+
+### Validation gate before merging into a scheduled testnet
+
+Per the project's "no broken container on main testnet" rule, a
+new testnet that adds asteria-game must dispatch a 1h Antithesis
+run via `workflow_dispatch` on the feature branch and confirm
+`findings_new ≤ baseline` before merging. The same gate applied
+when promoting asteria-game into [`cardano_node_master`][master-pr-128].
+
+### What does the cluster need to look like
+
+The asteria-game player drives `spawnShip` Plutus transactions
+that consume + replace the asteria UTxO. The cluster needs:
+
+- At least one block producer that accepts valid Plutus v3
+  transactions (the asteria validators are Aiken-compiled to
+  PlutusV3).
+- A relay reachable via `relay1.example:3001` (N2N) and
+  `relay1-state:/state/node.socket` (N2C). Aliasing it under a
+  different name requires editing
+  `components/asteria-game/composer/stub/parallel_driver_asteria_player.sh`.
+- Genesis funds in `utxo-keys/genesis.1.skey` sufficient for the
+  one-time bootstrap deploy plus a few thousand `spawnShip`
+  transactions over a 3h run.
+
+The master testnet meets all three by construction. New testnets
+that change the topology, network magic, or genesis layout will
+need to mirror those choices.
+
 ## What it does
 
 The container ships two binaries:
@@ -121,6 +221,9 @@ docker run --rm \
 [issue-56]: https://github.com/cardano-foundation/cardano-node-antithesis/issues/56
 [pr-57]: https://github.com/cardano-foundation/cardano-node-antithesis/pull/57
 [cnc-fix]: https://github.com/lambdasistemi/cardano-node-clients/commit/f6a31ca6c169810a46e45648a0868d7a48eb1f02
+[master-why]: ../testnets/cardano-node-master.md#why-asteria-game-is-here
+[master-compose]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/testnets/cardano_node_master/docker-compose.yaml
+[master-pr-128]: https://github.com/cardano-foundation/cardano-node-antithesis/pull/128
 [HAL]: https://github.com/cardano-foundation/hal
 [CF]: https://github.com/cardano-foundation
 [Cardano]: https://cardano.org/

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -17,9 +17,75 @@ This testnet exercises the node-to-node protocol across multiple cardano-node ve
 | **tracer** | cardano-tracer daemon collecting structured logs from all nodes |
 | **tracer-sidecar** | Processes tracer logs into Antithesis assertions (chain convergence, error detection) |
 | **sidecar** | Network health checks, the Antithesis setup signal, and the host of the chain-sync `adversary` driver (see [Adversary](../components/adversary.md)). |
-| **tx-generator** | Long-running daemon submitting well-formed ADA transfers via N2C (see `components/tx-generator/`). |
-| **asteria-bootstrap** | One-shot. Deploys asteria validators and creates the initial game UTxO. See [Asteria Player](../components/asteria-player.md). |
-| **asteria-player-1**, **asteria-player-2** | Long-running asteria game players. Drive realistic tx traffic (spendScript, mint, ref-inputs, validity bounds) through the cluster. |
+| **log-tailer** | Streams the per-pool node logs into Antithesis's log explorer for offline triage. |
+| **asteria-game** | Single container that hosts the long-lived utxo-indexer plus three short-lived binaries (`asteria-bootstrap`, `asteria-game`, `asteria-invariant`) fired by composer scripts. See [Why asteria-game is here](#why-asteria-game-is-here) below and [Asteria Player](../components/asteria-player.md). |
+
+## Why asteria-game is here
+
+Antithesis can only find bugs that the system **actually exercises** in
+the simulation. A cluster running idle — three producers minting empty
+blocks — explores almost nothing of the node's tx-handling code:
+mempool admission, script evaluation, ledger validation under
+contention, fork resolution while inputs are being consumed. Faults
+fired against an idle cluster mostly prove that the cluster restarts.
+
+The asteria-game container is the **workload generator** that turns
+master into a *busy* testnet. Without it, the cluster has no
+realistic tx pressure. With it, the cluster sees the full envelope:
+
+- **`parallel_driver_asteria_player.sh`** — fired concurrently by the
+  composer many times per timeline. Each invocation reads the asteria
+  UTxO from chain via the long-lived utxo-indexer, plans a move, and
+  for player-1 builds + signs + submits a `spawnShip` Plutus
+  transaction (consume asteria → mint a `SHIP*` token → write to the
+  spacetime address → produce the next asteria UTxO with
+  `ship_counter += 1`). Player-2 and player-3 run the same observe
+  + plan path without acting, exercising the read side.
+- **`serial_driver_asteria_bootstrap.sh`** — exclusive-access driver
+  that idempotently re-deploys the validators and admin NFT each
+  invocation. Re-runs detect the existing state via the indexer and
+  skip the mint, exercising the "is already deployed" path under
+  fault injection.
+- **`anytime_asteria_admin_singleton.sh`** — periodic invariant
+  probe. Asserts (via `sdk_always`) that exactly one `asteriaAdmin`
+  NFT exists at the asteria spend address — the one-shot mint
+  policy must hold under any combination of forks, kills, and
+  partitions.
+- **`finally_asteria_consistency.sh`** — end-of-run consistency
+  snapshot. `ship_counter` on the asteria UTxO must equal the count
+  of `SHIP*` tokens at the spacetime address.
+- **`eventually_alive.sh`** / **`finally_alive.sh`** — short
+  liveness probes against the indexer's `ready` endpoint.
+
+What this gives Antithesis to score:
+
+- **Tx-build pressure under faults**. The player driver builds, signs,
+  and submits real Plutus transactions concurrently with fault
+  injection. Validation: a 1h validation run on
+  [PR #128][pr-128] saw 22,990 player invocations,
+  2,599 successful spawn-ship transactions landing on chain, and 149
+  observed fork switches during the run.
+- **Plutus-script ledger paths**. The validators (asteria.spend,
+  spacetime.spend, shipyard.mint) execute on every ship spawn —
+  exercises ref-input handling, datum decoding, redeemer validation,
+  exec-budget accounting.
+- **Multi-version interop**. Producers p1/p2/p3 run three different
+  cardano-node versions; the same Plutus tx must validate identically
+  across versions or the cluster forks.
+- **Invariants that survive faults**. `asteria_admin_singleton`
+  (sdkAlways) and `asteria_state_consistent` (sdkSometimes) provide
+  oracle properties Antithesis can falsify if a fault produces a
+  divergent view, a double-mint, or a lost ship.
+
+The container is the **load + oracle** of the test. Its image is
+pinned by SHA in `docker-compose.yaml`; building it locally goes
+through `components/asteria-game/`. The composer scripts that drive
+it live alongside the binaries in `components/asteria-game/composer/stub/`
+and are baked into the image at build time.
+
+For the architectural detail of how the binaries integrate with
+`cardano-node-clients` (provider, submitter, indexer, TxBuild DSL,
+fee bisection), see [Asteria Player](../components/asteria-player.md).
 
 ## Network topology
 


### PR DESCRIPTION
## Summary

Two doc additions sparked by promoting asteria-game into the master testnet ([PR #128](https://github.com/cardano-foundation/cardano-node-antithesis/pull/128)):

### \`docs/testnets/cardano-node-master.md\` — Why asteria-game is here

Explains the rationale: Antithesis can only find bugs the system actually exercises, an idle cluster fuzzes nothing useful, and asteria-game is the workload generator that makes master a busy testnet. Lists the four composer-driver categories (player, bootstrap, invariant probe, consistency snapshot) with their roles, and references concrete numbers from the validation run (22,990 player invocations, 2,599 ship spawns, 149 fork switches, \`asteria_admin_singleton\` 15,488 / 0).

Also refreshes the supporting-services table to match the actual current shape (single \`asteria-game\` container, not the old \`asteria-bootstrap\` + \`asteria-player-1/2\` arrangement).

### \`docs/components/asteria-player.md\` — Adding asteria-game to a testnet

Consumer-facing integration guide:
- Pre-requisites (relay1-state volume, utxo-keys volume, network magic 42)
- The compose block to paste into a new testnet's \`docker-compose.yaml\` plus the two named volumes
- The validation gate (1h Antithesis workflow_dispatch run, \`findings_new ≤ baseline\`) that must pass before merging into a scheduled testnet
- The cluster shape the player driver expects

The rest of \`asteria-player.md\` is left unchanged — the "Iterations" section still describes the original phase-1 wiring proof and is a follow-up cleanup target.

## Test plan

- [x] Markdown renders cleanly under MkDocs
- [x] Cross-references between the two files resolve via relative paths
- [ ] Spot-check on \`mkdocs serve\` locally if needed