### PR TITLE
chore(asteria-game): rename composer/stub → composer/asteria-game (drop stale label)

### DIFF
--- a/components/asteria-game/composer/asteria-game/anytime_asteria_admin_singleton.sh
+++ b/components/asteria-game/composer/asteria-game/anytime_asteria_admin_singleton.sh
@@ -23,7 +23,7 @@ source "$(dirname "$0")/helper_sdk.sh"
 # between the invocation and the case statement (or before the
 # binary even starts) would still trip Always:zero-exit-code.
 # See #142.
-sdk_install_signal_trap "stub anytime_admin_singleton signal"
+sdk_install_signal_trap "asteria_game anytime_admin_singleton signal"
 
 export ASTERIA_INVARIANT=admin_singleton
 # `timeout --kill-after=2 12` bounds the invariant-check binary
@@ -33,5 +33,5 @@ export ASTERIA_INVARIANT=admin_singleton
 # on a torn socket; sdk_run_signal_safe doesn't absorb 1, so the
 # property would fire. --kill-after=2 escalates to SIGKILL 2 s
 # after SIGTERM → exit 137 → absorbed. See #145.
-sdk_run_signal_safe "stub anytime_admin_singleton container_stopped" \
+sdk_run_signal_safe "asteria_game anytime_admin_singleton container_stopped" \
     timeout --kill-after=2 12 /bin/asteria-invariant

--- a/components/asteria-game/composer/asteria-game/eventually_alive.sh
+++ b/components/asteria-game/composer/asteria-game/eventually_alive.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# eventually_alive.sh — stub post-fault liveness probe via the indexer.
+# eventually_alive.sh — post-fault liveness probe via the indexer.
 #
 # Antithesis stops fault injection before this script starts. The
 # check is intentionally small: confirm the long-lived utxo-indexer
@@ -43,15 +43,15 @@ RETRY_DELAY="${RETRY_DELAY:-1}"
 
 # Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
 # observation + exit 0; see #142 for context.
-sdk_install_signal_trap "stub eventually_alive signal"
+sdk_install_signal_trap "asteria_game eventually_alive signal"
 
-sdk_reachable "stub eventually_alive entered"
+sdk_reachable "asteria_game eventually_alive entered"
 
 sleep "$SLEEP_SETTLE"
 
 # Body wrapped via sdk_run_signal_safe_fn so signal-induced exits
 # anywhere in the loop get absorbed the same way the single-binary
-# launches in sibling stubs already do.
+# launches in sibling scripts already do.
 # shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
 _eventually_alive_body() {
     local last_reply=""
@@ -74,7 +74,7 @@ _eventually_alive_body() {
                     >/dev/null 2>&1; then
             local tip
             tip="$(printf '%s' "$last_reply" | jq -r '.tipSlot // 0')"
-            sdk_sometimes true "stub eventually_alive holds" \
+            sdk_sometimes true "asteria_game eventually_alive holds" \
                 "$(jq -nc --argjson a "$attempt" --argjson t "$tip" \
                     '{attempt:$a, tipSlot:$t}')"
             return 0
@@ -96,17 +96,17 @@ _eventually_alive_body() {
         # emit fired as a finding when it only saw condition:false,
         # defeating the intent that this be informational coverage
         # only.
-        sdk_sometimes_optional false "stub eventually_alive cold_start" \
+        sdk_sometimes_optional false "asteria_game eventually_alive cold_start" \
             "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
                 '{attempts_exhausted:$a, last_reply:$reply, reason:"tipSlot=null — no RollForward yet from upstream"}')"
         return 0
     fi
 
-    sdk_sometimes false "stub eventually_alive holds" \
+    sdk_sometimes false "asteria_game eventually_alive holds" \
         "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
             '{attempts_exhausted:$a, last_reply:$reply}')"
 }
 
-sdk_run_signal_safe_fn "stub eventually_alive container_stopped" \
+sdk_run_signal_safe_fn "asteria_game eventually_alive container_stopped" \
     _eventually_alive_body
 exit 0

--- a/components/asteria-game/composer/asteria-game/finally_alive.sh
+++ b/components/asteria-game/composer/asteria-game/finally_alive.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# finally_alive.sh — stub post-workload liveness probe via the indexer.
+# finally_alive.sh — post-workload liveness probe via the indexer.
 #
 # Runs after every parallel_driver completes (no fault injection).
 # Same shape as eventually_alive.sh — confirm the indexer is at the
