### PR TITLE
chore(testnet): mirror master in cardano_node_adversary

### DIFF
--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -43,16 +43,19 @@ x-cardano-relay: &cardano-relay
 services:
   configurator:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator@sha256:6e6ba428838bf754ad286b62a151c63c683ef27fbdd5dd1bb5bab11ec9a6a34d
+    container_name: configurator
     volumes:
-      - ./testnet.yaml:/testnet.yaml
-      - p1-configs:/configs/1
-      - p2-configs:/configs/2
-      - p3-configs:/configs/3
-      - utxo-keys:/utxo-keys
+      - ./testnet.yaml:/testnet.yaml #  source of configurations
+      - p1-configs:/configs/1 # configs for p1
+      - p2-configs:/configs/2 # configs for p2
+      - p3-configs:/configs/3 # configs for p3
+      - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
     image: ghcr.io/intersectmbo/cardano-tracer@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
+
     hostname: tracer.example
+    container_name: tracer
     volumes:
       - tracer:/opt/cardano-tracer
       - ./tracer-config.yaml:/tracer-config.yaml:ro
@@ -64,6 +67,7 @@ services:
 
   p1:
     <<: *cardano-node
+    container_name: p1
     hostname: p1.example
     volumes:
       - p1-configs:/configs:ro
@@ -72,6 +76,7 @@ services:
   p2:
     <<: *cardano-node
     image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    container_name: p2
     hostname: p2.example
     volumes:
       - p2-configs:/configs:ro
@@ -80,6 +85,7 @@ services:
   p3:
     <<: *cardano-node
     image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    container_name: p3
     hostname: p3.example
     volumes:
       - p3-configs:/configs:ro
@@ -88,6 +94,7 @@ services:
   relay1:
     <<: *cardano-relay
     image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
+    container_name: relay1
     hostname: relay1.example
     volumes:
       - p1-configs:/configs:ro
@@ -98,6 +105,7 @@ services:
   relay2:
     <<: *cardano-relay
     image: ghcr.io/intersectmbo/cardano-node@sha256:45857be8d86b314a05cd46d310b74b24e5f5870469f90c6464994a7f78142271
+    container_name: relay2
     hostname: relay2.example
     volumes:
       - p1-configs:/configs:ro
@@ -105,12 +113,49 @@ services:
       - relay2-state:/state
       - tracer:/tracer
 
+  # Tx-generator workload — promoted from cardano_node_tx_generator
+  # after a 0-findings 1h Antithesis validation run on commit
+  # 4687a09. The daemon connects to relay1 via N2C and the
+  # composer fires short `transact`, `refill`, `eventually`, and
+  # `finally` control-socket probes. Tag 69bf815 contains the
+  # bounded socket-probe wrapper that cleared the four previous
+  # "Commands finish with zero exit code" findings.
+  tx-generator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:69bf815
+    container_name: tx-generator
+    hostname: tx-generator.example
+    command:
+      - --relay-socket
+      - /state/node.socket
+      - --control-socket
+      - /state/tx-generator-control.sock
+      - --state-dir
+      - /state/txgen
+      - --master-seed-file
+      - /state/txgen/master.seed
+      - --faucet-skey-file
+      - /utxo-keys/genesis.1.skey
+      - --network-magic
+      - "42"
+    volumes:
+      # rw - daemon writes its control socket + state dir
+      # under /state.
+      - relay1-state:/state
+      - utxo-keys:/utxo-keys:ro
+    restart: always
+    depends_on:
+      relay1:
+        condition: service_started
+      configurator:
+        condition: service_completed_successfully
+
   sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:1ff6913
     environment:
       NETWORKMAGIC: 42
       PORT: 3001
       POOLS: "3"
+    container_name: sidecar
     hostname: sidecar.example
     depends_on:
       tracer-sidecar:
@@ -129,6 +174,7 @@ services:
   # idempotent host.
   adversary:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:5173fa8
+    container_name: adversary
     hostname: adversary.example
     volumes:
       # Read-only — tracer-sidecar writes chainPoints.log here.
@@ -142,6 +188,7 @@ services:
 
   tracer-sidecar:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:8dbf509
+    container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     command:
       - "/opt/cardano-tracer/logs"
@@ -157,12 +204,51 @@ services:
 
   log-tailer:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
+    container_name: log-tailer
     hostname: log-tailer.example
     volumes:
       - tracer:/tracer:ro
     restart: always
     depends_on:
       tracer:
