### PR TITLE
fix(asteria-game): absorb in-bash signals + flock sdk.jsonl appends so stub/*.sh honour exit-0 contract under fault injection

### DIFF
--- a/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
+++ b/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
@@ -17,6 +17,14 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0. sdk_run_signal_safe already handles the
+# wrapped binary's exit code, but a signal delivered to bash itself
+# between the invocation and the case statement (or before the
+# binary even starts) would still trip Always:zero-exit-code.
+# See #142.
+sdk_install_signal_trap "stub anytime_admin_singleton signal"
+
 export ASTERIA_INVARIANT=admin_singleton
 # `timeout 12` bounds the invariant-check binary under composer's
 # anytime per-command cap. The binary queries the chain via N2C

--- a/components/asteria-game/composer/stub/eventually_alive.sh
+++ b/components/asteria-game/composer/stub/eventually_alive.sh
@@ -41,49 +41,72 @@ SLEEP_SETTLE="${SLEEP_SETTLE:-3}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-8}"
 RETRY_DELAY="${RETRY_DELAY:-1}"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0; see #142 for context.
+sdk_install_signal_trap "stub eventually_alive signal"
+
 sdk_reachable "stub eventually_alive entered"
 
 sleep "$SLEEP_SETTLE"
 
-LAST_REPLY=""
-for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    # `timeout 1 socat`: socat blocks indefinitely on UNIX-CONNECT
-    # waiting for the indexer's reply with no internal deadline.
-    # Without bounding, each loop iteration runs as long as the
-    # indexer takes — observed wall times of 70 s for the whole
-    # script when several iterations stalled, well past composer's
-    # per-command cap. 1 s per attempt keeps the loop's worst case
-    # at 3 s settle + 8 × 1 s = 11 s.
-    LAST_REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
-    if [ -n "$LAST_REPLY" ] \
-        && printf '%s' "$LAST_REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
-        TIP="$(printf '%s' "$LAST_REPLY" | jq -r '.tipSlot // 0')"
-        sdk_sometimes true "stub eventually_alive holds" \
-            "$(jq -nc --argjson a "$attempt" --argjson t "$TIP" '{attempt:$a, tipSlot:$t}')"
-        exit 0
+# Body wrapped via sdk_run_signal_safe_fn so signal-induced exits
+# anywhere in the loop get absorbed the same way the single-binary
+# launches in sibling stubs already do.
+# shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
+_eventually_alive_body() {
+    local last_reply=""
+    local attempt
+    for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+        # `timeout 1 socat`: socat blocks indefinitely on
+        # UNIX-CONNECT waiting for the indexer's reply with no
+        # internal deadline. Without bounding, each loop iteration
+        # runs as long as the indexer takes — observed wall times
+        # of 70 s for the whole script when several iterations
+        # stalled, well past composer's per-command cap. 1 s per
+        # attempt keeps the loop's worst case at
+        # 3 s settle + 8 × 1 s = 11 s.
+        last_reply="$(printf '{"ready": null}\n' \
+                       | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null \
+                       || true)"
+        if [ -n "$last_reply" ] \
+            && printf '%s' "$last_reply" \
+                | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' \
+                    >/dev/null 2>&1; then
+            local tip
+            tip="$(printf '%s' "$last_reply" | jq -r '.tipSlot // 0')"
+            sdk_sometimes true "stub eventually_alive holds" \
+                "$(jq -nc --argjson a "$attempt" --argjson t "$tip" \
+                    '{attempt:$a, tipSlot:$t}')"
+            return 0
+        fi
+        sleep "$RETRY_DELAY"
+    done
+
+    # Budget exhausted. Distinguish "indexer has no chain data yet"
+    # from "indexer is up but stuck behind". Both record as
+    # Sometimes-false observations (no finding); operators read
+    # the rate of each cause in the report's Sometimes-assertion
+    # table.
+    if [ -n "$last_reply" ] \
+        && printf '%s' "$last_reply" | jq -e '.tipSlot == null' >/dev/null 2>&1; then
+        # must_hit:false — the cold-start branch isn't guaranteed
+        # to be reached across timelines (depends on whether a
+        # fault-cascade window coincides with an eventually_
+        # dispatch). The earlier sdk_sometimes (must_hit:true)
+        # emit fired as a finding when it only saw condition:false,
+        # defeating the intent that this be informational coverage
+        # only.
+        sdk_sometimes_optional false "stub eventually_alive cold_start" \
+            "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
+                '{attempts_exhausted:$a, last_reply:$reply, reason:"tipSlot=null — no RollForward yet from upstream"}')"
+        return 0
     fi
-    sleep "$RETRY_DELAY"
-done
 
-# Budget exhausted. Distinguish "indexer has no chain data yet" from
-# "indexer is up but stuck behind". Both record as Sometimes-false
-# observations (no finding); operators read the rate of each cause
-# in the report's Sometimes-assertion table.
-if [ -n "$LAST_REPLY" ] \
-    && printf '%s' "$LAST_REPLY" | jq -e '.tipSlot == null' >/dev/null 2>&1; then
-    # must_hit:false — the cold-start branch isn't guaranteed to be
-    # reached across timelines (depends on whether a fault-cascade
-    # window coincides with an eventually_ dispatch). The earlier
-    # sdk_sometimes (must_hit:true) emit fired as a finding when it
-    # only saw condition:false, defeating the intent that this be
-    # informational coverage only.
-    sdk_sometimes_optional false "stub eventually_alive cold_start" \
-        "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$LAST_REPLY" \
-            '{attempts_exhausted:$a, last_reply:$reply, reason:"tipSlot=null — no RollForward yet from upstream"}')"
-    exit 0
-fi
+    sdk_sometimes false "stub eventually_alive holds" \
+        "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
+            '{attempts_exhausted:$a, last_reply:$reply}')"
+}
 
-sdk_sometimes false "stub eventually_alive holds" \
-    "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$LAST_REPLY" \
-        '{attempts_exhausted:$a, last_reply:$reply}')"
+sdk_run_signal_safe_fn "stub eventually_alive container_stopped" \
+    _eventually_alive_body
 exit 0

--- a/components/asteria-game/composer/stub/finally_alive.sh
+++ b/components/asteria-game/composer/stub/finally_alive.sh
@@ -26,26 +26,46 @@ SLEEP_SETTLE="${SLEEP_SETTLE:-3}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-8}"
 RETRY_DELAY="${RETRY_DELAY:-1}"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0; see #142 for context.
+sdk_install_signal_trap "stub finally_alive signal"
+
 sdk_reachable "stub finally_alive entered"
 
 sleep "$SLEEP_SETTLE"
 
-LAST_REPLY=""
-for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-    # `timeout 1 socat` — bounds each attempt; see eventually_alive.sh
-    # for rationale.
-    LAST_REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
-    if [ -n "$LAST_REPLY" ] \
-        && printf '%s' "$LAST_REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
-        TIP="$(printf '%s' "$LAST_REPLY" | jq -r '.tipSlot // 0')"
-        sdk_sometimes true "stub finally_alive holds" \
-            "$(jq -nc --argjson a "$attempt" --argjson t "$TIP" '{attempt:$a, tipSlot:$t}')"
-        exit 0
-    fi
-    sleep "$RETRY_DELAY"
-done
+# Body wrapped via sdk_run_signal_safe_fn so signal-induced exits
+# anywhere in the loop get absorbed the same way the single-binary
+# launches in sibling stubs already do.
+# shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
+_finally_alive_body() {
+    local last_reply=""
+    local attempt
+    for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+        # `timeout 1 socat` — bounds each attempt; see
+        # eventually_alive.sh for rationale.
+        last_reply="$(printf '{"ready": null}\n' \
+                       | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null \
+                       || true)"
+        if [ -n "$last_reply" ] \
+            && printf '%s' "$last_reply" \
+                | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' \
+                    >/dev/null 2>&1; then
+            local tip
+            tip="$(printf '%s' "$last_reply" | jq -r '.tipSlot // 0')"
+            sdk_sometimes true "stub finally_alive holds" \
+                "$(jq -nc --argjson a "$attempt" --argjson t "$tip" \
+                    '{attempt:$a, tipSlot:$t}')"
+            return 0
+        fi
+        sleep "$RETRY_DELAY"
+    done
 
-sdk_sometimes false "stub finally_alive holds" \
-    "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$LAST_REPLY" \
-        '{attempts_exhausted:$a, last_reply:$reply}')"
+    sdk_sometimes false "stub finally_alive holds" \
+        "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
+            '{attempts_exhausted:$a, last_reply:$reply}')"
+}
+
+sdk_run_signal_safe_fn "stub finally_alive container_stopped" \
+    _finally_alive_body
 exit 0

--- a/components/asteria-game/composer/stub/finally_asteria_consistency.sh
+++ b/components/asteria-game/composer/stub/finally_asteria_consistency.sh
@@ -18,6 +18,11 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0; defense in depth around sdk_run_signal_safe.
+# See #142.
+sdk_install_signal_trap "stub finally_consistency signal"
+
 # 10 s settle + 30 s binary cap = 40 s worst case, comfortably
 # under composer's finally per-command cap (~54 s observed). The
 # binary queries chain UTxOs and counts SHIP tokens; under

--- a/components/asteria-game/composer/stub/helper_sdk.sh
+++ b/components/asteria-game/composer/stub/helper_sdk.sh
@@ -17,26 +17,36 @@ _sdk_emit() {
     local dir
     dir="$(_sdk_output_dir)"
     mkdir -p "$dir"
-    jq -nc \
-        --arg id "$id" \
-        --arg msg "$msg" \
-        --arg dt "$display_type" \
-        --arg at "$assert_type" \
-        --argjson cond "$condition" \
-        --argjson hit "$hit" \
-        --argjson details "$details_json" \
-        --argjson must_hit "$must_hit" \
-        '{antithesis_assert: {
-            id: $id,
-            message: $msg,
-            condition: $cond,
-            display_type: $dt,
-            hit: $hit,
-            must_hit: $must_hit,
-            assert_type: $at,
-            location: {file:"", function:"", class:"", begin_line:0, begin_column:0},
-            details: $details
-         }}' >> "$dir/sdk.jsonl"
+    # flock the open append-FD so concurrent parallel_driver_*
+    # invocations can't interleave at the syscall level under
+    # Antithesis FS-fault injection. O_APPEND alone is atomic for
+    # small writes on stable kernels, but observed flake (#142)
+    # shows pathological hangs on shared sdk.jsonl writes when the
+    # platform throttles fs syscalls; the lock makes the contention
+    # explicit and bounded.
+    {
+        flock -x 9
+        jq -nc \
+            --arg id "$id" \
+            --arg msg "$msg" \
+            --arg dt "$display_type" \
+            --arg at "$assert_type" \
+            --argjson cond "$condition" \
+            --argjson hit "$hit" \
+            --argjson details "$details_json" \
+            --argjson must_hit "$must_hit" \
+            '{antithesis_assert: {
+                id: $id,
+                message: $msg,
+                condition: $cond,
+                display_type: $dt,
+                hit: $hit,
+                must_hit: $must_hit,
+                assert_type: $at,
+                location: {file:"", function:"", class:"", begin_line:0, begin_column:0},
+                details: $details
+             }}' >&9
+    } 9>>"$dir/sdk.jsonl"
 }
 
 sdk_reachable()   { _sdk_emit "Reachable"             "reachability" true  true "$1" "$1" "${2:-null}"; }
@@ -112,4 +122,70 @@ sdk_run_signal_safe() {
             ;;
         *) return "$rc" ;;
     esac
+}
+
+# sdk_run_signal_safe_fn <sig_id> <fn_name>
+#
+# Same absorption contract as sdk_run_signal_safe, but for an entire
+# shell function body — needed for stubs whose work is a multi-stage
+# pipeline (printf | timeout 1 socat | jq), not a single binary call.
+# Caller defines a function and passes its name; the function runs in
+# the current shell (so it sees outer locals + traps) and its overall
+# exit status flows through the same case statement.
+sdk_run_signal_safe_fn() {
+    local sig_id="$1" fn="$2"
+    "$fn"
+    local rc=$?
+    case "$rc" in
+        0) return 0 ;;
+        129 | 137 | 143 | 124 | 255)
+            sdk_sometimes_optional false "$sig_id" \
+                "$(jq -nc --argjson r "$rc" \
+                    '{rc:$r, reason:"shell pipeline exited with signal-induced code; container stopped mid-run or timeout(1) deadline hit"}')"
+            return 0
+            ;;
+        *) return "$rc" ;;
+    esac
+}
+
+# sdk_install_signal_trap <sig_id>
+#
+# Catches SIGTERM/SIGINT/SIGPIPE that arrive at the bash interpreter
+# itself (not the wrapped binary) and converts them into a silent
+# observation + exit 0. Antithesis fault injection can deliver these
+# signals to any process at any time; without a trap, bash dies with
+# 128+sig and the composer's "Always: zero exit code" property fires
+# even though the script was about to honour its "exit 0 always"
+# contract. SIGPIPE in particular is delivered when any command in
+# the script tries to write to a pipe whose reader has closed — a
+# common shape under parallel scheduling on shared FDs.
+#
+# Idempotent: safe to call once at the top of every stub script
+# right after `source helper_sdk.sh`.
+sdk_install_signal_trap() {
+    local sig_id="$1"
+    # SC2064 disabled deliberately: we *want* "$sig_id" to expand
+    # NOW (at trap installation), so each script binds the trap to
+    # its own static id; the second arg is a literal signal name
+    # that doesn't need late expansion.
+    # shellcheck disable=SC2064
+    trap "_sdk_handle_trap '$sig_id' TERM" SIGTERM
+    # shellcheck disable=SC2064
+    trap "_sdk_handle_trap '$sig_id' INT"  SIGINT
+    # shellcheck disable=SC2064
+    trap "_sdk_handle_trap '$sig_id' PIPE" SIGPIPE
+}
+
+# Internal — invoked by the trap installed above. Best-effort emit
+# of a Sometimes-optional false event, then exit 0. Tolerates jq
+# failure under fault injection so the exit-0 contract holds even
+# when the platform is actively sabotaging fs/process syscalls.
+_sdk_handle_trap() {
+    local sig_id="$1" sig="$2"
+    sdk_sometimes_optional false "$sig_id" \
+        "$(jq -nc --arg sig "$sig" \
+            '{killed_by_signal:$sig, reason:"bash interpreter received signal under fault injection"}' \
+            2>/dev/null \
+         || printf '%s' 'null')"
+    exit 0
 }

--- a/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
+++ b/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
@@ -18,6 +18,11 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0; defense in depth around sdk_run_signal_safe.
+# See #142.
+sdk_install_signal_trap "stub asteria_player signal"
+
 PLAYER_ID="$(( ($(date +%s) % 3) + 1 ))"
 export ASTERIA_PLAYER_ID="$PLAYER_ID"
 # `timeout 12 /bin/asteria-game` — the binary has no internal

--- a/components/asteria-game/composer/stub/parallel_driver_heartbeat.sh
+++ b/components/asteria-game/composer/stub/parallel_driver_heartbeat.sh
@@ -16,22 +16,46 @@ source "$(dirname "$0")/helper_sdk.sh"
 
 INDEXER_SOCK="${INDEXER_SOCK:-/tmp/idx.sock}"
 
+# Absorb signals delivered to the bash interpreter itself (SIGTERM /
+# SIGINT / SIGPIPE) into a silent observation + exit 0. Antithesis
+# can deliver any of these mid-script under fault injection; without
+# this trap the script dies 128+sig and trips the composer's
+# Always:zero-exit-code property. See #142.
+sdk_install_signal_trap "stub heartbeat signal"
+
 sdk_reachable "stub heartbeat entered"
 
-# `timeout 1 socat` bounds the heartbeat under composer's
-# parallel_driver per-command cap (~16 s).
-REPLY="$(printf '{"ready": null}\n' | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null || true)"
+# Multi-stage pipeline (printf | timeout 1 socat | jq) wrapped via
+# sdk_run_signal_safe_fn so that signal-induced exits anywhere in
+# the body get absorbed the same way single-binary launches in the
+# sibling stubs already do. Function defined locally so it sees the
+# outer set -u and locals.
+# shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
+_heartbeat_body() {
+    # `timeout 1 socat` bounds the indexer query; the outer wrapper
+    # absorbs 124 if it fires.
+    local reply
+    reply="$(printf '{"ready": null}\n' \
+              | timeout 1 socat - "UNIX-CONNECT:${INDEXER_SOCK}" 2>/dev/null \
+              || true)"
 
-if [ -n "$REPLY" ] && printf '%s' "$REPLY" | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' >/dev/null 2>&1; then
-    PROCESSED="$(printf '%s' "$REPLY" | jq -r '.processedSlot // 0')"
-    TIP="$(printf '%s' "$REPLY" | jq -r '.tipSlot // 0')"
-    BEHIND="$(printf '%s' "$REPLY" | jq -r '.slotsBehind // 0')"
-    sdk_sometimes true "stub heartbeat ticked" \
-        "$(jq -nc --argjson p "$PROCESSED" --argjson t "$TIP" --argjson b "$BEHIND" \
-            '{processedSlot:$p, tipSlot:$t, slotsBehind:$b}')"
-else
-    sdk_sometimes false "stub heartbeat ticked" \
-        "$(jq -nc --arg reply "$REPLY" '{indexer_unresponsive:true, reply:$reply}')"
-fi
+    if [ -n "$reply" ] \
+        && printf '%s' "$reply" \
+            | jq -e '(.slotsBehind // null) != null and .slotsBehind <= 5' \
+                >/dev/null 2>&1; then
+        local processed tip behind
+        processed="$(printf '%s' "$reply" | jq -r '.processedSlot // 0')"
+        tip="$(printf '%s' "$reply"       | jq -r '.tipSlot // 0')"
+        behind="$(printf '%s' "$reply"    | jq -r '.slotsBehind // 0')"
+        sdk_sometimes true "stub heartbeat ticked" \
+            "$(jq -nc --argjson p "$processed" --argjson t "$tip" --argjson b "$behind" \
+                '{processedSlot:$p, tipSlot:$t, slotsBehind:$b}')"
+    else
+        sdk_sometimes false "stub heartbeat ticked" \
+            "$(jq -nc --arg reply "$reply" \
+                '{indexer_unresponsive:true, reply:$reply}')"
+    fi
+}
 
+sdk_run_signal_safe_fn "stub heartbeat container_stopped" _heartbeat_body
 exit 0

--- a/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
+++ b/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
@@ -18,6 +18,11 @@ set -u
 # shellcheck disable=SC1091
 source "$(dirname "$0")/helper_sdk.sh"
 
+# Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
+# observation + exit 0; defense in depth around sdk_run_signal_safe.
+# See #142.
+sdk_install_signal_trap "stub asteria_bootstrap signal"
+
 # `timeout 25` bounds the bootstrap binary; it's a serial_driver
 # so its budget is at least as generous as parallel_driver. 25 s
 # is conservative — first-time deploy needs to mint+lock the NFT

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:c588914
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:444a1a5
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:c588914
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:444a1a5
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

Closes #142.

Run try-10 of commit `290a8ed3` reported 7 NEW findings, all under
`Always: Commands finish with zero exit code` against `stub/*.sh`. Try-11
on the same commit and the same image digests was clean. Same code,
different scheduling — the stubs flake when Antithesis fault injection
delivers a signal to the bash interpreter (not the wrapped binary), or
when concurrent `parallel_driver_*` invocations race on `/tmp/sdk.jsonl`.

## Changes

`helper_sdk.sh`:

- `_sdk_emit` now wraps its `>> /tmp/sdk.jsonl` append with `flock -x`
  on the open append-FD so two concurrent shells can't interleave at
  the syscall level under FS-fault injection.
- New `sdk_install_signal_trap` installs absorbing traps on
  `SIGTERM` / `SIGINT` / `SIGPIPE` that emit `sdk_sometimes_optional false`
  and exit 0; called once at the top of every stub script.
- New `sdk_run_signal_safe_fn` extends `sdk_run_signal_safe` to wrap
  shell-function bodies, not just single-binary launches — needed for
  the heartbeat / eventually_alive / finally_alive stubs whose work is a
  `printf | timeout 1 socat | jq` pipeline rather than one binary.

Per-stub:

- `parallel_driver_heartbeat.sh`, `eventually_alive.sh`, `finally_alive.sh` —
  body extracted into a local `_xxx_body` function, run through the
  new fn-wrapper. Variable names lower-cased to match local style.
- `anytime_asteria_admin_singleton.sh`, `finally_asteria_consistency.sh`,
  `parallel_driver_asteria_player.sh`, `serial_driver_asteria_bootstrap.sh` —
  add the signal trap as defense-in-depth around the existing
  `sdk_run_signal_safe` binary wrap.

## Local verification (standalone)

| check | result |
|---|---|
| `bash -n` on all 8 files | OK |
| `shellcheck -x` on all 8 files | OK (intentional `SC2329` / `SC2064` suppressed inline) |
| 10 concurrent shells × 5 emits each → `/tmp/sdk.jsonl` | exactly 50 valid JSON lines, no loss/corruption |
| `SIGTERM` mid-`sleep` to a script that installed the trap | exit 0; trap-emit recorded |
| `timeout 1 sleep 5` body via `sdk_run_signal_safe_fn` | exit 0; `must_hit:false` recorded |

## What this PR does NOT do

- Does not rebuild the asteria-game image — that's a follow-up `chore: bump pin to <sha>` once this lands and an image with the new scripts is published, mirroring the pattern of #6be8939 → #290a8ed3.
- Does not run the local cluster end-to-end — my changes are shell-only and go through `cp -r` in `nix/docker-image.nix` (no compile path), and the existing local-cluster image on this host has the old scripts. The standalone tests cover script correctness.

## Acceptance (from #142)

`Always: Commands finish with zero exit code` passes for every
`stub/*.sh` across **3 consecutive `try`s** on a single commit, on
`testnets/cardano_node_master/` with `custom.faults_enabled:true`.
`findings_new` and `findings_ongoing` for that property group on
`stub/*.sh` are both 0 across those 3 runs.

## Verification plan after merge

1. Land this PR.
2. Bump `components/asteria-game/flake.nix` `cardano-node-clients` pin (or rebuild the asteria-game image tag) so the new scripts are baked in. Same shape as the `c588914 → 290a8ed3` follow-up.
3. Trigger 3 consecutive 1h Antithesis runs on `testnets/cardano_node_master/` with faults enabled. Confirm 0 stub findings each.

cc: #49, #106, #102, #121.