### PR TITLE
feat: add cardano-node 11.0.1 to master cluster

### DIFF
--- a/docs/components/configurator.md
+++ b/docs/components/configurator.md
@@ -6,9 +6,9 @@ Generates genesis files, node configuration, topology, and signing keys for the 
 
 1. Reads `testnet.yaml` for genesis parameters (pool count, network magic, epoch length, protocol version)
 2. Runs the [testnet-generation-tool](https://github.com/cardano-foundation/testnet-generation-tool) to produce genesis files and pool keys
-3. Generates a ring topology for producers (p1↔p2↔p3)
+3. Generates a ring topology for producers (`p1` through `pN`, where `N` is `poolCount`)
 4. Sets the system start time to the current time
-5. Writes configs to per-pool volumes (p1-configs, p2-configs, p3-configs)
+5. Writes configs to per-pool volumes (`p1-configs` through `pN-configs`)
 
 ## Image
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Docker containers that set up and drive the Antithesis test environment. Dependi
 
 Currently we provide and maintain one testnet configuration. Some old testnets are preserved in the [old-broken](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/old-broken) directory for historical reference.
 
-- `cardano_node_master/`: A mixed-version testnet with 3 block producers (10.5.3, 10.6.2, 10.7.1), 2 relay nodes (10.6.2, 10.7.1), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
+- `cardano_node_master/`: A mixed-version testnet with 4 block producers (10.5.3, 10.6.2, 10.7.1, 11.0.1), 3 relay nodes (10.6.2, 10.7.1, 11.0.1), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
 
 ## Image publishing
 

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -6,8 +6,8 @@ A mixed-version Cardano testnet for Antithesis fault-injection testing.
 
 This testnet exercises the node-to-node protocol across multiple cardano-node versions:
 
-- **3 block producers**: p1 (10.5.3), p2 (10.6.2), p3 (10.7.1) — forge blocks in a ring topology (p1↔p2↔p3)
-- **2 relay nodes**: relay1 (10.6.2), relay2 (10.7.1) — non-producing nodes connected to all producers
+- **4 block producers**: p1 (10.5.3), p2 (10.6.2), p3 (10.7.1), p4 (11.0.1) — forge blocks in a ring topology (p1↔p2↔p3↔p4)
+- **3 relay nodes**: relay1 (10.6.2), relay2 (10.7.1), relay3 (11.0.1) — non-producing nodes connected to all producers
 
 ### Supporting services
 
@@ -70,7 +70,7 @@ What this gives Antithesis to score:
   spacetime.spend, shipyard.mint) execute on every ship spawn —
   exercises ref-input handling, datum decoding, redeemer validation,
   exec-budget accounting.
-- **Multi-version interop**. Producers p1/p2/p3 run three different
+- **Multi-version interop**. Producers p1/p2/p3/p4 run four different
   cardano-node versions; the same Plutus tx must validate identically
   across versions or the cluster forks.
 - **Invariants that survive faults**. `asteria_admin_singleton`
@@ -173,10 +173,11 @@ Measured pressure in that run:
 ## Network topology
 
 ```
-p1 (10.5.3) ←→ p2 (10.6.2) ←→ p3 (10.7.1) ←→ p1
-   ↑                ↑               ↑
-relay1 (10.6.2) ----+---------------+
-relay2 (10.7.1) ----+---------------+
+p1 (10.5.3) ←→ p2 (10.6.2) ←→ p3 (10.7.1) ←→ p4 (11.0.1) ←→ p1
+   ↑                ↑               ↑               ↑
+relay1 (10.6.2) ----+---------------+---------------+
+relay2 (10.7.1) ----+---------------+---------------+
+relay3 (11.0.1) ----+---------------+---------------+
 ```
 
 Producers form a ring. Relays connect to all producers.

--- a/docs/testnets/cardano-node-tx-generator.md
+++ b/docs/testnets/cardano-node-tx-generator.md
@@ -48,10 +48,10 @@ The report-level resolved digests matched for `configurator`,
 
 ## Network topology
 
