### PR TITLE
chore(asteria-game): bump pin to e49d4ab to activate budget fix

### DIFF
--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:f7ce4a2
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:e49d4ab
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:f7ce4a2
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:e49d4ab
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

PR #135 (https://github.com/cardano-foundation/cardano-node-antithesis/pull/135, merged as commit https://github.com/cardano-foundation/cardano-node-antithesis/commit/e49d4ab) tightened the asteria-game eventually/finally probe budgets and dropped the bogus AlwaysOrUnreachable cold-start emit. **But the compose pins were not bumped**, so publish-images saw the existing \`asteria-game:f7ce4a2\` tag in registry, skipped the rebuild, and every cron / dispatch since then has continued to pull the buggy image.

This PR bumps both compose pins to \`asteria-game:e49d4ab\`. publish-images will resolve the new tag, build from source at e49d4ab, push, and the next master cron + next adversary dispatch will pick up the new image.

## Why now

Of the last three \`cardano_node_master\` cron runs, two failed:

- 2026-05-07 01:43 UTC: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25469497049 — failure
- 2026-05-06 19:40 UTC: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25457234055 — failure
- 2026-05-06 13:44 UTC: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25444034551 — success

Same flake as the adversary dispatch failures (full triage report: https://cardano.antithesis.com/report/9_VSL0Up0MFelP0KPcfYVGa2/w8B4pkjUu_uOyps0rRuZMybMPF6eLMRq_vXjq23jWB0.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA1LTA2VDE1OjAzOjA1LjMwMDM0MjkzNFoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoidzhCNHBralV1X3VPeXBzMHJSdVpNeWJNUEY2ZUxNUnFfdlhqcTIzaldCMC5odG1sIiwicmVwb3J0X2lkIjoiOV9WU0wwVXAwTUZlbFAwS1BjZllWR2EyIn19fSCsz9a7x3irqIH4gyKm89NWrb0N5gUt4dk5VQZiU2msbz6RdQ5WIN_NJ7ZIRzNSvDyy9j08xL9nyTAEYDEf7A0).

## Test plan

- [ ] CI: \`Build and push component images\` builds asteria-game:e49d4ab and pushes
- [ ] CI: \`Compose smoke test\` and \`Compose smoke test (asteria_game)\` green
- [ ] After merge: next \`cardano_node_master\` cron run shows 0 findings on the asteria-game properties
- [ ] After merge: dispatch a 1h \`cardano_node_adversary\` run to confirm the asteria-game findings don't recur

## Out of scope

- Other test commands hit by the same composer-timeout flake (\`chain-sync-client/parallel_driver_flap.sh\`, \`chain-sync-client/finally_adversary_summary.sh\`) — separate fix required, see https://github.com/cardano-foundation/cardano-node-antithesis/issues/123 and the open follow-up.
- Promoting the adversary container into \`cardano_node_master\` — separate PR once we're confident in the cleaned-up baseline.