### PR TITLE
fix(asteria-game): cold_start emit must_hit:false + bump pin to 6a9a93b

### DIFF
--- a/components/asteria-game/composer/stub/eventually_alive.sh
+++ b/components/asteria-game/composer/stub/eventually_alive.sh
@@ -64,7 +64,13 @@ done
 # in the report's Sometimes-assertion table.
 if [ -n "$LAST_REPLY" ] \
     && printf '%s' "$LAST_REPLY" | jq -e '.tipSlot == null' >/dev/null 2>&1; then
-    sdk_sometimes false "stub eventually_alive cold_start" \
+    # must_hit:false — the cold-start branch isn't guaranteed to be
+    # reached across timelines (depends on whether a fault-cascade
+    # window coincides with an eventually_ dispatch). The earlier
+    # sdk_sometimes (must_hit:true) emit fired as a finding when it
+    # only saw condition:false, defeating the intent that this be
+    # informational coverage only.
+    sdk_sometimes_optional false "stub eventually_alive cold_start" \
         "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$LAST_REPLY" \
             '{attempts_exhausted:$a, last_reply:$reply, reason:"tipSlot=null — no RollForward yet from upstream"}')"
     exit 0

--- a/components/asteria-game/composer/stub/helper_sdk.sh
+++ b/components/asteria-game/composer/stub/helper_sdk.sh
@@ -11,9 +11,9 @@
 _sdk_output_dir() { printf '%s' "${ANTITHESIS_OUTPUT_DIR:-/tmp}"; }
 
 _sdk_emit() {
-    # args: display_type assert_type condition hit id message details_json
+    # args: display_type assert_type condition hit id message details_json [must_hit]
     local display_type="$1" assert_type="$2" condition="$3"
-    local hit="$4" id="$5" msg="$6" details_json="${7:-null}"
+    local hit="$4" id="$5" msg="$6" details_json="${7:-null}" must_hit="${8:-true}"
     local dir
     dir="$(_sdk_output_dir)"
     mkdir -p "$dir"
@@ -25,13 +25,14 @@ _sdk_emit() {
         --argjson cond "$condition" \
         --argjson hit "$hit" \
         --argjson details "$details_json" \
+        --argjson must_hit "$must_hit" \
         '{antithesis_assert: {
             id: $id,
             message: $msg,
             condition: $cond,
             display_type: $dt,
             hit: $hit,
-            must_hit: true,
+            must_hit: $must_hit,
             assert_type: $at,
             location: {file:"", function:"", class:"", begin_line:0, begin_column:0},
             details: $details
@@ -42,9 +43,28 @@ sdk_reachable()   { _sdk_emit "Reachable"             "reachability" true  true 
 sdk_unreachable() { _sdk_emit "AlwaysOrUnreachable"   "always"       false true "$1" "$1" "${2:-null}"; }
 
 # sdk_sometimes <true|false> <id> [details_json]
+#
+# Emits a Sometimes assertion with must_hit:true. Antithesis flags it
+# as failed if the run never sees a hit with condition:true at least
+# once. Use ONLY for paths where the success state is reachable across
+# the timelines explored.
 sdk_sometimes() {
     local cond=false; [ "$1" = "true" ] && cond=true
     _sdk_emit "Sometimes" "sometimes" "$cond" true "$2" "$2" "${3:-null}"
+}
+
+# sdk_sometimes_optional <true|false> <id> [details_json]
+#
+# Same shape as sdk_sometimes but with must_hit:false — observational
+# coverage, never a finding. Use this for branches where condition:true
+# is not guaranteed reachable across the explored timelines (rare
+# branches, fault-cascade fallbacks, cold-start probes). Replaces the
+# previous use of sdk_unreachable for "informational only" emits;
+# AlwaysOrUnreachable with hit:true + condition:false IS a finding,
+# while sdk_sometimes_optional false is silent.
+sdk_sometimes_optional() {
+    local cond=false; [ "$1" = "true" ] && cond=true
+    _sdk_emit "Sometimes" "sometimes" "$cond" true "$2" "$2" "${3:-null}" false
 }
 
 # sdk_always <true|false> <id> [details_json]

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:e49d4ab
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:6a9a93b
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:e49d4ab
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:6a9a93b
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

PR #135 (https://github.com/cardano-foundation/cardano-node-antithesis/pull/135) replaced \`sdk_unreachable\` in \`stub/eventually_alive.sh\`'s cold-start path with \`sdk_sometimes false\`, but \`sdk_sometimes\` hardcodes \`must_hit:true\`. The Antithesis report flags any \`must_hit:true\` Sometimes that only ever sees \`condition:false\` — and that's exactly what the cold-start branch produces. Result: instead of "AlwaysOrUnreachable hit with false" finding, we got "Sometimes assertions never satisfied with true" finding. Different label, same problem.

This PR adds a true must_hit:false sibling helper and uses it.

## Evidence

[Master verify run](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25481043842) on commit https://github.com/cardano-foundation/cardano-node-antithesis/commit/33abd75 (first run after PR #136 activated the asteria fix):

[Triage report](https://cardano.antithesis.com/report/ibYqDPjxdWnsxDuO9lt084N_/5oOfqfzFQcxYRJVeLmqd6UdccVGXJggM-WJIHtjyfHc.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiNW9PZnFmekZRY3hZUkpWZUxtcWQ2VWRjY1ZHWEpnZ00tV0pJSHRqeWZIYy5odG1sIiwicmVwb3J0X2lkIjoiaWJZcURQanhkV25zeER1TzlsdDA4NE5fIn19LCJuYmYiOiIyMDI2LTA1LTA3VDA3OjE5OjQ0LjM3MzQ5NjU3OVoifXqe_rhnVTlETEO11nS3vWxUn-PaOX-MwBqBRBImKN3fDwC9IBppkBLj73EnHX0RyMX-NxVIeZmfVDIkuSZqhAI) — single finding: \`Sometimes assertions → stub eventually_alive cold_start: new\`. 3 examples, all condition:false.

## Changes

### \`helper_sdk.sh\`

- \`_sdk_emit\` now accepts an optional 8th argument \`must_hit\` (default \`true\`). All existing callers keep their behavior.
- New \`sdk_sometimes_optional <true|false> <id> [details_json]\` — same shape as \`sdk_sometimes\` but emits with \`must_hit:false\`. Use for branches where \`condition:true\` isn't guaranteed reachable across explored timelines (rare branches, fault-cascade fallbacks, cold-start probes).

### \`eventually_alive.sh\`

- Cold-start path switched from \`sdk_sometimes false\` → \`sdk_sometimes_optional false\`.

### compose pin

- Bump \`asteria-game:e49d4ab → asteria-game:6a9a93b\` in both master and adversary composes (the pin convention from PR #136). publish-images will resolve the new tag → build → push.

## Smoke test

Locally invoked \`sdk_sometimes_optional false "test_id"\` and inspected \`/tmp/sdk-smoke/sdk.jsonl\`:
\`\`\`json
{"antithesis_assert":{"id":"test_id","message":"test_id","condition":false,"display_type":"Sometimes","hit":true,"must_hit":false,"assert_type":"sometimes",...}}
\`\`\`
\`must_hit:false\` correctly set.

## Test plan

- [ ] CI: \`Compose smoke test\` and \`Compose smoke test (asteria_game)\` green
- [ ] After merge: dispatch a 1h on \`cardano_node_master\` and verify \`stub eventually_alive cold_start\` no longer fires as a finding (it may still appear as a \`Sometimes\` row, just no longer flagged)