### PR TITLE
fix(tracer-sidecar): scope fork depth to producers

### DIFF
--- a/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
+++ b/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
@@ -76,6 +76,9 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import System.Environment (lookupEnv)
 import System.IO (IOMode (AppendMode), withFile)
+import Text.Read
+    ( readMaybe
+    )
 
 -- spec ------------------------------------------------------------------------
 
@@ -110,9 +113,11 @@ mkSpec nPools = do
     observe forwardAddedToCurrentChain
     observe recordAllChainPoints
 
-    -- Cluster-wide fork-depth probe (#119).
-    forkTreeProbe defaultK defaultDepthCap
-
+    -- Producer fork-depth probe (#119).  Relays may lag or disappear under
+    -- fault injection; they must not turn catch-up lag into a Praos fork
+    -- depth violation.
+    forkTreeProbe nPools defaultK defaultDepthCap
+  where
     -- Issue #123, Layer 2 was here — a "did the adversary appear in
     -- some producer's InboundGovernor stream" probe via substring
     -- match on @adversary.example@. Verified empirically that
@@ -120,7 +125,7 @@ mkSpec nPools = do
     -- peer IP (192.168.x.y) not hostname, so the substring check
     -- never fires. Re-implementing this needs the tracer-side
     -- hostname↔IP mapping, which is non-trivial. Removed for now.
-  where
+
     recordAllChainPoints :: State -> LogMessage -> [Output]
     recordAllChainPoints
         _s
@@ -305,12 +310,12 @@ sometimesOptional name f =
 --   3. @AlwaysOrUnreachable: cluster fork depth < k@ — fires
 --      once 'forkExceededK' becomes 'True'.  An unrecoverable
 --      divergence by Praos's definition.
-forkTreeProbe :: Int -> Int -> Spec
-forkTreeProbe k depthCap = do
+forkTreeProbe :: Int -> Int -> Int -> Spec
+forkTreeProbe nPools k depthCap = do
     Spec
         $ tell
             [ Rule
-                { _ruleProcess = updateForkTree k depthCap
+                { _ruleProcess = updateForkTree nPools k depthCap
                 , ruleDeclaration = Nothing
                 , ruleInit = id
                 }
@@ -356,18 +361,22 @@ parseTip
 -- update derived flags.  No SDK output here — the
 -- 'sometimes' / 'alwaysOrUnreachable' rules above turn the
 -- flags into observable assertions.
-updateForkTree :: Int -> Int -> State -> LogMessage -> (State, [Output])
-updateForkTree k depthCap s LogMessage{host, details} =
-    case details of
-        AddedToCurrentChain{newTipSelectView, newtip} ->
-            let newTip = parseTip newTipSelectView newtip
-                forkTree' = recordExtension host newTip (forkTree s)
-            in  (refresh s{forkTree = forkTree'}, [])
-        SwitchedToAFork{newTipSelectView, newtip} ->
-            let newTip = parseTip newTipSelectView newtip
-                forkTree' = setTip host newTip (forkTree s)
-            in  (refresh s{forkTree = forkTree'}, [])
-        _ -> (s, [])
+updateForkTree
+    :: Int -> Int -> Int -> State -> LogMessage -> (State, [Output])
+updateForkTree nPools k depthCap s LogMessage{host, details} =
+    case producerHost nPools host of
+        Nothing -> (s, [])
+        Just producer ->
+            case details of
+                AddedToCurrentChain{newTipSelectView, newtip} ->
+                    let newTip = parseTip newTipSelectView newtip
+                        forkTree' = recordExtension producer newTip (forkTree s)
+                    in  (refresh s{forkTree = forkTree'}, [])
+                SwitchedToAFork{newTipSelectView, newtip} ->
+                    let newTip = parseTip newTipSelectView newtip
+                        forkTree' = setTip producer newTip (forkTree s)
+                    in  (refresh s{forkTree = forkTree'}, [])
+                _ -> (s, [])
   where
     refresh st = case clusterForkDepth depthCap (forkTree st) of
         Nothing -> st
@@ -378,6 +387,14 @@ updateForkTree k depthCap s LogMessage{host, details} =
                 , maxForkDepth = max d (maxForkDepth st)
                 }
 
+producerHost :: Int -> Text -> Maybe Text
+producerHost nPools host =
+    case T.stripPrefix "p" bareHost >>= readMaybe . T.unpack of
+        Just i
+            | i >= 1 && i <= nPools -> Just bareHost
+        _ -> Nothing
+  where
+    bareHost = fromMaybe host (T.stripSuffix ".example" host)
 
 declarations :: Spec -> [Output]
 declarations (Spec s) = mapMaybe (fmap AntithesisSdk . ruleDeclaration) $ execWriter s

--- a/components/tracer-sidecar/test/Spec.hs
+++ b/components/tracer-sidecar/test/Spec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -7,7 +8,12 @@ module Spec (spec)
 where
 
 import App (tailJsonLinesFromTracerLogDir)
-import Cardano.Antithesis.LogMessage (LogMessage)
+import Cardano.Antithesis.LogMessage
+    ( LogMessage (..)
+    , LogMessageData (..)
+    , NewTipSelectView (..)
+    , Severity (..)
+    )
 import Cardano.Antithesis.Sidecar
     ( Output (..)
     , initialState
@@ -24,11 +30,15 @@ import Control.Concurrent
 import Control.Concurrent.Async (async, cancel)
 import Data.Aeson
     ( ToJSON (toJSON)
-    , Value
+    , Value (..)
     , decodeStrict'
     , eitherDecodeStrict
     , encode
+    , object
+    , (.=)
     )
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Char8 qualified as B8
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Lazy.Char8 qualified as BL8
@@ -42,6 +52,8 @@ import Data.List
 import Data.Maybe
     ( mapMaybe
     )
+import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Time
 import ForkTreeSpec qualified
 import System.FilePath ((</>))
@@ -77,6 +89,27 @@ spec = do
                 expectationFailure
                     $ "Some messages couldn't be decoded: " <> show errs
 
+    describe "cluster fork-depth assertion" $ do
+        it "does not count stale relay lag as producer fork depth" $ do
+            let propSpec = mkSpec 3
+                msgs =
+                    added "relay1" "root" 0
+                        : sameProducerChain 432
+                (_finalState, actualVals) =
+                    processMessages propSpec (initialState propSpec) msgs
+
+            failedAssertionIds actualVals
+                `shouldNotContain` ["cluster fork depth < k"]
+
+        it "still fails when producers diverge by k" $ do
+            let propSpec = mkSpec 3
+                (_finalState, actualVals) =
+                    processMessages propSpec (initialState propSpec)
+                        $ divergentProducerChains 432
+
+            failedAssertionIds actualVals
+                `shouldContain` ["cluster fork depth < k"]
+
     describe "tailJsonLinesFromTracerLogDir" $ do
         it "works on 10 files with 10 values"
             $ withSystemTempDirectory "tracer-log-dir"
@@ -103,6 +136,77 @@ jsonifyOutput :: Output -> Value
 jsonifyOutput (StdOut msg) = toJSON $ "### STDOUT: " <> msg
 jsonifyOutput (AntithesisSdk v) = v
 jsonifyOutput (RecordChainPoint msg) = toJSON $ "### chainPoints.log: " <> msg
+
+failedAssertionIds :: [Output] -> [Text]
+failedAssertionIds outputs =
+    [ assertionId
+    | AntithesisSdk (Object o) <- outputs
+    , Just (Object assertion) <-
+        [KeyMap.lookup (Key.fromString "antithesis_assert") o]
+    , Just (Bool True) <- [KeyMap.lookup (Key.fromString "hit") assertion]
+    , Just (Bool False) <-
+        [KeyMap.lookup (Key.fromString "condition") assertion]
+    , Just (String assertionId) <-
+        [KeyMap.lookup (Key.fromString "id") assertion]
+    ]
+
+sameProducerChain :: Int -> [LogMessage]
+sameProducerChain depth =
+    [added host "root" 0 | host <- producerHosts]
+        <> concat
+            [ [added host ("h" <> T.pack (show n)) n | host <- producerHosts]
+            | n <- [1 .. depth]
+            ]
+
+divergentProducerChains :: Int -> [LogMessage]
+divergentProducerChains depth =
+    [added host "root" 0 | host <- producerHosts]
+        <> concat
+            [ [ added "p1.example" ("a" <> T.pack (show n)) n
+              , added "p2" ("b" <> T.pack (show n)) n
+              , added "p3" ("c" <> T.pack (show n)) n
+              ]
+            | n <- [1 .. depth]
+            ]
+
+producerHosts :: [Text]
+producerHosts = ["p1.example", "p2", "p3"]
+
+added :: Text -> Text -> Int -> LogMessage
+added host hash chainLength =
+    LogMessage
+        { at = UTCTime (fromGregorian 2026 5 8) 0
+        , ns = "ChainDB.AddBlockEvent.AddedToCurrentChain"
+        , details =
+            AddedToCurrentChain
+                { newTipSelectView = tipSelectView chainLength
+                , newtip = hash <> "@" <> T.pack (show chainLength)
+                }
+        , sev = Notice
+        , thread = "test"
+        , host = host
+        , kind = "AddedToCurrentChain"
+        , json =
+            object
+                [ "host" .= host
+                , "data"
+                    .= object
+                        [ "kind" .= ("AddedToCurrentChain" :: Text)
+                        , "newtip" .= (hash <> "@" <> T.pack (show chainLength))
+                        ]
+                ]
+        }
+
+tipSelectView :: Int -> NewTipSelectView
+tipSelectView chainLength =
+    NewTipSelectView
+        { chainLength = chainLength
+        , issueNo = 0
+        , issuerHash = "issuer"
+        , kind = "PraosTiebreakerView"
+        , slotNo = chainLength
+        , tieBreakVRF = "vrf"
+        }
 
 myGoldenTest :: [Value] -> Golden [Value]
 myGoldenTest actualOutput =


### PR DESCRIPTION
Closes #140

## Summary

- Scope the tracer-sidecar fork-depth probe to normalized producer hosts (`p1..pN`) using the existing `POOLS` count.
- Exclude relays from the Praos `cluster fork depth < k` state so stale relay lag cannot be reported as producer fork depth.
- Add regression tests for the stale-relay case and for a real producer divergence at `k`.

## Verification

- `nix build --print-build-logs .#tracer-sidecar-tests && ./result/bin/test` from `components/tracer-sidecar` passed: 13 examples, 0 failures.
- `nix build --print-build-logs .#tracer-sidecar` passed.
- `nix develop .#quality --print-build-logs -c just format` passed.
- `nix develop .#quality --print-build-logs -c just hlint` passed: No hints.

## Note

The full default dev shell (`nix develop --quiet -c just test`) was not usable on this host because it builds HLS/format tooling and hit `No space left on device` before reaching tests. The narrower package build and test executable were used for verification.