### PR TITLE
fix(asteria-game): add --kill-after=2 to all stub timeout-wrapped binaries

### DIFF
--- a/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
+++ b/components/asteria-game/composer/stub/anytime_asteria_admin_singleton.sh
@@ -26,9 +26,12 @@ source "$(dirname "$0")/helper_sdk.sh"
 sdk_install_signal_trap "stub anytime_admin_singleton signal"
 
 export ASTERIA_INVARIANT=admin_singleton
-# `timeout 12` bounds the invariant-check binary under composer's
-# anytime per-command cap. The binary queries the chain via N2C
-# and can hang under partition; bound to 12 s with margin for the
-# absorb path. timeout 124 → sdk_run_signal_safe → no finding.
+# `timeout --kill-after=2 12` bounds the invariant-check binary
+# under composer's anytime per-command cap. Plain SIGTERM at 12 s
+# is not enough — the Haskell binary can catch it, run slow N2C
+# cleanup, and exit rc=1 (Haskell default unhandled-exception code)
+# on a torn socket; sdk_run_signal_safe doesn't absorb 1, so the
+# property would fire. --kill-after=2 escalates to SIGKILL 2 s
+# after SIGTERM → exit 137 → absorbed. See #145.
 sdk_run_signal_safe "stub anytime_admin_singleton container_stopped" \
-    timeout 12 /bin/asteria-invariant
+    timeout --kill-after=2 12 /bin/asteria-invariant

--- a/components/asteria-game/composer/stub/finally_asteria_consistency.sh
+++ b/components/asteria-game/composer/stub/finally_asteria_consistency.sh
@@ -23,12 +23,15 @@ source "$(dirname "$0")/helper_sdk.sh"
 # See #142.
 sdk_install_signal_trap "stub finally_consistency signal"
 
-# 10 s settle + 30 s binary cap = 40 s worst case, comfortably
-# under composer's finally per-command cap (~54 s observed). The
-# binary queries chain UTxOs and counts SHIP tokens; under
-# partition it can hang on N2C handshake, hence the `timeout 30`
-# bound. Earlier 15 s + unbounded binary blew past 54 s.
+# 10 s settle + 30 s binary cap + 2 s SIGKILL grace = 42 s worst
+# case, comfortably under composer's finally per-command cap (~54 s
+# observed). The binary queries chain UTxOs and counts SHIP tokens;
+# under partition it can hang on N2C handshake, hence the
+# `timeout 30` bound. `--kill-after=2` escalates to SIGKILL 2 s
+# after SIGTERM so the binary's slow-cleanup path can't outlive the
+# deadline and exit rc=1 (Haskell default unhandled-exception
+# code) which sdk_run_signal_safe doesn't absorb. See #145.
 sleep 10
 export ASTERIA_INVARIANT=consistency
 sdk_run_signal_safe "stub finally_consistency container_stopped" \
-    timeout 30 /bin/asteria-invariant
+    timeout --kill-after=2 30 /bin/asteria-invariant

--- a/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
+++ b/components/asteria-game/composer/stub/parallel_driver_asteria_player.sh
@@ -25,12 +25,16 @@ sdk_install_signal_trap "stub asteria_player signal"
 
 PLAYER_ID="$(( ($(date +%s) % 3) + 1 ))"
 export ASTERIA_PLAYER_ID="$PLAYER_ID"
-# `timeout 12 /bin/asteria-game` — the binary has no internal
-# deadline and can hang on N2C handshake or chain-follower reads
-# under cluster perturbation. Composer's parallel_driver per-command
-# cap is ~16 s; bounding to 12 s gives margin for the bash trap +
-# sdk_run_signal_safe emit. Timeout exits 124 → caught by
-# sdk_run_signal_safe → recorded via sdk_sometimes_optional false
-# (no finding).
+# `timeout --kill-after=2 12 /bin/asteria-game` — the binary has no
+# internal deadline and can hang on N2C handshake or chain-follower
+# reads under cluster perturbation. Composer's parallel_driver
+# per-command cap is ~16 s; bounding to 12 s gives margin for the
+# bash trap + sdk_run_signal_safe emit. Timeout's plain SIGTERM at
+# 12 s is not enough — the Haskell binary catches SIGTERM and runs
+# slow N2C cleanup that exits rc=1 (Haskell default unhandled-
+# exception code) on a torn socket; sdk_run_signal_safe deliberately
+# does NOT absorb 1, so the property fired (#145, observed runtimes
+# 27–47 s on commit 8690faa). --kill-after=2 escalates to SIGKILL
+# 2 s after SIGTERM, producing exit 137 which IS absorbed.
 sdk_run_signal_safe "stub asteria_player_${PLAYER_ID} container_stopped" \
-    timeout 12 /bin/asteria-game
+    timeout --kill-after=2 12 /bin/asteria-game

--- a/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
+++ b/components/asteria-game/composer/stub/serial_driver_asteria_bootstrap.sh
@@ -23,11 +23,14 @@ source "$(dirname "$0")/helper_sdk.sh"
 # See #142.
 sdk_install_signal_trap "stub asteria_bootstrap signal"
 
