### PR TITLE
feat(testnets): cardano_amaru regular testnet on amaru main HEAD

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -51,7 +51,7 @@ jobs:
     name: Compose smoke test
     runs-on: ubuntu-latest
     needs: publish-images
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
@@ -59,3 +59,7 @@ jobs:
           ref: ${{ github.event.inputs.ref_name || '' }}
       - name: Run smoke test
         run: ./scripts/smoke-test.sh cardano_node_master 600
+      - name: Run smoke test (cardano_amaru)
+        env:
+          AMARU_BOOTSTRAP_SMOKE_TIMEOUT: "900"
+        run: ./scripts/smoke-test.sh cardano_amaru 700

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -17,8 +17,12 @@ jobs:
   smoke-test:
     name: Smoke test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
       - name: Run smoke test
         run: ./scripts/smoke-test.sh cardano_node_master 600
+      - name: Run smoke test (cardano_amaru)
+        env:
+          AMARU_BOOTSTRAP_SMOKE_TIMEOUT: "900"
+        run: ./scripts/smoke-test.sh cardano_amaru 700

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -68,6 +68,51 @@ done
 # Always assertion enforces the cluster-wide unrecoverable-divergence
 # bound at runtime.
 
+# cardano_amaru: prove the amaru bootstrap pipeline. bootstrap-producer
+# builds the bundle (create-snapshots + bootstrap) and exits 0; the two
+# relay-only amaru nodes then consume it, exec `amaru run`, and stay up.
+if [[ "$TESTNET" == cardano_amaru* ]]; then
+  BOOTSTRAP_TIMEOUT="${AMARU_BOOTSTRAP_SMOKE_TIMEOUT:-1500}"
+  echo "Waiting for bootstrap-producer to build the bundle (timeout ${BOOTSTRAP_TIMEOUT}s)..."
+  BP_DEADLINE=$((SECONDS + BOOTSTRAP_TIMEOUT))
+  while true; do
+    BP_STATE="$(docker inspect -f '{{.State.Status}}' bootstrap-producer 2>/dev/null || true)"
+    BP_EXIT="$(docker inspect -f '{{.State.ExitCode}}' bootstrap-producer 2>/dev/null || echo -1)"
+    if [ "$BP_STATE" = "exited" ] && [ "$BP_EXIT" = "0" ]; then
+      echo "OK: bootstrap-producer built the bundle (exit 0)"; break
+    fi
+    if [ "$BP_STATE" = "exited" ] && [ "$BP_EXIT" != "0" ]; then
+      echo "FAIL: bootstrap-producer exited ${BP_EXIT}"
+      docker compose -f "$COMPOSE_FILE" logs --tail 60 bootstrap-producer 2>&1; exit 1
+    fi
+    if [ "$SECONDS" -ge "$BP_DEADLINE" ]; then
+      echo "FAIL: bootstrap-producer did not finish within ${BOOTSTRAP_TIMEOUT}s (state=${BP_STATE})"
+      docker compose -f "$COMPOSE_FILE" logs --tail 60 bootstrap-producer 2>&1; exit 1
+    fi
+    sleep 10
+  done
+  for RELAY in amaru-relay-1 amaru-relay-2; do
+    echo "Waiting for ${RELAY} to consume the bundle and run amaru..."
+    R_DEADLINE=$((SECONDS + 180))
+    while [ "$(docker inspect -f '{{.State.Status}}' "$RELAY" 2>/dev/null || true)" != "running" ]; do
+      if [ "$SECONDS" -ge "$R_DEADLINE" ]; then
+        echo "FAIL: ${RELAY} not running after bootstrap"
+        docker compose -f "$COMPOSE_FILE" logs --tail 60 "$RELAY" 2>&1; exit 1
+      fi
+      sleep 5
+    done
+    RB="$(docker inspect -f '{{.RestartCount}}' "$RELAY")"; sleep 20
+    RA="$(docker inspect -f '{{.RestartCount}}' "$RELAY" 2>/dev/null || echo x)"
+    if [ "$(docker inspect -f '{{.State.Status}}' "$RELAY" 2>/dev/null)" != "running" ] || [ "$RB" != "$RA" ]; then
+      echo "FAIL: ${RELAY} did not stay running (restarts ${RB}->${RA})"
+      docker compose -f "$COMPOSE_FILE" logs --tail 60 "$RELAY" 2>&1; exit 1
+    fi
+    echo "OK: ${RELAY} consumed bundle and stayed running"
+  done
+  echo "PASS: cardano_amaru bootstrap + relays"
+  exit 0
+fi
+
 # Adversary probe: if the testnet has the adversary container, exec
 # its driver once to prove the binary runs, the chainpoints file is
 # reachable, and exit code is zero. Antithesis composer dispatches

