### PR TITLE
fix(composer): ship flock (util-linux) in asteria-game + tx-generator images

### DIFF
--- a/components/asteria-game/nix/docker-image.nix
+++ b/components/asteria-game/nix/docker-image.nix
@@ -51,6 +51,7 @@ pkgs.dockerTools.buildImage {
       pkgs.jq
       pkgs.netcat-openbsd
       pkgs.socat
+      pkgs.util-linux # provides flock, used by helper_sdk_common.sh
       utxo-indexer
       antithesis-drivers
       usrBinEnv

--- a/components/tx-generator/nix/docker-image.nix
+++ b/components/tx-generator/nix/docker-image.nix
@@ -84,6 +84,7 @@ in pkgs.dockerTools.buildImage {
       pkgs.gnugrep
       pkgs.netcat-openbsd
       pkgs.unixtools.xxd
+      pkgs.util-linux # provides flock, used by helper_sdk_common.sh
       usrBinEnv
       sleepForever
       antithesis-drivers


### PR DESCRIPTION
## Problem
`components/composer-sdk/helper_sdk_common.sh:37` serializes concurrent `sdk.jsonl` appends with `flock -x 9`, but the **asteria-game** and **tx-generator** images (the two that bake this helper) never shipped `util-linux`, which provides `flock`. Their `copyToRoot` had bash/coreutils/gnugrep/jq/netcat/socat only — and `flock` is **not** in coreutils.

Result: every SDK emit logs `flock: command not found` and writes **unlocked**, so the concurrency protection added in `df7ef80` has been silently inert. Caught in the container logs of run `1254a898…`:
```
/opt/antithesis/test/v1/asteria-game/helper_sdk.sh: line 28: flock: command not found
```

## Fix
Add `pkgs.util-linux` to `copyToRoot` in both `components/asteria-game/nix/docker-image.nix` and `components/tx-generator/nix/docker-image.nix`.

## Impact
Soft bug — assertions still land, but unlocked. This restores the intended locking. Activated like any image change: merge → bump the master compose pins to the new sha (separate step).

Found while investigating a player-driver `Always: zero exit code` finding; that finding has a *separate* root cause (player exits rc=1 on a torn upstream) tracked in its own issue.