### PR TITLE
fix(tracer-sidecar): stop logging an error while waiting for the tracer log root

### DIFF
--- a/components/tracer-sidecar/src/App.hs
+++ b/components/tracer-sidecar/src/App.hs
@@ -27,7 +27,7 @@ import Control.Concurrent
     , threadDelay
     )
 import Control.Concurrent.Async (async, link)
-import Control.Exception (SomeException, try)
+import Control.Exception (SomeException, fromException, try)
 import Control.Monad
     ( forM_
     , forever
@@ -51,6 +51,7 @@ import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
 import System.Directory
     ( listDirectory
     )
+import System.IO.Error (isDoesNotExistError)
 import System.Environment
     ( getArgs
     , getEnv
@@ -100,9 +101,17 @@ main = do
     forever $ do
         esubs <- try (listDirectory dir)
         case esubs of
-            Left (e :: SomeException) ->
-                putStrLn
-                    $ "Error listing directory " <> dir <> ": " <> show e
+            -- Until cardano-tracer creates the log root, listDirectory fails
+            -- with "does not exist". That is an expected startup race (and can
+            -- recur when fault injection recreates the volume), so wait quietly
+            -- rather than logging a misleading error each second.
+            Left (e :: SomeException)
+                | Just ioe <- fromException e
+                , isDoesNotExistError ioe ->
+                    pure ()
+                | otherwise ->
+                    putStrLn
+                        $ "Error listing directory " <> dir <> ": " <> show e
             Right subs -> do
                 seen <- readIORef seenRef
                 let current = Set.fromList $ fmap (dir </>) subs

--- a/testnets/cardano_node_adversary/docker-compose.yaml
+++ b/testnets/cardano_node_adversary/docker-compose.yaml
@@ -195,7 +195,7 @@ services:
     restart: always
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:8dbf509
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:fbcd664
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     labels:

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -192,7 +192,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:5271661
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:fbcd664
     container_name: tracer-sidecar
     hostname: tracer-sidecar.example
     labels:


### PR DESCRIPTION
## What

`tracer-sidecar` polls `listDirectory /opt/cardano-tracer/logs` every second. Until cardano-tracer creates that log root, the call throws "does not exist" and the loop logged it at `Error` once per second — misleading noise that looks like a fault (and recurs when fault injection recreates the volume).

This treats the `isDoesNotExistError` case as an expected startup wait (no log); genuine errors are still logged.

## Image pin

Bumps the `tracer-sidecar` pin in the master and adversary composes to `fbcd664` so `publish-images` rebuilds the image from this fix.

## Validation

- `nix build .#tracer-sidecar` passes locally.
- Will run a 1h Antithesis test on `cardano_node_master` once the image is published.

## Scope note

Investigation of the run failures also surfaced two non-issues handled separately:
- The `Illegal namespace` tracer warning (#157) is **not** fixed here — on the mixed-version cluster the legacy `Net.ErrorPolicy`/`Net.Subscription.*` namespaces are valid only on 10.5.3 (p1) and rejected by 10.6.2/10.7.1/11.0.1. Because the relays share p1's config dir, a clean fix needs a dedicated relay config dir; tracked as a follow-up under #157.
- `systemd-journal` SIGABRT is the Antithesis sandbox's own journald, not ours.

Closes #158