--- a/testnets/cardano_amaru/README.md
+++ b/testnets/cardano_amaru/README.md
@@ -1,0 +1,175 @@
+# Cardano Amaru Testnet
+
+This testnet extends the `cardano_node_master` shape with an Amaru
+bootstrap path:
+
+- three `cardano-node` block producers pinned to the official
+  `10.7.1-amd64` image digest;
+- two relays, also pinned to the same node release;
+- the published `amaru-bootstrap-producer` image from
+  `lambdasistemi/amaru-bootstrap`;
+- two relay-only Amaru nodes whose entrypoints wait until the producer
+  has committed a complete `testnet_42` bootstrap bundle.
+
+Amaru is not assigned stake in this testnet. The only stake-bearing block
+producers are the three cardano-node services `p1`, `p2`, and `p3`.
+`amaru-relay-1` and `amaru-relay-2` receive no KES key, VRF key, cold
+key, operational certificate, or stake-pool genesis assignment.
+
+This testnet uses a fast bootstrap profile:
+
+```yaml
+protocolConsts:
+  k: 10
+epochLength: 120
+securityParam: 10
+activeSlotsCoeff: 0.2
+TestConwayHardForkAtEpoch: 0
+```
+
+The producer requires two complete Conway epochs behind the immutable
+tip. These values make that proof bounded for local and CI runs without
+changing the cardano-node release target or giving Amaru producer
+credentials. Dense block production is part of the profile because the
+producer reads immutable chunks only; sparse block production can leave
+the immutable tip at genesis for too long.
+
+The Amaru relay containers are intentionally quiet for Antithesis log
+ingestion: compose sets `AMARU_LOG=warn`, `AMARU_TRACE=warn`, and
+`AMARU_COLOR=never`, and the wrapper loops do not print polling
+heartbeats. The bootstrap producer stores per-attempt logs under
+`/srv/amaru/.logs` in the bundle volume and prints only the final commit
+line or a bounded tail for a non-retryable failure.
+
+The producer image is pinned by full source commit SHA:
+
+```text
+ghcr.io/lambdasistemi/amaru-bootstrap-producer:pr-32-ad64e76778b0408ec66f353c7e58c8a1e7d4045f
+```
+
+The cardano-node release image is pinned in Compose by digest only:
+
+```text
+ghcr.io/intersectmbo/cardano-node@sha256:3275d357053d21f3220f74b0854fd584e1fe322dfa1bbb78effd760c3191d14c
+```
+
+That digest is the manifest digest for the upstream
+`ghcr.io/intersectmbo/cardano-node:10.7.1-amd64` tag. Compose must not
+use the Docker-valid `repo:tag@sha256:digest` spelling here because the
+Antithesis image parameter validator accepts image names by tag or by
+digest, but rejects the combined tag-plus-digest form before the cluster
+is built.
+
+The generic observability and assertion services remain enabled:
+`tracer`, `tracer-sidecar`, `log-tailer`, and `sidecar`. The
+transaction perturbator workload is deliberately absent; this testnet has
+no `tx-generator` service.
+
+## Runtime Flow
+
+```text
+configurator -> p1/p2/p3/relay1/relay2
+                  |
+                  v
+             p1 ChainDB
+                  |
+                  v
+      bootstrap-producer refresh loop
+                  |
+                  v
+          bootstrap ChainDB copy
+                  |
+                  v
+           amaru-bundle volume
+             |             |
+             v             v
+      amaru-relay-1   amaru-relay-2
+```
+
+`bootstrap-producer` owns the snapshot-refresh loop. It mounts `p1`'s
+live ChainDB read-only at `/live`, copies it into the isolated
+`bootstrap-state` volume, then mounts that copy read-write at
+`/cardano/state` for the upstream producer command. This preserves the
+cardano-node 10.7.1 consensus API requirement that immutable chunk
+validation has write permissions, while avoiding writes to the live `p1`
+ChainDB during Antithesis fault scheduling. Retryable readiness and copy
+failures use a short per-attempt deadline and refresh the snapshot inside
+the same container instead of exiting non-zero. Expected `cp` races
+against the live ledger directory are kept in the Amaru bundle logs, not
+container stdout.
+
+Each relay-only Amaru entrypoint copies the final bundle into its private
+state volume before it execs `amaru run`, so the two Amaru nodes do not
+share writable chain or ledger stores. The relays peer directly with
+cardano-node producers (`amaru-relay-1` to `p1`, `amaru-relay-2` to
+`p2`) rather than with each other, because this test is only proving
+bootstrap loading and should not require Amaru to serve blocks as a
+responder.
+
+Each relay also writes a startup marker into the shared `amaru-startup`
+volume immediately before the `amaru run` exec. The sidecar mounts that
+volume, and its image contains the Amaru startup proof scripts in the
+existing `convergence` Test Composer template so Antithesis can score
+`parallel_driver_amaru_started.sh` and `finally_amaru_started.sh` as
+explicit properties instead of asking readers to infer startup from
+container background-monitor logs. In this profile the sidecar also
+waits for those markers before emitting Antithesis setup-complete, so
+fault injection starts only after Amaru has consumed the bootstrap bundle
+at least once.
+
+## Local Commands
+
+Validate the Compose model:
+
+```bash
+INTERNAL_NETWORK=false docker compose -f testnets/cardano_amaru/docker-compose.yaml config
+```
+
+Run the standard node smoke test:
+
+```bash
+./scripts/smoke-test.sh cardano_amaru 600
+```
+
+The standard smoke test proves the cardano-node network and sidecar
+convergence checks still start. Because this profile has no
+`tx-generator`, the generic tx-generator smoke gate is skipped. For
+`cardano_amaru`, the smoke waits for `bootstrap-producer` to complete,
+checks that both relay-only Amaru nodes copied the bundle into private
+state and stayed running after `amaru run` opened the stores, and then
+executes the same Amaru startup property that Antithesis discovers under
+`/opt/antithesis/test/v1/convergence/`.
+
+For the bootstrap-specific proof, inspect:
+
+```bash
+docker compose -f testnets/cardano_amaru/docker-compose.yaml logs -f bootstrap-producer
+docker compose -f testnets/cardano_amaru/docker-compose.yaml ps bootstrap-producer amaru-relay-1 amaru-relay-2
+```
+
+Expected completion sequence:
+
+1. `bootstrap-producer` prints `wrote /srv/amaru/testnet_42` and exits
+   `0`.
+2. `amaru-relay-1` and `amaru-relay-2` copy the bundle into their private state
+   volumes.
+3. `amaru-relay-1` and `amaru-relay-2` start with `amaru run` and stay
+   running without a restart during the smoke gate.
+4. The sidecar setup signal is delayed until both relay startup markers
+   exist.
+5. `parallel_driver_amaru_started.sh` emits `amaru_relays_started` when
+   it samples both relay startup markers; `finally_amaru_started.sh`
+   fails the run if those markers are still missing at the final check.
+   Both commands run from the `convergence` template so Antithesis does
+   not mix separate test directories in one sidecar.
+6. The sidecar uses a larger post-fault convergence budget in this
+   profile (`30s` settle, `15` attempts, `3s` delay) so a final check is
+   not scored while producer tips are still catching up after faults
+   stop.
+
+## Compatibility Constraint
+
+This stack intentionally targets cardano-node 10.7.1. The Amaru
+bootstrap CBOR projection is release-sensitive, so a green compile
+against a different ledger dependency set is not evidence that the
+runtime bytes are compatible with this cluster.