+        condition: service_started
+
+  # Asteria game workload — promoted from testnets/asteria_game/ on
+  # the strength of the 0-findings 1h Antithesis run on commit
+  # 9984a1e (PR #100). Long-lived utxo-indexer follows relay1's
+  # chain via N2C, exposes ready/utxos_at/await on /tmp/idx.sock;
+  # composer scripts at /opt/antithesis/test/v1/stub/ drive
+  # bootstrap (one-shot serial driver), the player loop, and the
+  # admin-singleton / consistency invariant snapshots. The player
+  # parallel_driver_ is the workload generator: builds + signs +
+  # submits spawnShip txs against relay1 every tick, providing
+  # sustained tx pressure under fault injection.
+  #
+  # Built from upstream PR #98 (035-indexer-n2c-reconnect) —
+  # supervisor with exponential-backoff reconnect handles N2C peer
+  # close in-process, so the daemon stays up across relay restarts.
+  # RocksDB persistence at /idx-db keeps state across full process
+  # restarts too. /utxo-keys is mounted so the bootstrap binary
+  # can read the genesis wallet skey; /asteria-deploy holds the
+  # per-deploy seed TxIn so player + invariant binaries see the
+  # same applied validators.
+  asteria-game:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:f7ce4a2
+    container_name: asteria-game
+    hostname: asteria-game.example
+    environment:
+      INDEXER_SOCK: /tmp/idx.sock
+      CARDANO_NODE_SOCKET_PATH: /state/node.socket
+      NETWORK_MAGIC: "42"
+    volumes:
+      - relay1-state:/state:ro
+      - utxo-keys:/utxo-keys:ro
+      - asteria-game-db:/idx-db
+      - asteria-deploy:/asteria-deploy
+    tmpfs:
+      - /tmp
+    depends_on:
+      relay1:
         condition: service_started
 
 volumes:
@@ -173,8 +259,11 @@ volumes:
   relay1-state:
   relay2-state:
   utxo-keys:
+  asteria-game-db:
+  asteria-deploy:
 
 networks:
   default:
+    name: cardano-node-testnet
     driver: bridge
     internal: ${INTERNAL_NETWORK}


### PR DESCRIPTION
## Summary

Make \`cardano_node_adversary\` the dress rehearsal for the future master testnet — the state master will reach when the adversary container is promoted into it.

The adversary testnet's compose now equals master's compose verbatim plus the adversary service stanza, slotted between \`sidecar\` and \`tracer-sidecar\`.

## What changed

- **+\`tx-generator\` service** — newly active in master via [ecf7910](https://github.com/cardano-foundation/cardano-node-antithesis/commit/ecf7910). Drives N2C transactions against relay1.
- **+\`asteria-game\` service** — also newly active in master (PR #100). Long-lived utxo-indexer + composer scripts driving spawnShip txs.
- **+\`asteria-game-db\` and \`asteria-deploy\` volumes** required by asteria-game.
- **Restored cosmetics** that adversary had stripped: \`container_name:\` labels on every service, original config-comment annotations on the configurator volumes, and \`name: cardano-node-testnet\` on the default network. Diff against master is now exactly +adversary-block.

## Tracer-sidecar pin

Adversary keeps the post-#129 pin \`tracer-sidecar:8dbf509\` (Layer 3 fork-depth checklist). Master is intentionally **not** bumped here — when adversary is eventually promoted into master it will travel with this pin in a single drop.

## Verification

Local \`./scripts/smoke-test.sh cardano_node_adversary 240\` — green:

- 3 producers responding to cardano-cli ping
- Adversary driver fired against p1.example, reached slot 30 cleanly (3ms elapsed, slot_delta=3)
- tx-generator control socket ready, drove 5/5 transacts (populationSize=4)
- Asteria indexer observed refill UTxO (p50_lovelace=5e9)

## After merge

Dispatch a 1h Antithesis run on \`testnets/cardano_node_adversary\` to verify the mirrored topology under fault injection — adversary attacks + tx-generator load + asteria game traffic, all together. That's the future-master profile.

## Test plan

- [ ] CI: \`Compose smoke test\` green on \`cardano_node_adversary\`
- [ ] CI: \`Compose smoke test (asteria_game)\` green
- [ ] CI: build + unit tests + check code quality green
- [ ] After merge: 1h Antithesis dispatch on main shows 0 findings (or only known-flake findings)