-Same 3-pool +2-relay shape as master (p1 ↔ p2 ↔ p3 ring; relay1 +
-relay2 connect to all producers). The tx-generator container connects
-to **relay1** via N2C over a single multiplexed bearer (ChainSync +
-LocalStateQuery + LocalTxSubmission).
+Same 3-pool +2-relay shape as the 2026-05-05 validation baseline
+(p1 ↔ p2 ↔ p3 ring; relay1 + relay2 connect to all producers). The
+tx-generator container connects to **relay1** via N2C over a single
+multiplexed bearer (ChainSync + LocalStateQuery + LocalTxSubmission).
 
 Network name is `cardano-node-tx-generator-testnet` (distinct from
 master's `cardano-node-testnet`) so both testnets can coexist

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       - p1-configs:/configs/1 # configs for p1
       - p2-configs:/configs/2 # configs for p2
       - p3-configs:/configs/3 # configs for p3
+      - p4-configs:/configs/4 # configs for p4
       - utxo-keys:/utxo-keys # funded address keys for tx-generator
 
   tracer:
@@ -91,6 +92,15 @@ services:
       - p3-configs:/configs:ro
       - tracer:/tracer
 
+  p4:
+    <<: *cardano-node
+    image: ghcr.io/intersectmbo/cardano-node@sha256:007da778998d0bdb043fb834c62b9da1c95e33610f31f6f9cccab29a945e2b99
+    container_name: p4
+    hostname: p4.example
+    volumes:
+      - p4-configs:/configs:ro
+      - tracer:/tracer
+
   relay1:
     <<: *cardano-relay
     image: ghcr.io/intersectmbo/cardano-node@sha256:c3cbc5aa0b758ba211567791539a67001e661fbe7a09275e37449e8b1252c4b2
@@ -111,6 +121,17 @@ services:
       - p1-configs:/configs:ro
       - ./relay-topology.json:/configs/configs/topology.json:ro
       - relay2-state:/state
+      - tracer:/tracer
+
+  relay3:
+    <<: *cardano-relay
+    image: ghcr.io/intersectmbo/cardano-node@sha256:007da778998d0bdb043fb834c62b9da1c95e33610f31f6f9cccab29a945e2b99
+    container_name: relay3
+    hostname: relay3.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay3-state:/state
       - tracer:/tracer
 
   # Tx-generator workload — promoted from cardano_node_tx_generator
@@ -154,7 +175,7 @@ services:
     environment:
       NETWORKMAGIC: 42
       PORT: 3001
-      POOLS: "3"
+      POOLS: "4"
     container_name: sidecar
     hostname: sidecar.example
     depends_on:
@@ -171,7 +192,7 @@ services:
     command:
       - "/opt/cardano-tracer/logs"
     environment:
-      POOLS: "3"
+      POOLS: "4"
       CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
     volumes:
       - tracer:/opt/cardano-tracer
@@ -234,8 +255,10 @@ volumes:
   p1-configs:
   p2-configs:
   p3-configs:
+  p4-configs:
   relay1-state:
   relay2-state:
+  relay3-state:
   utxo-keys:
   asteria-game-db:
   asteria-deploy:

--- a/testnets/cardano_node_master/relay-topology.json
+++ b/testnets/cardano_node_master/relay-topology.json
@@ -4,11 +4,12 @@
       "accessPoints": [
         {"address": "p1.example", "port": 3001},
         {"address": "p2.example", "port": 3001},
-        {"address": "p3.example", "port": 3001}
+        {"address": "p3.example", "port": 3001},
+        {"address": "p4.example", "port": 3001}
       ],
       "advertise": false,
       "trustable": true,
-      "valency": 3
+      "valency": 4
     }
   ],
   "publicRoots": [],

--- a/testnets/cardano_node_master/testnet.yaml
+++ b/testnets/cardano_node_master/testnet.yaml
@@ -1,5 +1,5 @@
 --- # Required Testnet Parameters
-poolCount: 3
+poolCount: 4
 poolCost: 340000000
 poolMargin: 0.0
 poolPledge: 0

--- a/testnets/cardano_node_tx_generator/README.md
+++ b/testnets/cardano_node_tx_generator/README.md
@@ -3,8 +3,8 @@
 Iteration testnet for the Haskell `cardano-tx-generator` daemon
 ([upstream](https://github.com/lambdasistemi/cardano-node-clients)).
 
-The daemon is exercised by the standard 3-pool +2-relay Cardano cluster
-(same compose shape as `cardano_node_master`) plus the sidecar /
+The daemon is exercised by the 3-pool +2-relay Cardano cluster used by
+the 2026-05-05 validation baseline plus the sidecar /
 tracer-sidecar / log-tailer / tracer instrumentation.
 
 ## Why a separate testnet


### PR DESCRIPTION
Closes #148

## Summary

- Add `p4` as a `cardano-node` `11.0.1` block producer pinned by immutable digest.
- Add `relay3` as a `cardano-node` `11.0.1` relay pinned by the same immutable digest.
- Increase the master testnet pool count and sidecar/tracer-sidecar pool expectations from 3 to 4.
- Update relay topology and docs for the new 4-producer / 3-relay baseline.

## Verification

- `git diff --check`
- `INTERNAL_NETWORK=true docker compose -f testnets/cardano_node_master/docker-compose.yaml config --quiet`
- `jq . testnets/cardano_node_master/relay-topology.json`
- Isolated compose smoke, with fixed `container_name` entries removed to avoid the already-running local `cardano_amaru_epoch240` stack:
  - `p1`, `p2`, `p3`, and `p4` all answered `cardano-cli ping`.
  - `p1` through `p4` converged at `9bc6fd8e979044eec5dd96bfd1a8f5acb0592aa018153533c73f26e125ec50cf@2`.
  - `relay1`, `relay2`, and `relay3` were all `running`.

## Notes

The `11.0.1` image digest was resolved from `ghcr.io/intersectmbo/cardano-node:11.0.1` as `sha256:007da778998d0bdb043fb834c62b9da1c95e33610f31f6f9cccab29a945e2b99`.