@@ -28,15 +28,15 @@ RETRY_DELAY="${RETRY_DELAY:-1}"
 
 # Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
 # observation + exit 0; see #142 for context.
-sdk_install_signal_trap "stub finally_alive signal"
+sdk_install_signal_trap "asteria_game finally_alive signal"
 
-sdk_reachable "stub finally_alive entered"
+sdk_reachable "asteria_game finally_alive entered"
 
 sleep "$SLEEP_SETTLE"
 
 # Body wrapped via sdk_run_signal_safe_fn so signal-induced exits
 # anywhere in the loop get absorbed the same way the single-binary
-# launches in sibling stubs already do.
+# launches in sibling scripts already do.
 # shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
 _finally_alive_body() {
     local last_reply=""
@@ -53,7 +53,7 @@ _finally_alive_body() {
                     >/dev/null 2>&1; then
             local tip
             tip="$(printf '%s' "$last_reply" | jq -r '.tipSlot // 0')"
-            sdk_sometimes true "stub finally_alive holds" \
+            sdk_sometimes true "asteria_game finally_alive holds" \
                 "$(jq -nc --argjson a "$attempt" --argjson t "$tip" \
                     '{attempt:$a, tipSlot:$t}')"
             return 0
@@ -61,11 +61,11 @@ _finally_alive_body() {
         sleep "$RETRY_DELAY"
     done
 
-    sdk_sometimes false "stub finally_alive holds" \
+    sdk_sometimes false "asteria_game finally_alive holds" \
         "$(jq -nc --argjson a "$MAX_ATTEMPTS" --arg reply "$last_reply" \
             '{attempts_exhausted:$a, last_reply:$reply}')"
 }
 
-sdk_run_signal_safe_fn "stub finally_alive container_stopped" \
+sdk_run_signal_safe_fn "asteria_game finally_alive container_stopped" \
     _finally_alive_body
 exit 0

--- a/components/asteria-game/composer/asteria-game/finally_asteria_consistency.sh
+++ b/components/asteria-game/composer/asteria-game/finally_asteria_consistency.sh
@@ -21,7 +21,7 @@ source "$(dirname "$0")/helper_sdk.sh"
 # Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
 # observation + exit 0; defense in depth around sdk_run_signal_safe.
 # See #142.
-sdk_install_signal_trap "stub finally_consistency signal"
+sdk_install_signal_trap "asteria_game finally_consistency signal"
 
 # 10 s settle + 30 s binary cap + 2 s SIGKILL grace = 42 s worst
 # case, comfortably under composer's finally per-command cap (~54 s
@@ -33,5 +33,5 @@ sdk_install_signal_trap "stub finally_consistency signal"
 # code) which sdk_run_signal_safe doesn't absorb. See #145.
 sleep 10
 export ASTERIA_INVARIANT=consistency
-sdk_run_signal_safe "stub finally_consistency container_stopped" \
+sdk_run_signal_safe "asteria_game finally_consistency container_stopped" \
     timeout --kill-after=2 30 /bin/asteria-invariant

--- a/components/asteria-game/composer/asteria-game/helper_sdk.sh
+++ b/components/asteria-game/composer/asteria-game/helper_sdk.sh
@@ -127,7 +127,7 @@ sdk_run_signal_safe() {
 # sdk_run_signal_safe_fn <sig_id> <fn_name>
 #
 # Same absorption contract as sdk_run_signal_safe, but for an entire
-# shell function body — needed for stubs whose work is a multi-stage
+# shell function body — needed for scripts whose work is a multi-stage
 # pipeline (printf | timeout 1 socat | jq), not a single binary call.
 # Caller defines a function and passes its name; the function runs in
 # the current shell (so it sees outer locals + traps) and its overall
@@ -160,7 +160,7 @@ sdk_run_signal_safe_fn() {
 # the script tries to write to a pipe whose reader has closed — a
 # common shape under parallel scheduling on shared FDs.
 #
-# Idempotent: safe to call once at the top of every stub script
+# Idempotent: safe to call once at the top of every script
 # right after `source helper_sdk.sh`.
 sdk_install_signal_trap() {
     local sig_id="$1"

--- a/components/asteria-game/composer/asteria-game/parallel_driver_asteria_player.sh
+++ b/components/asteria-game/composer/asteria-game/parallel_driver_asteria_player.sh
@@ -21,7 +21,7 @@ source "$(dirname "$0")/helper_sdk.sh"
 # Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
 # observation + exit 0; defense in depth around sdk_run_signal_safe.
 # See #142.
-sdk_install_signal_trap "stub asteria_player signal"
+sdk_install_signal_trap "asteria_game asteria_player signal"
 
 PLAYER_ID="$(( ($(date +%s) % 3) + 1 ))"
 export ASTERIA_PLAYER_ID="$PLAYER_ID"
@@ -36,5 +36,5 @@ export ASTERIA_PLAYER_ID="$PLAYER_ID"
 # does NOT absorb 1, so the property fired (#145, observed runtimes
 # 27–47 s on commit 8690faa). --kill-after=2 escalates to SIGKILL
 # 2 s after SIGTERM, producing exit 137 which IS absorbed.
-sdk_run_signal_safe "stub asteria_player_${PLAYER_ID} container_stopped" \
+sdk_run_signal_safe "asteria_game asteria_player_${PLAYER_ID} container_stopped" \
     timeout --kill-after=2 12 /bin/asteria-game

--- a/components/asteria-game/composer/asteria-game/parallel_driver_heartbeat.sh
+++ b/components/asteria-game/composer/asteria-game/parallel_driver_heartbeat.sh
@@ -21,14 +21,14 @@ INDEXER_SOCK="${INDEXER_SOCK:-/tmp/idx.sock}"
 # can deliver any of these mid-script under fault injection; without
 # this trap the script dies 128+sig and trips the composer's
 # Always:zero-exit-code property. See #142.
-sdk_install_signal_trap "stub heartbeat signal"
+sdk_install_signal_trap "asteria_game heartbeat signal"
 
-sdk_reachable "stub heartbeat entered"
+sdk_reachable "asteria_game heartbeat entered"
 
 # Multi-stage pipeline (printf | timeout 1 socat | jq) wrapped via
 # sdk_run_signal_safe_fn so that signal-induced exits anywhere in
 # the body get absorbed the same way single-binary launches in the
-# sibling stubs already do. Function defined locally so it sees the
+# sibling scripts already do. Function defined locally so it sees the
 # outer set -u and locals.
 # shellcheck disable=SC2329  # invoked indirectly by sdk_run_signal_safe_fn below
 _heartbeat_body() {
@@ -47,15 +47,15 @@ _heartbeat_body() {
         processed="$(printf '%s' "$reply" | jq -r '.processedSlot // 0')"
         tip="$(printf '%s' "$reply"       | jq -r '.tipSlot // 0')"
         behind="$(printf '%s' "$reply"    | jq -r '.slotsBehind // 0')"
-        sdk_sometimes true "stub heartbeat ticked" \
+        sdk_sometimes true "asteria_game heartbeat ticked" \
             "$(jq -nc --argjson p "$processed" --argjson t "$tip" --argjson b "$behind" \
                 '{processedSlot:$p, tipSlot:$t, slotsBehind:$b}')"
     else
-        sdk_sometimes false "stub heartbeat ticked" \
+        sdk_sometimes false "asteria_game heartbeat ticked" \
             "$(jq -nc --arg reply "$reply" \
                 '{indexer_unresponsive:true, reply:$reply}')"
     fi
 }
 
-sdk_run_signal_safe_fn "stub heartbeat container_stopped" _heartbeat_body
+sdk_run_signal_safe_fn "asteria_game heartbeat container_stopped" _heartbeat_body
 exit 0

--- a/components/asteria-game/composer/asteria-game/serial_driver_asteria_bootstrap.sh
+++ b/components/asteria-game/composer/asteria-game/serial_driver_asteria_bootstrap.sh
@@ -21,7 +21,7 @@ source "$(dirname "$0")/helper_sdk.sh"
 # Absorb in-bash signals (SIGTERM/SIGINT/SIGPIPE) into a silent
 # observation + exit 0; defense in depth around sdk_run_signal_safe.
 # See #142.
-sdk_install_signal_trap "stub asteria_bootstrap signal"
+sdk_install_signal_trap "asteria_game asteria_bootstrap signal"
 
 # `timeout --kill-after=2 25` bounds the bootstrap binary; it's a
 # serial_driver so its budget is at least as generous as
@@ -32,5 +32,5 @@ sdk_install_signal_trap "stub asteria_bootstrap signal"
 # binary's slow-cleanup path can't outlive the deadline and exit
 # rc=1 (Haskell default unhandled-exception code) which
 # sdk_run_signal_safe doesn't absorb. See #145.
-sdk_run_signal_safe "stub asteria_bootstrap container_stopped" \
+sdk_run_signal_safe "asteria_game asteria_bootstrap container_stopped" \
     timeout --kill-after=2 25 /bin/asteria-bootstrap

--- a/docs/components/asteria-player.md
+++ b/docs/components/asteria-player.md
@@ -76,7 +76,7 @@ volumes:
 in [`testnets/cardano_node_master/docker-compose.yaml`][master-compose].
 
 The composer scripts that drive the binaries are baked into the
-image at build time at `/opt/antithesis/test/v1/stub/` - nothing extra
+image at build time at `/opt/antithesis/test/v1/asteria-game/` - nothing extra
 to mount. The Antithesis composer mounts that path into its execution
 sandbox automatically when the test runs.
 
@@ -99,7 +99,7 @@ that consume + replace the asteria UTxO. The cluster needs:
 - A relay reachable via `relay1.example:3001` (N2N) and
   `relay1-state:/state/node.socket` (N2C). Aliasing it under a
   different name requires editing
-  `components/asteria-game/composer/stub/parallel_driver_asteria_player.sh`.
+  `components/asteria-game/composer/asteria-game/parallel_driver_asteria_player.sh`.
 - Genesis funds in `utxo-keys/genesis.1.skey` sufficient for the
   one-time bootstrap deploy plus a few thousand `spawnShip`
   transactions over a 3h run.
@@ -130,7 +130,7 @@ the Antithesis composer fires as commands:
   end-of-run state consistency between the asteria `ship_counter` and
   the `SHIP*` tokens at the spacetime address.
 
-Composer scripts under `/opt/antithesis/test/v1/stub/`:
+Composer scripts under `/opt/antithesis/test/v1/asteria-game/`:
 
 | Script | Role |
 |--------|------|
@@ -155,7 +155,7 @@ Asteria contributes both workload and oracles:
   `asteriaAdmin` NFT exists at the asteria spend address.
 - `asteria_state_consistent` is a `Sometimes` property comparing
   `ship_counter` to `SHIP*` token count.
-- `stub eventually_alive holds` and `stub finally_alive holds` prove the
+- `asteria_game eventually_alive holds` and `asteria_game finally_alive holds` prove the
   long-lived indexer is responsive and close to the chain tip.
 
 ## Build the image

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -81,7 +81,7 @@ What this gives Antithesis to score:
 The container is the **load + oracle** of the test. Its image is
 pinned by SHA in `docker-compose.yaml`; building it locally goes
 through `components/asteria-game/`. The composer scripts that drive
-it live alongside the binaries in `components/asteria-game/composer/stub/`
+it live alongside the binaries in `components/asteria-game/composer/asteria-game/`
 and are baked into the image at build time.
 
 For the architectural detail of how the binaries integrate with

--- a/testnets/asteria_game/docker-compose.yaml
+++ b/testnets/asteria_game/docker-compose.yaml
@@ -200,7 +200,7 @@ services:
   # testnets/cardano_node_master/docker-compose.yaml. Long-lived
   # utxo-indexer follows relay1's chain via N2C, exposes
   # ready/utxos_at/await on /tmp/idx.sock; composer scripts at
-  # /opt/antithesis/test/v1/stub/ drive bootstrap (one-shot
+  # /opt/antithesis/test/v1/asteria-game/ drive bootstrap (one-shot
   # serial driver), the player loop, and the admin-singleton /
   # consistency invariant snapshots.
   #

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -233,7 +233,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:126bb4e
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:5252cad0
     container_name: asteria-game
     hostname: asteria-game.example
     environment:

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -217,7 +217,7 @@ services:
   # the strength of the 0-findings 1h Antithesis run on commit
   # 9984a1e (PR #100). Long-lived utxo-indexer follows relay1's
   # chain via N2C, exposes ready/utxos_at/await on /tmp/idx.sock;
-  # composer scripts at /opt/antithesis/test/v1/stub/ drive
+  # composer scripts at /opt/antithesis/test/v1/asteria-game/ drive
   # bootstrap (one-shot serial driver), the player loop, and the
   # admin-singleton / consistency invariant snapshots. The player
   # parallel_driver_ is the workload generator: builds + signs +

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -195,7 +195,7 @@ services:
   # the strength of the 0-findings 1h Antithesis run on commit
   # 9984a1e (PR #100). Long-lived utxo-indexer follows relay1's
   # chain via N2C, exposes ready/utxos_at/await on /tmp/idx.sock;
-  # composer scripts at /opt/antithesis/test/v1/stub/ drive
+  # composer scripts at /opt/antithesis/test/v1/asteria-game/ drive
   # bootstrap (one-shot serial driver), the player loop, and the
   # admin-singleton / consistency invariant snapshots. The player
   # parallel_driver_ is the workload generator: builds + signs +

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -211,7 +211,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:126bb4e
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:5252cad0
     container_name: asteria-game
     hostname: asteria-game.example
     environment:


### PR DESCRIPTION
## Summary

Closes #144.

The `stub/` label was a 2026-04 leftover from when there was no real
asteria-game ([3b6fb0e](https://github.com/cardano-foundation/cardano-node-antithesis/commit/3b6fb0e)). When the real
implementation arrived in [fbb8982](https://github.com/cardano-foundation/cardano-node-antithesis/commit/fbb8982), the directory was lifted verbatim
and the label stuck despite the scripts inside no longer being
placeholders. The rest of the repo follows `<component>/composer/<purpose>/`
(e.g. `tx-generator/composer/tx-generator/`,
`adversary/composer/chain-sync-client/`); this PR aligns the
asteria-game scripts with that pattern.

The label was leaking into Antithesis reports — every finding showed
up as `stub/parallel_driver_X.sh` and every assertion as
`stub heartbeat ticked` — which read as "placeholder code being
flaky" rather than "real driver". This actually misled triage on
[#142](https://github.com/cardano-foundation/cardano-node-antithesis/issues/142).

## Changes

| | |
|---|---|
| Directory | `components/asteria-game/composer/stub/` → `components/asteria-game/composer/asteria-game/` (8 files moved with `git mv`) |
| Antithesis composer install path | `/opt/antithesis/test/v1/stub/` → `/opt/antithesis/test/v1/asteria-game/` (via `nix/docker-image.nix`'s `cp -r`) |
| SDK assertion IDs | `stub <name>` → `asteria_game <name>` for all 21 IDs across 7 scripts (matches `tx-generator`'s snake-case component-prefix convention) |
| Prose comments | "stub script" / "sibling stubs" / "stub post-fault liveness probe" wording cleaned up — the rename makes the original framing wrong |
| Docs | `docs/components/asteria-player.md`, `docs/testnets/cardano-node-master.md` path references updated |
| Compose mount comments | `testnets/{cardano_node_master,cardano_node_adversary,asteria_game}/docker-compose.yaml` |
| Pin bump | both testnets bumped from `:126bb4e` to `:5252cad0` so the next Antithesis run picks up the renamed image |

`components/asteria-stub/` (the legacy component with the un-bounded
socat reference baseline) is left untouched — that one really is a
stub.

## Antithesis identity reset

Antithesis identifies composer commands by their path and SDK
assertions by their string ID. Both change in this PR, so the report's
history bar **resets** for these scripts/assertions:

- `stub/parallel_driver_heartbeat.sh` (archived) ↔ `asteria-game/parallel_driver_heartbeat.sh` (new)
- `stub heartbeat ticked` (archived) ↔ `asteria_game heartbeat ticked` (new)
- ... and 21 more pairs

One-time cost; the payoff is permanently readable triage output.

## Local verification

`bash -n` and `shellcheck -x` clean on all 8 files. Smoke-tested via
the renamed paths:

| check | result |
|---|---|
| 10 concurrent shells × 5 emits → `/tmp/sdk.jsonl` | exactly 50 valid JSON lines |
| `SIGTERM` mid-`sleep` to a script that installed the trap | exit 0; trap-emit recorded |
| `timeout --kill-after=2 1` body via `sdk_run_signal_safe` | exit 0; SIGKILL → 137 absorbed |

## Acceptance

After merge, the next Antithesis run on `cardano_node_master` shows
the new paths in the report (`asteria-game/parallel_driver_heartbeat.sh`,
`asteria_game heartbeat ticked`, etc.) and 0 findings.
`git grep -i stub components/asteria-game/` returns nothing.

cc [#142](https://github.com/cardano-foundation/cardano-node-antithesis/issues/142), [#143](https://github.com/cardano-foundation/cardano-node-antithesis/pull/143), [#145](https://github.com/cardano-foundation/cardano-node-antithesis/issues/145), [#146](https://github.com/cardano-foundation/cardano-node-antithesis/pull/146).