-# `timeout 25` bounds the bootstrap binary; it's a serial_driver
-# so its budget is at least as generous as parallel_driver. 25 s
-# is conservative — first-time deploy needs to mint+lock the NFT
-# (a few chain rounds) but subsequent invocations exit fast on the
-# isAlreadyDeployed short-circuit. timeout 124 →
-# sdk_run_signal_safe → no finding.
+# `timeout --kill-after=2 25` bounds the bootstrap binary; it's a
+# serial_driver so its budget is at least as generous as
+# parallel_driver. 25 s is conservative — first-time deploy needs
+# to mint+lock the NFT (a few chain rounds) but subsequent
+# invocations exit fast on the isAlreadyDeployed short-circuit.
+# `--kill-after=2` escalates to SIGKILL 2 s after SIGTERM so the
+# binary's slow-cleanup path can't outlive the deadline and exit
+# rc=1 (Haskell default unhandled-exception code) which
+# sdk_run_signal_safe doesn't absorb. See #145.
 sdk_run_signal_safe "stub asteria_bootstrap container_stopped" \
-    timeout 25 /bin/asteria-bootstrap
+    timeout --kill-after=2 25 /bin/asteria-bootstrap

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:444a1a5
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:126bb4e
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:444a1a5
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:126bb4e
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

Closes #145.

After [#143](https://github.com/cardano-foundation/cardano-node-antithesis/pull/143) landed, six of seven previously-failing stubs went green on the first post-merge cron of [`8690faa`](https://github.com/cardano-foundation/cardano-node-antithesis/commit/8690faa) ([report](https://cardano.antithesis.com/report/JcNXIvjxQX5Kjy1tgkwjff_W/XgOqmDKymL1f_KbXBSRG_lM-dL-MJjICYrgLyBuNwMA.html?auth=v2.public.eyJuYmYiOiIyMDI2LTA1LTEwVDIxOjU0OjA1LjY0NjYwMzM4MFoiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiWGdPcW1ES3ltTDFmX0tiWEJTUkdfbE0tZEwtTUpqSUNZcmdMeUJ1TndNQS5odG1sIiwicmVwb3J0X2lkIjoiSmNOWEl2anhRWDVLankxdGdrd2pmZl9XIn19fXS9uq6NBL5fgO854uoH4RSsO3YQoBJa3G-MSflj5qBrpigw3h0qh6GSZfv0DkYTEyrbJbB8QOohwRIBMQlX_gU)), but `stub/parallel_driver_asteria_player.sh` still tripped `Always: Commands finish with zero exit code` (1 new finding, 3h 19m, faults on).

## Diagnosis

Decoded `event_desc` for the 4 examples on that finding:

```
example 1  fail  rc=1  runtime 27.27 s   stdout="" stderr=""
example 2  fail  rc=1  runtime 28.65 s   stdout="" stderr=""
example 3  fail  rc=1  runtime 47.31 s   stdout="" stderr=""
example 4  pass  rc=0  runtime  3.02 s   stdout="" stderr=""
```

The wrapper is `sdk_run_signal_safe ... timeout 12 /bin/asteria-game`. Plain `timeout 12` sends SIGTERM at the 12 s deadline but does **not** escalate to SIGKILL — that requires `--kill-after`. The Haskell binary catches SIGTERM, runs slow N2C cleanup that fails on a torn socket, then exits **rc=1** (Haskell default unhandled-exception code). `sdk_run_signal_safe` deliberately propagates non-signal exits so the property fires.

Adding `--kill-after=2` escalates to SIGKILL 2 s after SIGTERM. The kernel-killed exit (**137**) is in `sdk_run_signal_safe`'s absorb set along with `124`/`129`/`143`/`255`, so the script terminates deterministically inside `(deadline + 2)` seconds and the property stays green.

## Changes

Same fix on all four binary-launching stubs (same wrapper pattern, same risk):

| stub | before | after |
|---|---|---|
| `parallel_driver_asteria_player.sh` | `timeout 12 /bin/asteria-game` | `timeout --kill-after=2 12 /bin/asteria-game` |
| `anytime_asteria_admin_singleton.sh` | `timeout 12 /bin/asteria-invariant` | `timeout --kill-after=2 12 /bin/asteria-invariant` |
| `finally_asteria_consistency.sh` | `timeout 30 /bin/asteria-invariant` | `timeout --kill-after=2 30 /bin/asteria-invariant` |
| `serial_driver_asteria_bootstrap.sh` | `timeout 25 /bin/asteria-bootstrap` | `timeout --kill-after=2 25 /bin/asteria-bootstrap` |

Plus the docker-compose pin bump in both testnets so the next Antithesis run actually picks up the rebuilt image (mirrors [#143](https://github.com/cardano-foundation/cardano-node-antithesis/pull/143)'s `444a1a5 → dfd6a3e2` shape).

## Local verification

```
$ timeout 1 bash -c "trap 'sleep 8; exit 1' TERM; sleep 60"
exit code: 124   ← unreliable: depends on whether timeout outwaits the trap

$ timeout --kill-after=2 1 bash -c "trap 'sleep 8; exit 1' TERM; sleep 60"
exit code: 137   ← deterministic SIGKILL, absorbed by sdk_run_signal_safe
```

`bash -n` and `shellcheck -x` both clean on all four files.

## Why all four when only one tripped

`asteria_player` was the only stub flagged on this run, but the other three have the **identical** wrapper pattern. Rather than fixing run-by-run as each one happens to trip, fix the failure mode. No semantic change for healthy runs; the failure path now terminates predictably in `N + 2` seconds.

## Acceptance

`Always: Commands finish with zero exit code` passes for all four scripts across **3 consecutive `try`s** on a single commit on `testnets/cardano_node_master/` with `custom.faults_enabled:true`. Combined with #142's bash-level absorption, all 7 originally-failing stubs from #142 should hold clean.

cc [#142](https://github.com/cardano-foundation/cardano-node-antithesis/issues/142), [#143](https://github.com/cardano-foundation/cardano-node-antithesis/pull/143).