### PR TITLE
testnet(master): add adversary workload

### DIFF
--- a/docs/components/adversary.md
+++ b/docs/components/adversary.md
@@ -133,14 +133,17 @@ delete the two `relay*.example` lines. To attack only one node,
 delete the others. The list lives next to the network magic and the
 port — one place describes the attack target.
 
-## Wiring on `cardano_node_adversary`
+## Wiring on master and `cardano_node_adversary`
 
-The adversary runs as its own service in
-[`testnets/cardano_node_adversary/docker-compose.yaml`][compose]:
+The adversary runs as its own service in the main
+[`testnets/cardano_node_master/docker-compose.yaml`][master-compose]
+profile and in the separate
+[`testnets/cardano_node_adversary/docker-compose.yaml`][adversary-compose]
+validation profile:
 
 ```yaml
 adversary:
-  image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:69f49c5
+  image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:5173fa8
   hostname: adversary.example
   volumes:
     - tracer:/tracer:ro       # tracer-sidecar writes chainPoints.log here
@@ -156,6 +159,15 @@ No `command:` override — the image's `EntryPoint` is `tail -f
 /dev/null`. No socket volume. No shared state with anyone else. The
 only mount is `tracer:/tracer:ro` so the binary can read
 `/tracer/chainPoints.log`.
+
+Promotion to master followed a faults-enabled 1h Antithesis validation
+run of `cardano_node_adversary` on commit `290a8ed3`. That validation
+profile contained the same `tx-generator`, `asteria-game`, and
+`adversary` workload mix now used by master. Master also uses the
+validated tracer-sidecar pin that emits the cluster fork-depth
+checklist; that telemetry is independent of proving the adversary
+appears as a peer and is the critical signal for measuring perturbation
+weight.
 
 ## Build the image
 
@@ -281,7 +293,8 @@ the daemon's home repo: [`cardano-node-clients` PR #122][pr-122].
 
 [adv-comp]: https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/components/adversary
 [driver]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/components/adversary/composer/chain-sync-client/parallel_driver_flap.sh
-[compose]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/testnets/cardano_node_adversary/docker-compose.yaml
+[master-compose]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/testnets/cardano_node_master/docker-compose.yaml
+[adversary-compose]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/testnets/cardano_node_adversary/docker-compose.yaml
 [publish-images]: https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/.github/workflows/publish-images.yaml
 [pr-110]: https://github.com/cardano-foundation/cardano-node-antithesis/pull/110
 [pr-122]: https://github.com/lambdasistemi/cardano-node-clients/pull/122

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -16,7 +16,8 @@ This testnet exercises the node-to-node protocol across multiple cardano-node ve
 | **configurator** | Generates genesis files, node configs, and signing keys at startup |
 | **tracer** | cardano-tracer daemon collecting structured logs from all nodes |
 | **tracer-sidecar** | Processes tracer logs into Antithesis assertions (chain convergence, error detection) |
-| **sidecar** | Network health checks, the Antithesis setup signal, and the host of the chain-sync `adversary` driver (see [Adversary](../components/adversary.md)). |
+| **sidecar** | Network health checks and the Antithesis setup signal. |
+| **adversary** | Sleep-forever host for the chain-sync adversary CLI; Antithesis composer execs its driver per tick to churn N2N clients against producers and relays. See [Adversary](../components/adversary.md). |
 | **log-tailer** | Streams the per-pool node logs into Antithesis's log explorer for offline triage. |
 | **asteria-game** | Single container that hosts the long-lived utxo-indexer plus three short-lived binaries (`asteria-bootstrap`, `asteria-game`, `asteria-invariant`) fired by composer scripts. See [Why asteria-game is here](#why-asteria-game-is-here) below and [Asteria Game](../components/asteria-player.md). |
 | **tx-generator** | Long-running daemon that submits well-formed ADA transfers through relay1's N2C socket. Composer drivers fire deterministic `transact`, `refill`, `eventually`, and `finally` control-socket probes. See [Why tx-generator is here](#why-tx-generator-is-here) below and [Tx-generator](../components/tx-generator.md). |

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -164,8 +164,30 @@ services:
     tmpfs:
       - /tmp
 
+  # Sleep-forever container holding the cardano-adversary CLI plus
+  # its driver scripts under /opt/antithesis/test/v1/. Antithesis
+  # composer `docker exec`s into here per tick to fire one
+  # initiator-only chain-sync session against a randomly-chosen
+  # target node (any of p1/p2/p3/relay1/relay2). The container
+  # itself never receives the request and holds no shared state —
+  # if Antithesis chaos kills it, restart: always brings back an
+  # idempotent host.
+  adversary:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:5173fa8
+    container_name: adversary
+    hostname: adversary.example
+    volumes:
+      # Read-only — tracer-sidecar writes chainPoints.log here.
+      - tracer:/tracer:ro
+    depends_on:
+      tracer-sidecar:
+        condition: service_started
+      configurator:
+        condition: service_completed_successfully
+    restart: always
+
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:5271661
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:8dbf509
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     command:


### PR DESCRIPTION
## Summary

Promotes the adversary workload into `cardano_node_master` after validating the full workload mix on `cardano_node_adversary`.

Changes:
- add the `adversary` sleep-forever service to `testnets/cardano_node_master/docker-compose.yaml`
- promote the validated tracer-sidecar pin that emits the cluster fork-depth checklist (`cluster_fork_depth_*_observed`)
- update master/adversary docs so the adversary is documented as its own service, and fork-depth telemetry is called out as independent of adversary peer-observability

## Evidence

Pre-promotion proof on current `main@290a8ed3`:
- `cardano_node_adversary` already contained `tx-generator`, `asteria-game`, and `adversary`
- faults-enabled 1h Antithesis dispatch succeeded: https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/25558789651
- submitted `testnets/cardano_node_adversary`, `TRY=1`, `faults_enabled=true`, testRunId `2c07af282d8f5c2d05fe1f1703f6ca66f7a7a4e5e801c16fe1e4938cd6178c53`

Why tracer-sidecar moves too:
- the critical part is fork-depth telemetry, not adversary peer-observability
- `8dbf509` emits sparse `cluster_fork_depth_2/3/5/10/50/100/200_observed` optional Sometimes assertions
- that is the perturbation-weight signal we need to judge whether the combined workload is actually stressing the cluster

Local validation on this branch:
- `INTERNAL_NETWORK=true docker compose -f testnets/cardano_node_master/docker-compose.yaml config --quiet`
- resolved master services include `adversary`, `asteria-game`, and `tx-generator`
- `nix develop --quiet -c mkdocs build --strict`

## Follow-up gate

A real `cardano_node_master` Antithesis dispatch on this branch should run before merge to validate the promoted master profile under faults.
