### PR TITLE
ci(cardano-node): pin moog requester to v0.5.1.5

### DIFF
--- a/.github/workflows/cardano-node.yaml
+++ b/.github/workflows/cardano-node.yaml
@@ -73,10 +73,17 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
-        # Latest moog release. The portable Linux requester binary is the
-        # statically-linked musl tarball (the old `*-linux64.tar.gz`
-        # asset was dropped at the 0.5.x packaging change).
-        TAG=$(gh release view -R cardano-foundation/moog --json tagName -q .tagName)
+        # Pinned moog release. The production MPFS/agent/oracle stack runs the
+        # v0.5.x line, so the requester CLI must match it. Do NOT track the
+        # "latest" release: moog v2.0.0 (the moog-v2 MPFS cutover, 2026-06-13)
+        # is incompatible with the deployed v0.5.x MPFS — its `facts test-runs`
+        # returns an error envelope instead of the array this workflow's jq
+        # expects, which silently broke every scheduled launch. Bump this tag
+        # only once the whole stack migrates to v2.
+        # The portable Linux requester binary is the statically-linked musl
+        # tarball (the old `*-linux64.tar.gz` asset was dropped at the 0.5.x
+        # packaging change).
+        TAG=v0.5.1.5
         echo "moog release: $TAG"
         gh release download "$TAG" -R cardano-foundation/moog \
           -p 'moog-*-x86_64-linux-musl.tar.gz' --clobber


### PR DESCRIPTION
## Problem

The scheduled **"Antithesis on cardano-node testnet"** workflow has failed every run since ~2026-06-14, so **no new Antithesis runs have been launched** (the agent has been stuck reconciling the same 158 runs).

Root cause: the `Install moog` step resolved the **latest** moog release with no tag:

```bash
TAG=$(gh release view -R cardano-foundation/moog --json tagName -q .tagName)
```

moog **v2.0.0** (the moog-v2 MPFS cutover) was published and marked *Latest* on **2026-06-13**, so CI silently upgraded to it. v2.0.0 is **incompatible with the deployed v0.5.x MPFS** at `mpfs.plutimus.com` — its `moog facts test-runs` calls `GET /status` (→ 404) and returns an error envelope object instead of the array of `{key,value}` facts the `Submit test` step's jq expects. The step dies with:

```
jq: error (at <stdin>:1): Cannot index string with string "key"
```

…in ~20s, before any test is submitted.

Verified by running all three binaries against the live token:

| moog | `facts test-runs` output | CI jq |
|---|---|---|
| v0.5.1.4 | array of 1036 `{key,value}` objects | ✅ |
| v0.5.1.5 | identical array | ✅ |
| v2.0.0 | `{"exception": …}` (GET /status → 404) | ❌ |

## Fix

Pin `TAG=v0.5.1.5` (last v0.5.x, matching the production agent/oracle/MPFS stack). Bump only once the whole stack migrates to v2.

## Note

Earlier failures (2026-06-11 → 06-13) were a **different, real** issue — `Submit test` succeeded and the runs executed for hours, but came back with outcome `failure` (`Wait for results` step). That is a genuine test regression to investigate separately; this PR only restores the launch path.