### PR TITLE
fix(asteria-game): timeout wrappers on every external call + bump pin

### DIFF
--- a/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
+++ b/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
@@ -18,5 +18,9 @@ set -u
 source "$(dirname "$0")/helper_sdk.sh"
 
 export ASTERIA_INVARIANT=admin_singleton
+# `timeout 12` bounds the invariant-check binary under composer's
+# anytime per-command cap. The binary queries the chain via N2C
+# and can hang under partition; bound to 12 s with margin for the
+# absorb path. timeout 124 → sdk_run_signal_safe → no finding.
 sdk_run_signal_safe "stub anytime_admin_singleton container_stopped" \
-    /bin/asteria-invariant
+    timeout 12 /bin/asteria-invariant

--- a/components/asteria-game/composer/stub/eventually_alive.sh
+++ b/components/asteria-game/composer/stub/eventually_alive.sh
@@ -47,7 +47,14 @@ sleep "$SLEEP_SETTLE"
 
 LAST_REPLY=""
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    LAST_REPLY="$(printf '{"ready": null}\n' | socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
+    # `timeout 1 socat`: socat blocks indefinitely on UNIX-CONNECT
+    # waiting for the indexer's reply with no internal deadline.
+    # Without bounding, each loop iteration runs as long as the
+    # indexer takes — observed wall times of 70 s for the whole
+    # script when several iterations stalled, well past composer's
+    # per-command cap. 1 s per attempt keeps the loop's worst case
+    # at 3 s settle + 8 × 1 s = 11 s.
+    LAST_REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
     if [ -n "$LAST_REPLY" ] \
         && printf '%s' "$LAST_REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
         TIP="$(printf '%s' "$LAST_REPLY" | jq -r '.tipSlot // 0')"

--- a/components/asteria-game/composer/stub/finally_alive.sh
+++ b/components/asteria-game/composer/stub/finally_alive.sh
@@ -32,7 +32,9 @@ sleep "$SLEEP_SETTLE"
 
 LAST_REPLY=""
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    LAST_REPLY="$(printf '{"ready": null}\n' | socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
+    # `timeout 1 socat` — bounds each attempt; see eventually_alive.sh
+    # for rationale.
+    LAST_REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
     if [ -n "$LAST_REPLY" ] \
         && printf '%s' "$LAST_REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
         TIP="$(printf '%s' "$LAST_REPLY" | jq -r '.tipSlot // 0')"

--- a/components/asteria-game/composer/stub/finally_asteria_consistency.sh
+++ b/components/asteria-game/composer/stub/finally_asteria_consistency.sh
@@ -18,7 +18,12 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
-sleep 15
+# 10 s settle + 30 s binary cap = 40 s worst case, comfortably
+# under composer's finally per-command cap (~54 s observed). The
+# binary queries chain UTxOs and counts SHIP tokens; under
+# partition it can hang on N2C handshake, hence the `timeout 30`
+# bound. Earlier 15 s + unbounded binary blew past 54 s.
+sleep 10
 export ASTERIA_INVARIANT=consistency
 sdk_run_signal_safe "stub finally_consistency container_stopped" \
-    /bin/asteria-invariant
+    timeout 30 /bin/asteria-invariant

