### PR TITLE
testnet(amaru): repin producer image to amaru-bootstrap main HEAD

### DIFF
--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -44,7 +44,7 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
-  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:03d2727b71e8d1fe7c793d5036dce3c3ce294f6c
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6258c39552604a1f458d74399358937a63485b9e
   entrypoint:
     - /bin/sh
   environment:
@@ -147,7 +147,7 @@ services:
       - tracer:/tracer
 
   bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:03d2727b71e8d1fe7c793d5036dce3c3ce294f6c
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6258c39552604a1f458d74399358937a63485b9e
     container_name: bootstrap-producer
     labels: *fault-exclude
     hostname: bootstrap-producer.example


### PR DESCRIPTION
Repins `cardano_amaru` from the PR-branch image `03d2727` to the main-published `amaru-bootstrap-producer:6258c39552604a1f458d74399358937a63485b9e` (amaru-bootstrap main HEAD). Content-identical (same amaru `5923f085` + harness scripts) — provenance polish so the testnet tracks main, not a merged PR head. Validated green on Antithesis with the equivalent image (run `22c58261…`).