### PR TITLE
Exclude support services + asteria-game from fault injection (compose labels)

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -57,6 +57,8 @@ services:
 
     hostname: tracer.example
     container_name: tracer
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     volumes:
       - tracer:/opt/cardano-tracer
       - ./tracer-config.yaml:/tracer-config.yaml:ro
@@ -145,6 +147,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:69bf815
     container_name: tx-generator
     hostname: tx-generator.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     command:
       - --relay-socket
       - /state/node.socket
@@ -178,6 +182,8 @@ services:
       POOLS: "4"
     container_name: sidecar
     hostname: sidecar.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     depends_on:
       tracer-sidecar:
         condition: service_started
@@ -189,6 +195,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:5271661
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     command:
       - "/opt/cardano-tracer/logs"
     environment:
@@ -235,6 +243,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:5252cad0
     container_name: asteria-game
     hostname: asteria-game.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     environment:
       INDEXER_SOCK: /tmp/idx.sock
       CARDANO_NODE_SOCKET_PATH: /state/node.socket


### PR DESCRIPTION
Adds `com.antithesis.exclude_from_faults` labels to the master testnet compose so moog (compose-label fault-exclusion, PR #108) excludes the support services and the asteria-game indexer from `network,kill,pause,stop` faults, while leaving the cardano nodes (p1–p4, relay1–3) fully faultable.

## What is proven (Antithesis A/B)

| Build | Failing properties |
|---|---|
| `1854d11` (main, no labels) | 6 — incl. `No Antithesis errors`, `Unexpected terminations: state_timed_out`, `systemd-journal` |
| `8eb62045` (this branch) | 3 — `Sometimes: Root moments`, `Unique Edges`, `node - throttle` (coverage-baseline only) |

Excluding asteria-game (and the support services) drops exactly the three fault-induced failures; the remaining three are coverage artifacts. This is the empirical justification for the change.

## What is understood vs still open

- The asteria-game utxo-indexer is healthy in isolation: on a clean local compose it reaches `ready:true, slotsBehind:0` in ~13s. So the production RED is fault-injection-induced, not an indexer bug.
- Local single-fault probes did **not** reproduce the stuck `node-replaying` state: a `network disconnect` has no effect (the indexer reaches relay1 over a unix socket on a shared volume, not TCP), and a single 45s `pause` recovers cleanly in <4s. The production stall therefore likely requires *sustained* fault churn (repeated kill/pause) rather than a one-shot fault — the precise micro-mechanism is not yet pinned down.

The A/B result stands on its own; pinning the exact fault sequence is a follow-up, not a blocker.