### PR TITLE
Exclude support services + adversary from fault injection (adversary testnet)

### DIFF
--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -56,6 +56,8 @@ services:
 
     hostname: tracer.example
     container_name: tracer
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     volumes:
       - tracer:/opt/cardano-tracer
       - ./tracer-config.yaml:/tracer-config.yaml:ro
@@ -124,6 +126,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:69bf815
     container_name: tx-generator
     hostname: tx-generator.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     command:
       - --relay-socket
       - /state/node.socket
@@ -157,6 +161,8 @@ services:
       POOLS: "3"
     container_name: sidecar
     hostname: sidecar.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     depends_on:
       tracer-sidecar:
         condition: service_started
@@ -176,6 +182,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/adversary:5173fa8
     container_name: adversary
     hostname: adversary.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     volumes:
       # Read-only — tracer-sidecar writes chainPoints.log here.
       - tracer:/tracer:ro
@@ -190,6 +198,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:8dbf509
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     command:
       - "/opt/cardano-tracer/logs"
     environment:
@@ -236,6 +246,8 @@ services:
     image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:5252cad0
     container_name: asteria-game
     hostname: asteria-game.example
+    labels:
+      com.antithesis.exclude_from_faults: "network,kill,pause,stop"
     environment:
       INDEXER_SOCK: /tmp/idx.sock
       CARDANO_NODE_SOCKET_PATH: /state/node.socket


### PR DESCRIPTION
Ports PR #155's compose-label fault-exclusion to the **adversary** testnet (`testnets/cardano_node_adversary/docker-compose.yaml`). Labels `com.antithesis.exclude_from_faults: "network,kill,pause,stop"` on the support services (`tracer`, `tx-generator`, `sidecar`, `tracer-sidecar`, `asteria-game`) **and the `adversary` host itself**. The cardano nodes (`p1`, `p2`, `p3`, `relay1`, `relay2`) stay unlabeled / faultable.

## Why exclude the adversary host
The `adversary` container is a sleep-forever host the composer `docker exec`s into to fire chain-sync attacks against the nodes. If the fault injector kills/pauses it, it can't attack — so it should be a stable launchpad, not a fault target. (Same reasoning that kept asteria-game's indexer out of faults in #155.)

## Open question (experiment)
This excludes ALL fault classes from the adversary, including `network`, for parity with #155. There's a real argument to keep `network` faults **on** the adversary so attacks run under a degraded link. Left as full-exclusion for v1; a comparison run can tell us whether to re-enable `network` on the adversary.

Draft until a 1h adversary-testnet run confirms the effect.