### PR TITLE
fix(testnets/master): drop 10.5.3 → 10.6.4, add relay4, remove legacy trace namespaces

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Docker containers that set up and drive the Antithesis test environment. Dependi
 
 Currently we provide and maintain one testnet configuration. Some old testnets are preserved in the [old-broken](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/old-broken) directory for historical reference.
 
-- `cardano_node_master/`: A mixed-version testnet with 4 block producers (10.6.4, 10.6.2, 10.7.1, 11.0.1), 3 relay nodes (10.6.2, 10.7.1, 11.0.1), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
+- `cardano_node_master/`: A mixed-version testnet with 4 block producers (10.6.4, 10.6.2, 10.7.1, 11.0.1), 4 relay nodes (10.6.2, 10.7.1, 11.0.1, 10.6.4), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
 
 ## Image publishing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Docker containers that set up and drive the Antithesis test environment. Dependi
 
 Currently we provide and maintain one testnet configuration. Some old testnets are preserved in the [old-broken](https://github.com/cardano-foundation/cardano-node-antithesis/tree/main/old-broken) directory for historical reference.
 
-- `cardano_node_master/`: A mixed-version testnet with 4 block producers (10.5.3, 10.6.2, 10.7.1, 11.0.1), 3 relay nodes (10.6.2, 10.7.1, 11.0.1), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
+- `cardano_node_master/`: A mixed-version testnet with 4 block producers (10.6.4, 10.6.2, 10.7.1, 11.0.1), 3 relay nodes (10.6.2, 10.7.1, 11.0.1), tracer observability, Asteria Plutus workload pressure, and tx-generator ADA-transfer pressure. See [cardano-node-master](testnets/cardano-node-master.md) for details.
 
 ## Image publishing
 

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -6,7 +6,7 @@ A mixed-version Cardano testnet for Antithesis fault-injection testing.
 
 This testnet exercises the node-to-node protocol across multiple cardano-node versions:
 
-- **4 block producers**: p1 (10.5.3), p2 (10.6.2), p3 (10.7.1), p4 (11.0.1) — forge blocks in a ring topology (p1↔p2↔p3↔p4)
+- **4 block producers**: p1 (10.6.4), p2 (10.6.2), p3 (10.7.1), p4 (11.0.1) — forge blocks in a ring topology (p1↔p2↔p3↔p4)
 - **3 relay nodes**: relay1 (10.6.2), relay2 (10.7.1), relay3 (11.0.1) — non-producing nodes connected to all producers
 
 ### Supporting services
@@ -174,7 +174,7 @@ Measured pressure in that run:
 ## Network topology
 
 ```
-p1 (10.5.3) ←→ p2 (10.6.2) ←→ p3 (10.7.1) ←→ p4 (11.0.1) ←→ p1
+p1 (10.6.4) ←→ p2 (10.6.2) ←→ p3 (10.7.1) ←→ p4 (11.0.1) ←→ p1
    ↑                ↑               ↑               ↑
 relay1 (10.6.2) ----+---------------+---------------+
 relay2 (10.7.1) ----+---------------+---------------+

--- a/docs/testnets/cardano-node-master.md
+++ b/docs/testnets/cardano-node-master.md
@@ -7,7 +7,7 @@ A mixed-version Cardano testnet for Antithesis fault-injection testing.
 This testnet exercises the node-to-node protocol across multiple cardano-node versions:
 
 - **4 block producers**: p1 (10.6.4), p2 (10.6.2), p3 (10.7.1), p4 (11.0.1) — forge blocks in a ring topology (p1↔p2↔p3↔p4)
-- **3 relay nodes**: relay1 (10.6.2), relay2 (10.7.1), relay3 (11.0.1) — non-producing nodes connected to all producers
+- **4 relay nodes**: relay1 (10.6.2), relay2 (10.7.1), relay3 (11.0.1), relay4 (10.6.4) — non-producing nodes connected to all producers
 
 ### Supporting services
 
@@ -179,6 +179,7 @@ p1 (10.6.4) ←→ p2 (10.6.2) ←→ p3 (10.7.1) ←→ p4 (11.0.1) ←→ p1
 relay1 (10.6.2) ----+---------------+---------------+
 relay2 (10.7.1) ----+---------------+---------------+
 relay3 (11.0.1) ----+---------------+---------------+
+relay4 (10.6.4) ----+---------------+---------------+
 ```
 
 Producers form a ring. Relays connect to all producers.

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -1,5 +1,7 @@
 x-cardano-node: &cardano-node
-  image: ghcr.io/intersectmbo/cardano-node@sha256:5ae211f92eac18ed27b9e2f73c190b56bf4c1a7145d282e78ca58597a385d19f
+  # p1 — bumped from 10.5.3 to 10.6.4; 10.5.x was the only version still
+  # accepting the legacy Net.ErrorPolicy/Net.Subscription.* trace namespaces.
+  image: ghcr.io/intersectmbo/cardano-node@sha256:f29c5a48475df1e1804fc7270cf1dc02a38f2d8f659f35781a73e38254fa9a5f
   environment:
     CARDANO_BLOCK_PRODUCER: true
   command: >

--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -138,6 +138,17 @@ services:
       - relay3-state:/state
       - tracer:/tracer
 
+  relay4:
+    <<: *cardano-relay
+    image: ghcr.io/intersectmbo/cardano-node@sha256:f29c5a48475df1e1804fc7270cf1dc02a38f2d8f659f35781a73e38254fa9a5f
+    container_name: relay4
+    hostname: relay4.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay4-state:/state
+      - tracer:/tracer
+
   # Tx-generator workload — promoted from cardano_node_tx_generator
   # after a 0-findings 1h Antithesis validation run on commit
   # 4687a09. The daemon connects to relay1 via N2C and the
@@ -271,6 +282,7 @@ volumes:
   relay1-state:
   relay2-state:
   relay3-state:
+  relay4-state:
   utxo-keys:
   asteria-game-db:
   asteria-deploy:

--- a/testnets/cardano_node_master/testnet.yaml
+++ b/testnets/cardano_node_master/testnet.yaml
@@ -110,10 +110,6 @@ TraceOptions:
     severity: Info
   Net.ConnectionManager.Remote.ConnectionManagerCounters:
     severity: Silence
-  Net.ErrorPolicy:
-    severity: Info
-  Net.ErrorPolicy.Local:
-    severity: Info
   Net.InboundGovernor:
     severity: Warning
   Net.InboundGovernor.Remote:
@@ -123,10 +119,6 @@ TraceOptions:
   Net.PeerSelection:
     severity: Silence
   Net.PeerSelection.Actions:
-    severity: Info
-  Net.Subscription.DNS:
-    severity: Info
-  Net.Subscription.IP:
     severity: Info
   Resources:
     severity: Silence


### PR DESCRIPTION
## What

- Bumps **p1** from **10.5.3 → 10.6.4** (the `x-cardano-node` anchor, which feeds only p1).
- Adds **relay4 on 10.6.4** so the relay set covers every producer version (mirrors the other relays: p1-configs, shared relay-topology.json, own `relay4-state`, tracer socket).
- Removes the legacy `Net.ErrorPolicy{,.Local}` and `Net.Subscription.{DNS,IP}` namespaces from `testnet.yaml`.
- Updates docs (producers, relays, topology diagram).

## Why

These four namespaces are valid only on 10.5.x. Every newer node (10.6.2 / 10.7.1 / 11.0.1) rejected them and logged `Illegal namespace` warnings every run. p1 (10.5.3) was the sole node keeping them legal — and the relays mount p1's config dir, so they inherited and rejected them too. Dropping 10.5.3 removes the only accepting node, so the global delete is now safe (no per-node tailoring needed). 11.0.1 remains the latest cardano-node release.

## No image rebuild

The configurator mounts `testnet.yaml` at runtime and regenerates node configs, so the namespace removal takes effect without rebuilding any image. p1 and relay4 use the upstream `intersectmbo/cardano-node` 10.6.4 digest. `POOLS` stays 4 (producers only).

## Note

The adversary cluster also has a 10.5.3 node (and no 11.0.1); left untouched here.

Closes #157