--- a/components/asteria-game/composer/stub/helper_sdk.sh
+++ b/components/asteria-game/composer/stub/helper_sdk.sh
@@ -75,13 +75,21 @@ sdk_always() {
 
 # sdk_run_signal_safe <sig_id> <binary> [args...]
 #
-# Run a binary and absorb signal-induced non-zero exits into an
-# sdk_unreachable signal + exit 0. Antithesis applies node faults
-# (stop/kill) to asteria-game mid-run; processes inside the
-# container then exit with codes like 137 (SIGKILL), 143 (SIGTERM),
-# or 255 (process aborted) — none of which are real test failures,
-# but the composer's "Always: Commands finish with zero exit code"
-# property would record them as bugs.
+# Run a binary and absorb signal-induced non-zero exits into a
+# sdk_sometimes_optional false event + exit 0. Antithesis applies
+# node faults (stop/kill) to asteria-game mid-run, and callers wrap
+# binaries with timeout(1) to bound execution under composer's
+# per-command cap. Either path produces signal-induced exit codes
+# (137 SIGKILL, 143 SIGTERM, 124 timeout, 255 abort) that aren't
+# real test failures — the composer's "Always: Commands finish with
+# zero exit code" property would otherwise flag them as bugs.
+#
+# Earlier the absorbed signal emitted as sdk_unreachable
+# (AlwaysOrUnreachable, hit:true + condition:false), which IS a
+# finding when fired. Switched to sdk_sometimes_optional (must_hit:
+# false) so the signal is recorded for observation but never trips a
+# finding — the signal-induced path may be reached or not, both
+# states are valid.
 #
 # Real non-zero exits (anything other than the signal-induced set)
 # propagate unchanged so genuine binary errors still surface.
@@ -97,9 +105,9 @@ sdk_run_signal_safe() {
         # 124 timeout(1) wrapper
         # 255 generic abort / exec failed mid-call
         129 | 137 | 143 | 124 | 255)
-            sdk_unreachable "$sig_id" \
+            sdk_sometimes_optional false "$sig_id" \
                 "$(jq -nc --argjson r "$rc" \
-                    '{rc:$r, reason:"process exited with signal-induced code; container likely stopped mid-run"}')"
+                    '{rc:$r, reason:"process exited with signal-induced code; container stopped mid-run or timeout(1) deadline hit"}')"
             return 0
             ;;
         *) return "$rc" ;;

--- a/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
+++ b/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
@@ -20,5 +20,12 @@ source "$(dirname "$0")/helper_sdk.sh"
 
 PLAYER_ID="$(( ($(date +%s) % 3) + 1 ))"
 export ASTERIA_PLAYER_ID="$PLAYER_ID"
+# `timeout 12 /bin/asteria-game` — the binary has no internal
+# deadline and can hang on N2C handshake or chain-follower reads
+# under cluster perturbation. Composer's parallel_driver per-command
+# cap is ~16 s; bounding to 12 s gives margin for the bash trap +
+# sdk_run_signal_safe emit. Timeout exits 124 → caught by
+# sdk_run_signal_safe → recorded via sdk_sometimes_optional false
+# (no finding).
 sdk_run_signal_safe "stub asteria_player_${PLAYER_ID} container_stopped" \
-    /bin/asteria-game
+    timeout 12 /bin/asteria-game

--- a/components/asteria-game/composer/stub/parallel_driver_heartbeat.sh
+++ b/components/asteria-game/composer/stub/parallel_driver_heartbeat.sh
@@ -18,7 +18,9 @@ INDEXER_SOCK="${INDEXER_SOCK:-/tmp/idx.sock}"
 
 sdk_reachable "stub heartbeat entered"
 
-REPLY="$(printf '{"ready": null}\n' | socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
+# `timeout 1 socat` bounds the heartbeat under composer's
+# parallel_driver per-command cap (~16 s).
+REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
 
 if [ -n "$REPLY" ] && printf '%s' "$REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
     PROCESSED="$(printf '%s' "$REPLY" | jq -r '.processedSlot // 0')"

--- a/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
+++ b/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
@@ -18,5 +18,11 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
+# `timeout 25` bounds the bootstrap binary; it's a serial_driver
+# so its budget is at least as generous as parallel_driver. 25 s
+# is conservative — first-time deploy needs to mint+lock the NFT
+# (a few chain rounds) but subsequent invocations exit fast on the
+# isAlreadyDeployed short-circuit. timeout 124 →
+# sdk_run_signal_safe → no finding.
 sdk_run_signal_safe "stub asteria_bootstrap container_stopped" \
-    /bin/asteria-bootstrap
+    timeout 25 /bin/asteria-bootstrap

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:6a9a93b
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:c588914
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:6a9a93b
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:c588914
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

Two compounding bugs across all asteria-game test scripts:

1. **socat** (eventually_alive, finally_alive, parallel_driver_heartbeat) and the **/bin/asteria-** binaries (asteria_player, admin_singleton, bootstrap, asteria_consistency) have **no internal deadlines**. When upstream stalls — indexer slow to reply, N2C handshake hung under partition, container restart — the wrapping bash gets SIGKILLed BEFORE the binary returns; the \`sdk_run_signal_safe\` wrapper never executes its rc check; composer assigns synthetic exit 1 and flags the script under "Always: Commands finish with zero exit code".

2. \`sdk_run_signal_safe\` absorbed signal-induced exits via \`sdk_unreachable\`, but AlwaysOrUnreachable with \`hit:true + condition:false\` IS a finding. Same root cause as the PR #137 cold_start fix.

## Evidence

[Triage report](https://cardano.antithesis.com/report/YAWRXb4qzTS7C2q3tkAPPCvk/wiQUkGb-XxHKj4Td-ZKrazjXKc8Q87vEcYRZolQeAtQ.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0Ijoid2lRVWtHYi1YeEhLajRUZC1aS3JhempYS2M4UTg3dkVjWVJab2xRZUF0US5odG1sIiwicmVwb3J0X2lkIjoiWUFXUlhiNHF6VFM3QzJxM3RrQVBQQ3ZrIn19LCJuYmYiOiIyMDI2LTA1LTA3VDA5OjU4OjA3LjUxMzA0ODYzN1oiffBvQGOojc-NHwr5-Sh_QHgDGp1Q0OTrYQL75fZHRQzsw-JgXbrT0G9fDPMrQIKxuYZN-C2yZVAeUFc0MoXjaQs) on commit https://github.com/cardano-foundation/cardano-node-antithesis/commit/9194921 (master after PR #137):

- \`stub/eventually_alive.sh\` — runtime 70.83s, way over the eventually cap (~16s). My PR #135's "11s budget" was insufficient because socat blocks on indexer reply with no deadline.
- \`stub/parallel_driver_asteria_player.sh\` — runtime 31.22s, over the parallel cap (~16s). \`/bin/asteria-game\` hangs on N2C handshake.

## Changes

### `helper_sdk.sh`

- \`sdk_run_signal_safe\` switched from \`sdk_unreachable\` (AlwaysOrUnreachable) to \`sdk_sometimes_optional false\` (Sometimes, must_hit:false). Signal-induced exits are absorbed silently — observation-only, never a finding.

### Per-script timeouts

| Script | External call | Wrapped with |
|---|---|---|
| \`eventually_alive.sh\` | socat | \`timeout 1\` per loop iteration |
| \`finally_alive.sh\` | socat | \`timeout 1\` per loop iteration |
| \`parallel_driver_heartbeat.sh\` | socat | \`timeout 1\` (single-shot) |
| \`parallel_driver_asteria_player.sh\` | /bin/asteria-game | \`timeout 12\` (parallel cap ~16 s) |
| \`anytime_asteria_admin_singleton.sh\` | /bin/asteria-invariant | \`timeout 12\` |
| \`serial_driver_asteria_bootstrap.sh\` | /bin/asteria-bootstrap | \`timeout 25\` |
| \`finally_asteria_consistency.sh\` | sleep 15 + /bin/asteria-invariant | \`sleep 10 + timeout 30\` (40 s vs ~54 s finally cap) |

### compose pin

Bump to \`asteria-game:c588914\` in both master + adversary composes.

## Smoke test

\`\`\`
ANTITHESIS_OUTPUT_DIR=/tmp/sdk-smoke bash -c '
  source helper_sdk.sh
  sdk_run_signal_safe "test" timeout 0.1 sleep 5
  echo "rc=\$?"
'
# rc=0
# JSONL: "must_hit":false, "details":{"rc":124,...}
\`\`\`

The 124 (timeout exit code) is correctly absorbed via the new must_hit:false emit.

## Test plan

- [ ] CI green
- [ ] After merge: dispatch a 1h on \`cardano_node_master\` and verify the asteria-game properties don't fire findings.