### PR TITLE
chore(testnets/master): activate flock fix (bump pins to bf48615)

### DIFF
--- a/testnets/cardano_node_master/docker-compose.yaml
+++ b/testnets/cardano_node_master/docker-compose.yaml
@@ -146,7 +146,7 @@ services:
   # wrapper that cleared the earlier "zero exit code" findings is
   # retained.
   tx-generator:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:d864ccf
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tx-generator:bf48615
     container_name: tx-generator
     hostname: tx-generator.example
     labels:
@@ -245,7 +245,7 @@ services:
   # per-deploy seed TxIn so player + invariant binaries see the
   # same applied validators.
   asteria-game:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:d864ccf
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/asteria-game:bf48615
     container_name: asteria-game
     hostname: asteria-game.example
     labels:


### PR DESCRIPTION
Activates #173. Bumps `cardano_node_master`'s `asteria-game` + `tx-generator` pins from `d864ccf` → **bf48615** (origin/main HEAD), so the running testnet uses images that ship `flock` (util-linux) and the `sdk.jsonl` locking in `helper_sdk_common.sh` works instead of logging `flock: command not found`.

`publish-images` will build/push the bf48615 images (nix cache-hits the binaries; the util-linux addition changes the final image layer).