--- a/testnets/cardano_amaru/amaru-runtime/era-history.json
+++ b/testnets/cardano_amaru/amaru-runtime/era-history.json
@@ -1,0 +1,18 @@
+{
+  "stability_window": 75,
+  "eras": [
+    {
+      "start": {
+        "time": 0,
+        "slot": 0,
+        "epoch": 0
+      },
+      "end": null,
+      "params": {
+        "epoch_size_slots": 125,
+        "slot_length": 1000,
+        "era_name": "Conway"
+      }
+    }
+  ]
+}

--- a/testnets/cardano_amaru/amaru-runtime/global-parameters.json
+++ b/testnets/cardano_amaru/amaru-runtime/global-parameters.json
@@ -1,0 +1,12 @@
+{
+  "consensus_security_param": 5,
+  "epoch_length_scale_factor": 5,
+  "active_slot_coeff_inverse": 5,
+  "max_lovelace_supply": 45000000000000000,
+  "slots_per_kes_period": 129600,
+  "max_kes_evolution": 62,
+  "epoch_length": 125,
+  "stability_window": 75,
+  "randomness_stabilization_window": 100,
+  "system_start": 0
+}

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -1,0 +1,406 @@
+x-cardano-node-10-7-1: &cardano-node-10-7-1
+  image: ghcr.io/intersectmbo/cardano-node@sha256:3275d357053d21f3220f74b0854fd584e1fe322dfa1bbb78effd760c3191d14c
+  environment:
+    CARDANO_BLOCK_PRODUCER: true
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --shelley-operational-certificate /configs/keys/opcert.cert
+      --shelley-kes-key /configs/keys/kes.skey
+      --shelley-vrf-key /configs/keys/vrf.skey
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    tracer-sidecar:
+      condition: service_started
+
+x-cardano-relay-10-7-1: &cardano-relay-10-7-1
+  image: ghcr.io/intersectmbo/cardano-node@sha256:3275d357053d21f3220f74b0854fd584e1fe322dfa1bbb78effd760c3191d14c
+  environment:
+    CARDANO_BLOCK_PRODUCER: false
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart: always
+  depends_on:
+    configurator:
+      condition: service_completed_successfully
+    tracer-sidecar:
+      condition: service_started
+
+x-amaru: &amaru
+  # Amaru is relay-only in this testnet. It receives no stake pool keys,
+  # no KES/VRF/opcert material, and no block-producing command.
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:03d2727b71e8d1fe7c793d5036dce3c3ce294f6c
+  entrypoint:
+    - /bin/sh
+  environment:
+    # Antithesis log ingestion is intentionally narrow: keep Amaru below
+    # warning/error quiet by default. Upstream Amaru uses AMARU_LOG rather
+    # than RUST_LOG for its tracing EnvFilter.
+    AMARU_LOG: warn
+    AMARU_TRACE: warn
+    AMARU_COLOR: never
+  restart: always
+  depends_on:
+    bootstrap-producer:
+      condition: service_started
+
+# Fault-exclusion (moog#107 compose labels): the system-under-test is
+# amaru-relay-1/2, so Antithesis faults target only those. Everything else — the
+# cardano-node chain cluster, the single-shot bootstrap-producer, and the
+# observability sidecars — must stay up or amaru never bootstraps (a fault that
+# kills the producer mid-bootstrap leaves the relay gate forever unmet). Emitting
+# any exclusion label replaces the notebook's historical default, so the
+# tracer/sidecar set is listed here too.
+x-fault-exclude: &fault-exclude
+  com.antithesis.exclude_from_faults: "network,kill,pause,stop"
+
+services:
+  configurator:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/configurator:0f9570b
+    container_name: configurator
+    labels: *fault-exclude
+    volumes:
+      - ./testnet.yaml:/testnet.yaml
+      - p1-configs:/configs/1
+      - p2-configs:/configs/2
+      - p3-configs:/configs/3
+
+  tracer:
+    image: ghcr.io/intersectmbo/cardano-tracer@sha256:da628263a851b419c38d020d3a7dc3b65b20ee84e730faeb74babd6d96f28efe
+    hostname: tracer.example
+    container_name: tracer
+    labels: *fault-exclude
+    volumes:
+      - tracer:/opt/cardano-tracer
+      - ./tracer-config.yaml:/tracer-config.yaml:ro
+    entrypoint: cardano-tracer
+    command:
+      - "--config"
+      - "/tracer-config.yaml"
+    restart: always
+
+  p1:
+    <<: *cardano-node-10-7-1
+    container_name: p1
+    labels: *fault-exclude
+    hostname: p1.example
+    volumes:
+      - p1-configs:/configs:ro
+      - p1-state:/state
+      - tracer:/tracer
+
+  p2:
+    <<: *cardano-node-10-7-1
+    container_name: p2
+    labels: *fault-exclude
+    hostname: p2.example
+    volumes:
+      - p2-configs:/configs:ro
+      - p2-state:/state
+      - tracer:/tracer
+
+  p3:
+    <<: *cardano-node-10-7-1
+    container_name: p3
+    labels: *fault-exclude
+    hostname: p3.example
+    volumes:
+      - p3-configs:/configs:ro
+      - p3-state:/state
+      - tracer:/tracer
+
+  relay1:
+    <<: *cardano-relay-10-7-1
+    container_name: relay1
+    labels: *fault-exclude
+    hostname: relay1.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay1-state:/state
+      - tracer:/tracer
+
+  relay2:
+    <<: *cardano-relay-10-7-1
+    container_name: relay2
+    labels: *fault-exclude
+    hostname: relay2.example
+    volumes:
+      - p1-configs:/configs:ro
+      - ./relay-topology.json:/configs/configs/topology.json:ro
+      - relay2-state:/state
+      - tracer:/tracer
+
+  bootstrap-producer:
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:03d2727b71e8d1fe7c793d5036dce3c3ce294f6c
+    container_name: bootstrap-producer
+    labels: *fault-exclude
+    hostname: bootstrap-producer.example
+    entrypoint:
+      - /bin/sh
+      - -ec
+    command:
+      - |
+        retry="$${AMARU_BOOTSTRAP_RETRY_SECONDS:-20}"
+        final="/srv/amaru/testnet_42"
+        attempt_log="/srv/amaru/.logs/bootstrap-producer-attempt.log"
+
+        bundle_complete() {
+          test -d "$${final}/ledger.testnet_42.db/live" \
+            && test -d "$${final}/chain.testnet_42.db"
+        }
+
+        refresh_snapshot() {
+          test -d /live/immutable || return 1
+          test -d /live/ledger || return 1
+          test -d /live/volatile || return 1
+          test -f /live/protocolMagicId || return 1
+          test -e /live/lock || return 1
+
+          mkdir -p /srv/amaru/.logs
+          rm -rf /cardano/state/.copy-tmp /cardano/state/*
+          mkdir -p /cardano/state/.copy-tmp
+          if cp -a /live/immutable /live/ledger /live/volatile /live/protocolMagicId /live/lock /cardano/state/.copy-tmp/ 2>/srv/amaru/.logs/snapshot-copy.err; then
+            rm -rf /cardano/state/immutable /cardano/state/ledger /cardano/state/volatile /cardano/state/protocolMagicId /cardano/state/lock
+            mv /cardano/state/.copy-tmp/immutable /cardano/state/
+            mv /cardano/state/.copy-tmp/ledger /cardano/state/
+            mv /cardano/state/.copy-tmp/volatile /cardano/state/
+            mv /cardano/state/.copy-tmp/protocolMagicId /cardano/state/
+            mv /cardano/state/.copy-tmp/lock /cardano/state/
+            rmdir /cardano/state/.copy-tmp
+            rm -f /srv/amaru/.logs/snapshot-copy.err
+            return 0
+          fi
+          rm -rf /cardano/state/.copy-tmp
+          return 1
+        }
+
+        while :; do
+          if bundle_complete; then
+            exit 0
+          fi
+
+          if refresh_snapshot; then
+            mkdir -p /srv/amaru/.logs
+            rc=0
+            /bin/bootstrap-producer /cardano/state /cardano/config/configs /srv/amaru testnet_42 >"$${attempt_log}" 2>&1 || rc=$$?
+            case "$${rc}" in
+              0)
+                if ! awk '/^wrote / { print; found=1 } END { exit found ? 0 : 1 }' "$${attempt_log}"; then
+                  echo "bootstrap-producer: committed $${final}"
+                fi
+                exit 0
+                ;;
+              1|2|5|7)
+                # Transient under Antithesis faults or a snapshot copied before
+                # enough immutable history was available. Refresh p1 state and
+                # try again inside this container so Antithesis does not record
+                # an expected readiness miss as a container failure.
+                ;;
+              *)
+                tail -n 50 "$${attempt_log}" >&2 || true
+                exit "$${rc}"
+                ;;
+            esac
+          fi
+
+          sleep "$${retry}"
+        done
+    environment:
+      AMARU_NETWORK: testnet_42
+      AMARU_CLUSTER_READY_DEADLINE_SECONDS: "30"
+      AMARU_WAIT_DEADLINE_SECONDS: "30"
+      AMARU_POLL_INTERVAL_SECONDS: "5"
+      AMARU_BOOTSTRAP_RETRY_SECONDS: "5"
+    volumes:
+      - p1-state:/live:ro
+      - bootstrap-state:/cardano/state
+      - p1-configs:/cardano/config:ro
+      - amaru-bundle:/srv/amaru
+    depends_on:
+      p1:
+        condition: service_started
+    # Single-shot, but retry on non-zero exit so an Antithesis fault that kills
+    # the producer mid-bootstrap doesn't permanently block the relay's
+    # service_completed_successfully gate. Exits 0 once the bundle is built.
+    restart: on-failure
+
+  amaru-relay-1:
+    <<: *amaru
+    container_name: amaru-relay-1
+    hostname: amaru-relay-1.example
+    depends_on:
+      bootstrap-producer:
+        condition: service_completed_successfully
+      relay1:
+        condition: service_started
+    command:
+      - -c
+      - |
+        set -eu
+        if [ ! -d /srv/amaru/ledger.testnet_42.db ] || [ ! -d /srv/amaru/chain.testnet_42.db ]; then
+          until [ -d /bundle/testnet_42/ledger.testnet_42.db ] \
+             && [ -d /bundle/testnet_42/chain.testnet_42.db ]; do
+            sleep 10
+          done
+          find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          cp -rL /bundle/testnet_42/. /srv/amaru/
+        fi
+        mkdir -p /startup
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > /startup/amaru-relay-1.started
+        export AMARU_GLOBAL_CONSENSUS_SECURITY_PARAM=5
+        export AMARU_GLOBAL_ACTIVE_SLOT_COEFF_INVERSE=5
+        export AMARU_GLOBAL_EPOCH_LENGTH_SCALE_FACTOR=5
+        export AMARU_GLOBAL_MAX_LOVELACE_SUPPLY=45000000000000000
+        export AMARU_GLOBAL_SLOTS_PER_KES_PERIOD=129600
+        export AMARU_GLOBAL_MAX_KES_EVOLUTION=62
+        export AMARU_GLOBAL_SYSTEM_START=0
+        exec /bin/amaru run \
+          --network testnet_42 \
+          --ledger-dir /srv/amaru/ledger.testnet_42.db \
+          --chain-dir /srv/amaru/chain.testnet_42.db \
+          --era-history /amaru-runtime/era-history.json \
+          --listen-address 0.0.0.0:3001 \
+          --peer-address relay1.example:3001
+    volumes:
+      - amaru-bundle:/bundle:ro
+      - ./amaru-runtime:/amaru-runtime:ro
+      - amaru-startup:/startup
+      - a1-state:/srv/amaru
+
+  amaru-relay-2:
+    <<: *amaru
+    container_name: amaru-relay-2
+    hostname: amaru-relay-2.example
+    depends_on:
+      bootstrap-producer:
+        condition: service_completed_successfully
+      relay2:
+        condition: service_started
+    command:
+      - -c
+      - |
+        set -eu
+        if [ ! -d /srv/amaru/ledger.testnet_42.db ] || [ ! -d /srv/amaru/chain.testnet_42.db ]; then
+          until [ -d /bundle/testnet_42/ledger.testnet_42.db ] \
+             && [ -d /bundle/testnet_42/chain.testnet_42.db ]; do
+            sleep 10
+          done
+          find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+          cp -rL /bundle/testnet_42/. /srv/amaru/
+        fi
+        mkdir -p /startup
+        printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > /startup/amaru-relay-2.started
+        export AMARU_GLOBAL_CONSENSUS_SECURITY_PARAM=5
+        export AMARU_GLOBAL_ACTIVE_SLOT_COEFF_INVERSE=5
+        export AMARU_GLOBAL_EPOCH_LENGTH_SCALE_FACTOR=5
+        export AMARU_GLOBAL_MAX_LOVELACE_SUPPLY=45000000000000000
+        export AMARU_GLOBAL_SLOTS_PER_KES_PERIOD=129600
+        export AMARU_GLOBAL_MAX_KES_EVOLUTION=62
+        export AMARU_GLOBAL_SYSTEM_START=0
+        exec /bin/amaru run \
+          --network testnet_42 \
+          --ledger-dir /srv/amaru/ledger.testnet_42.db \
+          --chain-dir /srv/amaru/chain.testnet_42.db \
+          --era-history /amaru-runtime/era-history.json \
+          --listen-address 0.0.0.0:3001 \
+          --peer-address relay2.example:3001
+    volumes:
+      - amaru-bundle:/bundle:ro
+      - ./amaru-runtime:/amaru-runtime:ro
+      - amaru-startup:/startup
+      - a2-state:/srv/amaru
+
+  sidecar:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:784c74c
+    environment:
+      NETWORKMAGIC: 42
+      PORT: 3001
+      LIMIT: 100
+      POOLS: "3"
+      NCONNS: 1
+      SLEEP_SETTLE: "30"
+      MAX_ATTEMPTS: "15"
+      RETRY_DELAY: "3"
+      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+      AMARU_STARTUP_REQUIRED: "true"
+      AMARU_STARTUP_DIR: "/amaru-startup"
+      AMARU_RELAYS: "amaru-relay-1 amaru-relay-2"
+    container_name: sidecar
+    labels: *fault-exclude
+    hostname: sidecar.example
+    volumes:
+      - tracer:/opt/cardano-tracer
+      - amaru-startup:/amaru-startup:ro
+    depends_on:
+      tracer-sidecar:
+        condition: service_started
+    restart: always
+    tmpfs:
+      - /tmp
+
+  tracer-sidecar:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
+    container_name: tracer-sidecar
+    labels: *fault-exclude
+    hostname: tracer-sidecar.example
+    command:
+      - "/opt/cardano-tracer/logs"
+    environment:
+      POOLS: "3"
+      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+    volumes:
+      - tracer:/opt/cardano-tracer
+    restart: always
+    depends_on:
+      tracer:
+        condition: service_started
+
+  log-tailer:
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/log-tailer@sha256:a5d23c42408a1003bb14208fd97dd2bdda102e7002e4e2a2804e71a80df56484
+    container_name: log-tailer
+    labels: *fault-exclude
+    hostname: log-tailer.example
+    volumes:
+      - tracer:/tracer:ro
+    restart: always
+    depends_on:
+      tracer:
+        condition: service_started
+
+volumes:
+  tracer:
+  p1-configs:
+  p2-configs:
+  p3-configs:
+  p1-state:
+  p2-state:
+  p3-state:
+  bootstrap-state:
+  relay1-state:
+  relay2-state:
+  amaru-bundle:
+  amaru-startup:
+  a1-state:
+  a2-state:
+
+networks:
+  default:
+    name: cardano-amaru-testnet
+    driver: bridge
+    internal: ${INTERNAL_NETWORK}

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -326,27 +326,19 @@ services:
       - amaru-startup:/startup
       - a2-state:/srv/amaru
 
+  # Convergence is the tracer-sidecar fork-tree probe ('cluster fork depth < k'),
+  # aligned to cardano_node_master. The old composer tip-equality probes (and
+  # the AMARU_RELAYS / amaru-startup wiring) were brittle and removed upstream
+  # (cna#119); amaru-follows-chain is tracked separately (cna#168).
   sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:784c74c
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/sidecar:1ff6913
     environment:
       NETWORKMAGIC: 42
       PORT: 3001
-      LIMIT: 100
       POOLS: "3"
-      NCONNS: 1
-      SLEEP_SETTLE: "30"
-      MAX_ATTEMPTS: "15"
-      RETRY_DELAY: "3"
-      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
-      AMARU_STARTUP_REQUIRED: "true"
-      AMARU_STARTUP_DIR: "/amaru-startup"
-      AMARU_RELAYS: "amaru-relay-1 amaru-relay-2"
     container_name: sidecar
     labels: *fault-exclude
     hostname: sidecar.example
-    volumes:
-      - tracer:/opt/cardano-tracer
-      - amaru-startup:/amaru-startup:ro
     depends_on:
       tracer-sidecar:
         condition: service_started
@@ -355,7 +347,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar@sha256:8474b148f447dc202ffb19511b136ef4bcb84be1e3aa668c2a96f01ce0b5c689
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:5271661
     container_name: tracer-sidecar
     labels: *fault-exclude
     hostname: tracer-sidecar.example

--- a/testnets/cardano_amaru/relay-topology.json
+++ b/testnets/cardano_amaru/relay-topology.json
@@ -1,0 +1,16 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p1.example", "port": 3001},
+        {"address": "p2.example", "port": 3001},
+        {"address": "p3.example", "port": 3001}
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 3
+    }
+  ],
+  "publicRoots": [],
+  "useLedgerAfterSlot": 0
+}

--- a/testnets/cardano_amaru/testnet.yaml
+++ b/testnets/cardano_amaru/testnet.yaml
@@ -1,0 +1,151 @@
+--- # Required Testnet Parameters
+poolCount: 3
+poolCost: 340000000
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 600000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: example
+
+--- # Optional Byron Genesis Overide
+protocolConsts:
+  k: 5
+
+--- # Optional Shelley Genesis Overide
+# Fast-bootstrap profile for the Amaru relay proof. The producer waits until
+# two complete Conway epochs are behind the immutable tip before it can build
+# the bundle, so this profile must keep that wait short. Two coupled constraints:
+#  1. Rewards: epochLength MUST exceed the stability and randomness windows
+#     (3k/f and 4k/f); else the stake snapshot never stabilizes in-epoch and the
+#     relay dies with RewardsSummaryNotReady at the first boundary.
+#  2. Bootstrap: "2 epochs behind the immutable tip" must complete within the
+#     Antithesis setup-time budget (~vtime 414). epochLength=256 needed ~slot 900
+#     (~15 min) and timed out before Amaru ever started (every run incomplete).
+# k=5, f=0.2 => windows 75 and 100, both < epochLength=125, AND the bootstrap
+# reaches 2-epochs-behind-immutable by ~slot 320 (~5 min). Keep scoped to
+# cardano_amaru; do not copy back to cardano_node_master.
+#  3. Amaru model: epoch_length MUST equal k*(1/f)*scale_factor (integer
+#     scale_factor) — pragma-org/amaru #963 removed the direct epoch_length
+#     override. k=5,1/f=5 => epoch_length is a multiple of 25; 125 is the
+#     smallest that also clears the 100-slot randomness window (scale_factor=5).
+epochLength: 125
+securityParam: 5
+activeSlotsCoeff: 0.2
+maxLovelaceSupply: 45000000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Optional Alonzo Genesis Overide
+
+--- # Optional Conway Genesis Overide
+
+--- # Optional Node Config Overide
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+LastKnownBlockVersion-Alt: 0
+LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Minor: 0
+MaxConcurrencyBulkSync: 2
+MaxConcurrencyDeadline: 4
+MaxKnownMajorProtocolVersion: 2
+PeerSharing: true
+TargetNumberOfActiveBigLedgerPeers: 2
+TargetNumberOfActivePeers: 3
+TargetNumberOfEstablishedBigLedgerPeers: 3
+TargetNumberOfEstablishedPeers: 3
+TargetNumberOfKnownBigLedgerPeers: 10
+TargetNumberOfKnownPeers: 30
+TargetNumberOfRootPeers: 10
+TestAllegraHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestShelleyHardForkAtEpoch: 0
+TraceConnectionManager: true
+TraceConnectionManagerTransitions: true
+TraceDNSResolver: true
+TraceDNSSubscription: true
+TraceDebugPeerSelection: true
+TraceForge: true
+TraceForgeStateInfo: true
+TraceHandshake: true
+TraceInboundGovernor: true
+TraceIpSubscription: true
+TraceLedgerPeers: true
+TraceLocalConnectionManager: true
+TraceLocalHandshake: true
+TraceLocalRootPeers: true
+TracePeerSelection: true
+TracePeerSelectionActions: true
+TracePublicRootPeers: true
+TraceServer: true
+TurnOnLoggingMetrics: true
+TurnOnLogging: true
+UseTraceDispatcher: true
+TraceOptionForwarder:
+  connQueueSize: 64
+  disconnQueueSize: 128
+  maxReconnectDeplay: 30
+TraceOptions:
+  '':
+    backends:
+    - EKGBackend
+    - Forwarder
+    detail: DNormal
+    severity: Notice
+  BlockFetch.Client.CompletedBlockFetch:
+    maxFrequency: 2
+  BlockFetch.Decision:
+    severity: Silence
+  ChainDB:
+    severity: Info
+  ChainDB.AddBlockEvent.AddBlockValidation:
+    severity: Silence
+  ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToQueue:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToVolatileDB:
+    maxFrequency: 2
+  ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB:
+    maxFrequency: 2
+  ChainSync.Client:
+    severity: Warning
+  Forge.Loop:
+    severity: Info
+  Forge.StateInfo:
+    severity: Info
+  Mempool:
+    severity: Silence
+  Net.ConnectionManager.Remote:
+    severity: Info
+  Net.ConnectionManager.Remote.ConnectionManagerCounters:
+    severity: Silence
+  Net.ErrorPolicy:
+    severity: Info
+  Net.ErrorPolicy.Local:
+    severity: Info
+  Net.InboundGovernor:
+    severity: Warning
+  Net.InboundGovernor.Remote:
+    severity: Info
+  Net.Mux.Remote:
+    severity: Info
+  Net.PeerSelection:
+    severity: Silence
+  Net.PeerSelection.Actions:
+    severity: Info
+  Net.Subscription.DNS:
+    severity: Info
+  Net.Subscription.IP:
+    severity: Info
+  Resources:
+    severity: Silence
+  Startup.DiffusionInit:
+    severity: Info

--- a/testnets/cardano_amaru/tracer-config.yaml
+++ b/testnets/cardano_amaru/tracer-config.yaml
@@ -1,0 +1,12 @@
+networkMagic: 42
+network:
+  tag: AcceptAt
+  contents: "/opt/cardano-tracer/tracer.socket"
+logging:
+- logRoot: "/opt/cardano-tracer/logs"
+  logMode: FileMode
+  logFormat: ForMachine
+verbosity: Minimum
+hasPrometheus:
+  epHost: 0.0.0.0
+  epPort: 4000


### PR DESCRIPTION
## Regular `cardano_amaru` testnet on amaru main HEAD

Promotes `cardano_amaru` to a regular on-main testnet running **literal pragma-org/amaru main** (image `03d2727`, amaru `5923f085`) — no fork, no patch.

### Validated
- **Local smoke**: `PASS` — bootstrap-producer builds the bundle (exit 0), both relay-only amaru nodes consume it and follow (tip tracks p1).
- **Antithesis**: run [`22c58261…-56-17`](https://amaru-cardano.antithesis.com/report/WIZhzxy3TkVKJSQv_fN1xvsy) **completed, zero failing properties** — `cluster fork depth < k` (fork-tree convergence) ✅, `All commands run to completion` ✅, no crashes/critical logs, faults injected.
- **CI**: green (incl. the `cardano_amaru` Compose smoke test).

### Testnet-side adaptations to amaru main's API (no amaru code)
- **epoch125** — `epoch_length = k·(1/f)·scale_factor` invariant (120 is unreachable → mainnet-default fallback → `expected epoch 0`). 125 = scale_factor 5.
- **Relay CLI** — `--era-history` + `AMARU_GLOBAL_*` env (no `--global-parameters-file`).
- **Convergence** — tracer-sidecar fork-tree (`sidecar:1ff6913` + `tracer-sidecar:5271661`); the old brittle tip-equality composer probes are dropped (cna#119). This also sidesteps the config-56 composer-removal issue.

Depends on harness image: lambdasistemi/amaru-bootstrap#47. Genesis-now configurator pinned (`0f9570b`); #169 lands it for master separately.