### PR TITLE
feat(tracer-sidecar): score amaru-consumer convergence as an Antithesis property (#180)

### DIFF
--- a/components/tracer-sidecar/src/App.hs
+++ b/components/tracer-sidecar/src/App.hs
@@ -47,6 +47,7 @@ import Data.List (isPrefixOf)
 import Data.Maybe (isJust)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import qualified Data.Text as Text
 import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
 import System.Directory
     ( listDirectory
@@ -54,6 +55,7 @@ import System.Directory
 import System.Environment
     ( getArgs
     , getEnv
+    , lookupEnv
     )
 import System.FilePath
     ( takeFileName
@@ -84,10 +86,11 @@ main = do
         _ -> error "Usage: <executable name> <directory>"
 
     (nPools :: Int) <- read <$> getEnv "POOLS"
+    consumerHost <- fmap Text.pack <$> lookupEnv "AMARU_CONSUMER_HOST"
 
     writeSdkJsonl $ sometimesTracesDeclaration "find log files"
 
-    let spec = mkSpec nPools
+    let spec = mkSpec nPools consumerHost
     mvar <- newMVar =<< initialStateIO spec
 
     -- Each cardano-node process gets its own subdirectory under `dir` once it

--- a/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
+++ b/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
@@ -41,6 +41,9 @@ import Cardano.Antithesis.Sdk
 import qualified Data.Set as Set
 import qualified Data.Text as T
 
+import Control.Applicative
+    ( (<|>)
+    )
 import Control.Arrow
     ( second
     )
@@ -91,8 +94,8 @@ defaultK = 432
 defaultDepthCap :: Int
 defaultDepthCap = defaultK * 2
 
-mkSpec :: Int -> Spec
-mkSpec nPools = do
+mkSpec :: Int -> Maybe Text -> Spec
+mkSpec nPools consumerHost = do
     mapM_
         sometimesTraces
         [ "TraceAddBlockEvent.SwitchedToAFork"
@@ -113,6 +116,9 @@ mkSpec nPools = do
     -- Cluster-wide fork-depth probe (#119).
     forkTreeProbe defaultK defaultDepthCap
 
+    forM_ consumerHost $ \host ->
+        amaruConsumerConvergenceProbe nPools host
+  where
     -- Issue #123, Layer 2 was here — a "did the adversary appear in
     -- some producer's InboundGovernor stream" probe via substring
     -- match on @adversary.example@. Verified empirically that
@@ -120,7 +126,7 @@ mkSpec nPools = do
     -- peer IP (192.168.x.y) not hostname, so the substring check
     -- never fires. Re-implementing this needs the tracer-side
     -- hostname↔IP mapping, which is non-trivial. Removed for now.
-  where
+
     recordAllChainPoints :: State -> LogMessage -> [Output]
     recordAllChainPoints
         _s
@@ -169,6 +175,13 @@ data State = State
     -- Surfaces as discrete Sometimes assertions per threshold so
     -- the report renders a depth-by-depth checklist of how deep
     -- the perturbation pushed the cluster.  Issue #123, Layer 3.
+    , producerTipHashes :: !(Set Text)
+    -- ^ Tip hashes observed on producer hosts.  Used by the
+    -- amaru-consumer convergence property.
+    , consumerFirstLen :: !(Maybe Int)
+    -- ^ First observed amaru-consumer chain length.  The
+    -- convergence property only fires after the consumer advances
+    -- beyond this baseline.
     }
 
 initialState :: Spec -> (State, [Output])
@@ -184,6 +197,8 @@ initialState spec =
             , forkObserved = False
             , forkExceededK = False
             , maxForkDepth = 0
+            , producerTipHashes = mempty
+            , consumerFirstLen = Nothing
             }
     setupFns = stateInitFunctions spec
 
@@ -356,7 +371,8 @@ parseTip
 -- update derived flags.  No SDK output here — the
 -- 'sometimes' / 'alwaysOrUnreachable' rules above turn the
 -- flags into observable assertions.
-updateForkTree :: Int -> Int -> State -> LogMessage -> (State, [Output])
+updateForkTree
+    :: Int -> Int -> State -> LogMessage -> (State, [Output])
 updateForkTree k depthCap s LogMessage{host, details} =
     case details of
         AddedToCurrentChain{newTipSelectView, newtip} ->
@@ -378,6 +394,74 @@ updateForkTree k depthCap s LogMessage{host, details} =
                 , maxForkDepth = max d (maxForkDepth st)
                 }
 
+-- Amaru consumer convergence probe (#180) -------------------------------------
+
+amaruConsumerConvergenceProbe :: Int -> Text -> Spec
+amaruConsumerConvergenceProbe nPools consumerHost = do
+    Spec
+        $ tell
+            [ Rule
+                { _ruleProcess = updateAmaruConsumerConvergence nPools consumerHost
+                , ruleDeclaration = Nothing
+                , ruleInit = id
+                }
+            ]
+    sometimes "amaru-served consumer reached producer tip"
+        $ \State{producerTipHashes, consumerFirstLen} LogMessage{host, details} ->
+            case details of
+                AddedToCurrentChain{newTipSelectView, newtip}
+                    | sameHost consumerHost host ->
+                        let newTip = parseTip newTipSelectView newtip
+                        in  maybe
+                                False
+                                ( \firstLen ->
+                                    tipChainLength newTip > firstLen
+                                        && Set.member
+                                            (tipHash newTip)
+                                            producerTipHashes
+                                )
+                                consumerFirstLen
+                _ -> False
+
+updateAmaruConsumerConvergence
+    :: Int -> Text -> State -> LogMessage -> (State, [Output])
+updateAmaruConsumerConvergence nPools consumerHost s LogMessage{host, details} =
+    case details of
+        AddedToCurrentChain{newTipSelectView, newtip}
+            | isProducerHost nPools host ->
+                let newTip = parseTip newTipSelectView newtip
+                in  ( s
+                        { producerTipHashes =
+                            Set.insert (tipHash newTip) (producerTipHashes s)
+                        }
+                    , []
+                    )
+            | sameHost consumerHost host ->
+                let newTip = parseTip newTipSelectView newtip
+                in  ( s
+                        { consumerFirstLen =
+                            consumerFirstLen s
+                                <|> Just (tipChainLength newTip)
+                        }
+                    , []
+                    )
+        _ -> (s, [])
+
+isProducerHost :: Int -> Text -> Bool
+isProducerHost nPools host =
+    hostStem host
+        `Set.member` Set.fromList
+            [ "p" <> T.pack (show i)
+            | i <- [1 :: Int .. nPools]
+            ]
+
+sameHost :: Text -> Text -> Bool
+sameHost configured observed =
+    hostStem configured == hostStem observed
+
+hostStem :: Text -> Text
+hostStem host =
+    fromMaybe host (T.stripSuffix ".example" host)
 
 declarations :: Spec -> [Output]
 declarations (Spec s) = mapMaybe (fmap AntithesisSdk . ruleDeclaration) $ execWriter s

--- a/components/tracer-sidecar/test/Spec.hs
+++ b/components/tracer-sidecar/test/Spec.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -7,7 +10,12 @@ module Spec (spec)
 where
 
 import App (tailJsonLinesFromTracerLogDir)
-import Cardano.Antithesis.LogMessage (LogMessage)
+import Cardano.Antithesis.LogMessage
+    ( LogMessage (..)
+    , LogMessageData (..)
+    , NewTipSelectView (..)
+    , Severity (..)
+    )
 import Cardano.Antithesis.Sidecar
     ( Output (..)
     , initialState
@@ -28,7 +36,11 @@ import Data.Aeson
     , decodeStrict'
     , eitherDecodeStrict
     , encode
+    , object
     )
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Char8 qualified as B8
 import Data.ByteString.Lazy qualified as BL
 import Data.ByteString.Lazy.Char8 qualified as BL8
@@ -42,6 +54,8 @@ import Data.List
 import Data.Maybe
     ( mapMaybe
     )
+import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Time
 import ForkTreeSpec qualified
 import System.FilePath ((</>))
@@ -59,10 +73,47 @@ spec = do
     ForkTreeSpec.spec
     (input :: [B8.ByteString]) <-
         runIO $ B8.lines <$> B8.readFile "test/data/input.jsonl"
+    let runSynthetic propSpec msgs =
+            snd $ processMessages propSpec (initialState propSpec) msgs
+
+    describe "amaru consumer convergence property" $ do
+        it "hits when the consumer advances to a producer tip" $ do
+            let outputs =
+                    sdkAssertions
+                        $ runSynthetic
+                            (mkSpec 1 (Just "amaru-consumer.example"))
+                            [ addedToCurrentChain "amaru-consumer.example" 10 "seed"
+                            , addedToCurrentChain "p1.example" 11 "producer-tip"
+                            , addedToCurrentChain "amaru-consumer.example" 11 "producer-tip"
+                            ]
+            outputs `shouldSatisfy` any (assertionHit convergencePropertyName)
+
+        it "is declared but not hit when the consumer stays at its first tip" $ do
+            let outputs =
+                    sdkAssertions
+                        $ runSynthetic
+                            (mkSpec 1 (Just "amaru-consumer.example"))
+                            [ addedToCurrentChain "amaru-consumer.example" 10 "seed"
+                            , addedToCurrentChain "p1.example" 11 "producer-tip"
+                            , addedToCurrentChain "amaru-consumer.example" 10 "seed"
+                            ]
+            outputs
+                `shouldSatisfy` any (assertionDeclared convergencePropertyName)
+            outputs `shouldNotSatisfy` any (assertionHit convergencePropertyName)
+
+        it "is not declared when no consumer is configured" $ do
+            let outputs =
+                    sdkAssertions
+                        $ runSynthetic
+                            (mkSpec 1 Nothing)
+                            [ addedToCurrentChain "p1.example" 11 "producer-tip"
+                            ]
+            outputs
+                `shouldNotSatisfy` any (assertionDeclared convergencePropertyName)
 
     it "processMessages"
         $ let
-            propSpec = mkSpec 3
+            propSpec = mkSpec 3 Nothing
             (_finalState, actualVals) = processMessages propSpec (initialState propSpec) msgs
             msgs = mapMaybe decodeStrict' input
           in
@@ -98,6 +149,67 @@ spec = do
 collectAllInts :: MVar [Int] -> Int -> IO ()
 collectAllInts xs newInt = do
     modifyMVar_ xs $ \ints -> pure (ints <> [newInt])
+
+convergencePropertyName :: Text
+convergencePropertyName = "amaru-served consumer reached producer tip"
+
+sdkAssertions :: [Output] -> [Value]
+sdkAssertions = mapMaybe $ \case
+    AntithesisSdk v -> Just v
+    _ -> Nothing
+
+assertionDeclared :: Text -> Value -> Bool
+assertionDeclared = assertionIdIs
+
+assertionHit :: Text -> Value -> Bool
+assertionHit name v =
+    assertionIdIs name v && assertionBool "hit" v == Just True
+
+assertionIdIs :: Text -> Value -> Bool
+assertionIdIs name v =
+    assertionText "id" v == Just name
+
+assertionText :: Text -> Value -> Maybe Text
+assertionText field v = case assertionField field v of
+    Just (Aeson.String t) -> Just t
+    _ -> Nothing
+
+assertionBool :: Text -> Value -> Maybe Bool
+assertionBool field v = case assertionField field v of
+    Just (Aeson.Bool b) -> Just b
+    _ -> Nothing
+
+assertionField :: Text -> Value -> Maybe Value
+assertionField field (Aeson.Object outer) = do
+    Aeson.Object assertion <-
+        KeyMap.lookup (Key.fromString "antithesis_assert") outer
+    KeyMap.lookup (Key.fromText field) assertion
+assertionField _ _ = Nothing
+
+addedToCurrentChain :: Text -> Int -> Text -> LogMessage
+addedToCurrentChain host chainLength hash =
+    LogMessage
+        { at = UTCTime (fromGregorian 2025 11 1) 0
+        , ns = "ChainDB"
+        , details =
+            AddedToCurrentChain
+                { newTipSelectView =
+                    NewTipSelectView
+                        { chainLength
+                        , issueNo = 0
+                        , issuerHash = "issuer"
+                        , kind = "PraosChainSelectView"
+                        , slotNo = chainLength * 2
+                        , tieBreakVRF = "vrf"
+                        }
+                , newtip = hash <> "@" <> T.pack (show (chainLength * 2))
+                }
+        , sev = Info
+        , thread = "test"
+        , host
+        , kind = "AddedToCurrentChain"
+        , json = object []
+        }
 
 jsonifyOutput :: Output -> Value
 jsonifyOutput (StdOut msg) = toJSON $ "### STDOUT: " <> msg

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Mechanical gate for the feat/consumer-convergence-property PR (#180).
+# The tracer-sidecar test suite is the RED->GREEN harness for the property.
+set -euo pipefail
+
+git diff --check
+
+# tracer-sidecar property tests (hspec + golden). Prefer the hermetic nix build
+# of the test derivation; fall back to cabal in the component dir.
+if command -v nix >/dev/null 2>&1 && [ -f components/tracer-sidecar/flake.nix ]; then
+  ( cd components/tracer-sidecar && nix build --quiet '.#tracer-sidecar-tests' )
+else
+  ( cd components/tracer-sidecar && cabal test --test-show-details=streaming )
+fi
+
+# Compose still validates with the tracer-sidecar env + image bump (slice 2).
+INTERNAL_NETWORK=false docker compose \
+  -f testnets/cardano_amaru/docker-compose.yaml config >/dev/null
+
+# master must NOT gain the consumer convergence env (would redden master runs).
+if grep -nE 'AMARU_CONSUMER_HOST' testnets/cardano_node_master/docker-compose.yaml >/dev/null 2>&1; then
+  echo "gate: cardano_node_master must not set AMARU_CONSUMER_HOST" >&2
+  exit 1
+fi
+
+echo "gate: OK"

--- a/specs/180-consumer-convergence-property/plan.md
+++ b/specs/180-consumer-convergence-property/plan.md
@@ -1,0 +1,133 @@
+# Implementation Plan: Score the amaru-consumer's convergence
+
+**Branch**: `feat/consumer-convergence-property` | **Date**: 2026-06-30 | **Spec**: `spec.md`
+**Input**: `specs/180-consumer-convergence-property/spec.md` (issue #180, epic #182)
+
+## Status
+
+**Completed**: #179 merged to main. Worktree + spec. tracer-sidecar assertion
+framework + test harness understood.
+**Current**: Plan — TDD red-first via the tracer-sidecar test suite.
+**Blockers**: None.
+
+## Summary
+
+Add a scored Antithesis property to `tracer-sidecar` that fires once the
+`amaru-consumer` has advanced past its first observed tip **and** reached a
+tip also seen on a producer — i.e. it converged onto the producers' chain
+through amaru. Because the consumer is network-isolated to amaru-only (#179),
+any advance is necessarily *via amaru*, so this property scores the exact
+liveness gap the cluster-wide fork-tree/no-critical probes miss (a stuck
+consumer goes stale, not forked).
+
+## The framework (verified)
+
+- `mkSpec :: Int -> Spec` builds `[Rule]` via `sometimes` / `alwaysOrUnreachable`
+  / `observe`. Each `sometimes name f` **declares** an Antithesis `must_hit`
+  assertion and emits *hit* the first time `f` returns True; if never hit, the
+  Antithesis report scores it as a failure.
+- `State { unreachedAssertions, forkTree, … }`; `LogMessage { host, kind,
+  details = AddedToCurrentChain{newtip,…}, sev, json }`. Producer detection
+  already uses `stripSuffix ".example" host == "pN"`.
+- Test harness: `test/Spec.hs` golden (`input.jsonl` → `output.jsonl`,
+  comparing emitted `antithesis_assert` JSON) + `ForkTreeSpec.hs` hspec. This
+  is the RED→GREEN driver — **no cluster, no Antithesis spend** for the logic.
+
+## CRITICAL design point — the property must be conditional
+
+`sometimes` declares a `must_hit` assertion **unconditionally**. If we add the
+convergence property to `mkSpec` flat, it would also be declared for
+`cardano_node_master` (which has **no** `amaru-consumer`) → never hit → a
+**spurious scored failure** on every master run. So:
+
+- `mkSpec` takes the consumer identity as a parameter (e.g.
+  `mkSpec :: Int -> Maybe Text -> Spec`, the `Maybe Text` = consumer host or
+  Nothing). The convergence property is added **only when a consumer host is
+  configured**.
+- `App.hs` reads it from a new env var (e.g. `AMARU_CONSUMER_HOST`); absent →
+  `Nothing` → property not declared (master runs unaffected).
+- Only the `cardano_amaru` compose sets `AMARU_CONSUMER_HOST=amaru-consumer.example`.
+
+This is the difference between "a new scored property" and "a regression that
+reddens an unrelated testnet". It is non-negotiable.
+
+## The property
+
+State gains:
+- `producerTipHashes :: Set BlockHash` — every `newtip` hash seen on a producer.
+- `consumerFirstLen :: Maybe Int` — consumer's first observed chain length.
+
+State updater rule (when consumer host is configured): on each
+`AddedToCurrentChain{newtip}`:
+- producer host → insert `newtip.hash` into `producerTipHashes`.
+- consumer host → set `consumerFirstLen` if unset.
+
+Property: `sometimes "amaru-served consumer reached producer tip"` fires when a
+consumer `AddedToCurrentChain` has `newtip.chainLength > consumerFirstLen`
+**and** `newtip.hash ∈ producerTipHashes` (accumulated across the run, so a
+producer "moving past" the point doesn't lose it).
+
+Why both clauses: length-advance proves it pulled blocks (only possible via
+amaru, since isolated); hash-on-a-producer proves it converged onto the
+producers' chain (not a private fork). A stuck consumer never advances → never
+hit → scored failure. (Optionally also an `alwaysOrUnreachable "amaru-consumer
+not on a divergent fork"` — decide during S1 if it adds signal over the
+existing `forkTreeProbe`; default to just the `sometimes` to keep it minimal.)
+
+## Slices (bisect-safe, one commit each)
+
+### Slice 1 — the conditional convergence property + RED→GREEN tests
+
+- `mkSpec` takes the consumer host; `App.hs` reads `AMARU_CONSUMER_HOST`.
+- Add the state fields + updater + `sometimes` property (only when configured).
+- **TDD (RED first, mandatory)**: add hspec cases (and/or extend the golden)
+  feeding synthetic `AddedToCurrentChain` streams:
+  - **hit case**: consumer advances and a tip hash matches a producer tip →
+    property emitted hit. Write this test FIRST, watch it FAIL (property
+    absent), then implement.
+  - **not-hit case**: consumer stuck at seed → property declared, not hit.
+  - **no-consumer case**: `Nothing` → property not declared at all (guards the
+    master-regression).
+- **Gate**: `cd components/tracer-sidecar && cabal test` (or `nix build
+  .#tracer-sidecar-tests`) green; `fourmolu`/`hlint`/`cabal-fmt` clean; the
+  existing golden output stays otherwise stable.
+- One commit: property + tests together.
+
+### Slice 2 — wire it into the cardano_amaru cluster + image bump
+
+- `testnets/cardano_amaru/docker-compose.yaml`: set
+  `AMARU_CONSUMER_HOST=amaru-consumer.example` on the `tracer-sidecar` service,
+  and **bump the `tracer-sidecar` image tag** to a `feat/consumer-convergence-
+  property` commit SHA (constitution: image-tag hygiene → `publish-images`
+  rebuilds with the property). Leave `cardano_node_master` unset (no consumer).
+- **Gate**: `INTERNAL_NETWORK=false docker compose -f
+  testnets/cardano_amaru/docker-compose.yaml config` validates; image spelling
+  constraint preserved (digest/tag rules).
+
+### Finalization — AC3, the one launched run
+
+After S1+S2 are green and merged-ready and `publish-images` has built the new
+`tracer-sidecar` image: launch **one** `cardano_amaru` run and confirm the
+`amaru-served consumer reached producer tip` property appears in the report
+(`anti properties <run_id>`). This is the only Antithesis spend for #180, and
+it happens **after** the logic is green locally and the image is published —
+never before. (The fault-scoped green run is #181.)
+
+## Risks
+
+- **R1 (master regression)**: forgetting the conditional → spurious failure on
+  `cardano_node_master`. Mitigated by the `no-consumer` test case (S1) + only
+  `cardano_amaru` setting the env (S2).
+- **R2 (chain-length field)**: confirm `AddedToCurrentChain` carries a usable
+  chain length / the `Tip` the ForkTree already parses (`newTipSelectView`);
+  reuse the ForkTree's existing tip parsing rather than re-deriving.
+- **R3 (golden churn)**: the new property changes emitted outputs only when a
+  consumer host is configured; the existing `input.jsonl` (master-shaped, no
+  consumer) golden should be unchanged. Add consumer fixtures in new test cases,
+  don't perturb the existing golden.
+
+## Test strategy
+
+The tracer-sidecar hspec/golden suite is the RED→GREEN harness — proven locally
+and deterministically. AC3 (surfaces in a report) is the only step needing a
+real run, performed last.

--- a/specs/180-consumer-convergence-property/spec.md
+++ b/specs/180-consumer-convergence-property/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Score the amaru-consumer's convergence as an Antithesis property
+
+**Feature Branch**: `feat/consumer-convergence-property`
+**Created**: 2026-06-30
+**Status**: Draft
+**Input**: GitHub issue #180 (parent epic #182, depends on merged #179)
+
+## Context
+
+#179 added an amaru-fed `amaru-consumer` cardano-node and a **local** smoke
+that fails closed unless the consumer advances past its seed and matches a
+producer tip. But that proof lives only in `scripts/smoke-test.sh` — it is
+**not** a scored Antithesis property. As established while triaging the
+(aborted) shake-out: the consumer's logs are collected (it forwards to
+cardano-tracer; `tracer-sidecar` tails its dir), and it's folded into the
+cluster-wide `forkTreeProbe` and `"no critical logs"` — but those only catch
+*divergence* and *crashes*. A consumer that silently froze because amaru
+stopped serving would go **stale on the same chain**: no fork, no critical →
+the run passes green while the boundary actually failed. #180 closes that gap.
+
+## User Scenarios & Testing
+
+### User Story 1 — A scored property proves the consumer converged via amaru (P1)
+
+As a tester, I read the Antithesis report and see a property that proves the
+amaru-fed consumer advanced past its seed and converged with the producers —
+so a green run is real evidence amaru served it.
+
+**Why P1**: Without it, a stuck consumer (amaru not serving) is invisible to
+Antithesis. This property is the whole point of the epic's Antithesis arc.
+
+**Independent Test**: Feed `tracer-sidecar` a synthetic log stream (golden /
+hspec) where the consumer advances and reaches a producer tip → the
+`sometimes "amaru-served consumer reached producer tip"` assertion is **hit**.
+Feed a stream where the consumer never reaches a producer tip → the assertion
+is **declared but not hit** (which Antithesis scores as a failure).
+
+**Acceptance Scenarios**:
+1. **Given** the consumer's `AddedToCurrentChain` tips advance past its first
+   observed tip **and** a tip hash also seen on a producer, **When**
+   `tracer-sidecar` processes the stream, **Then** it emits the
+   `amaru-served consumer reached producer tip` SDK assertion as hit.
+2. **Given** the consumer's tip never matches a producer tip (stuck at seed),
+   **When** the stream ends, **Then** the assertion is declared (`must_hit`)
+   and **not** hit — the Antithesis-scored failure signal.
+
+### User Story 2 — The property is live in the deployed image (P1)
+
+As a maintainer, I need the new property compiled into the `tracer-sidecar`
+image the cluster actually runs, so it surfaces in real runs.
+
+**Why P1**: A property only in source, with a stale image tag, never runs.
+
+**Independent Test**: The `tracer-sidecar` image tag in the `cardano_amaru`
+compose is bumped to a branch commit SHA (so `publish-images` rebuilds it),
+and `docker compose config` validates.
+
+### User Story 3 — The property surfaces in a real report (P1)
+
+As a tester, I confirm the property actually appears in a launched run's
+report (not absent/removed).
+
+**Why P1**: AC3 is explicit — the property must be *verified against a
+launched run*. This is the one unavoidable Antithesis spend for #180, done
+**only after** US1 is green locally and US2's image is published.
+
+**Independent Test**: Launch one `cardano_amaru` run and confirm the
+`amaru-served consumer reached producer tip` property appears in the report
+(`anti properties <run_id>` / the triage report).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `amaru-consumer` MUST be in the tracer-sidecar's observed set —
+  i.e. its `AddedToCurrentChain` events feed the same machinery as producers.
+  (Already true via #179's tracer wiring; verify, don't re-plumb.)
+- **FR-002**: A scored property MUST reflect convergence-through-amaru: a
+  `sometimes "amaru-served consumer reached producer tip"` that fires once the
+  consumer's tip has advanced past its first observed tip **and** equals a tip
+  also observed on a producer (p1/p2/p3). Optionally an `alwaysOrUnreachable`
+  guarding a regression.
+- **FR-003**: The property MUST be exercised by the tracer-sidecar test
+  harness (hspec/golden) with BOTH a hit case and a not-hit case — proven RED
+  before GREEN.
+- **FR-004**: The `tracer-sidecar` image tag in `testnets/cardano_amaru/
+  docker-compose.yaml` MUST be bumped to a branch commit SHA so
+  `publish-images` rebuilds the image with the property (constitution: image
+  tag hygiene).
+- **FR-005**: The property MUST be verified to SURFACE in a launched
+  `cardano_amaru` run's report (AC3) — after FR-002/003 are green and FR-004's
+  image is built.
+
+### Constraints
+
+- **C-001**: No fault scoping of the assertion — that's #181.
+- **C-002**: Don't touch amaru's own-tip observability (cna#168).
+- **C-003**: The property must not regress the existing fork-tree /
+  no-critical / per-producer assertions (golden output stays otherwise stable).
+
+## Success Criteria
+
+- The tracer-sidecar test suite has a hit case and a not-hit case for the new
+  property, both proven (RED seen before GREEN).
+- A launched `cardano_amaru` run's report shows the property.
+- A stuck consumer (amaru not serving) would make the property **not hit** —
+  the gap #179's local smoke caught, now scored by Antithesis.
+
+## Out of Scope
+
+- Fault scoping / which faults may break it (#181).
+- The fault-scoped green run (#181).

--- a/specs/180-consumer-convergence-property/tasks.md
+++ b/specs/180-consumer-convergence-property/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Score the amaru-consumer's convergence (#180)
+
+## Slice 1 — conditional convergence property + RED→GREEN tests
+
+- [ ] T001 RED: add tracer-sidecar test cases (hspec/golden) for the new
+  property — hit case (consumer advances + matches a producer tip), not-hit
+  case (consumer stuck), no-consumer case (property not declared). Run and
+  watch them FAIL (property absent). Record RED in WIP.md.
+- [ ] T002 `mkSpec` takes the consumer host (`Maybe Text`); `App.hs` reads
+  `AMARU_CONSUMER_HOST` and passes it.
+- [ ] T003 Extend `State` (`producerTipHashes`, `consumerFirstLen`) + the
+  updater rule + the `sometimes "amaru-served consumer reached producer tip"`
+  property, added ONLY when a consumer host is configured.
+- [ ] T004 GREEN: `cd components/tracer-sidecar && cabal test` passes (all
+  three cases); `fourmolu`/`hlint`/`cabal-fmt` clean; existing golden stable.
+  One bisect-safe commit (property + tests).
+
+## Slice 2 — wire into cardano_amaru + image bump
+
+- [ ] T005 `testnets/cardano_amaru/docker-compose.yaml`: set
+  `AMARU_CONSUMER_HOST=amaru-consumer.example` on `tracer-sidecar`; leave
+  `cardano_node_master` unset.
+- [ ] T006 Bump the `tracer-sidecar` image tag to a branch commit SHA so
+  `publish-images` rebuilds with the property (image-tag hygiene).
+- [ ] T007 `INTERNAL_NETWORK=false docker compose -f
+  testnets/cardano_amaru/docker-compose.yaml config` validates; image-spelling
+  constraint preserved.
+
+## Finalization — AC3 (one launched run, after S1+S2 green + image built)
+
+- [ ] T008 Launch one `cardano_amaru` run; confirm the
+  `amaru-served consumer reached producer tip` property appears in the report
+  (`anti properties <run_id>`). Record the run_id + report link in the PR.

--- a/specs/180-consumer-convergence-property/tasks.md
+++ b/specs/180-consumer-convergence-property/tasks.md
@@ -17,12 +17,12 @@
 
 ## Slice 2 — wire into cardano_amaru + image bump
 
-- [ ] T005 `testnets/cardano_amaru/docker-compose.yaml`: set
+- [X] T005 `testnets/cardano_amaru/docker-compose.yaml`: set
   `AMARU_CONSUMER_HOST=amaru-consumer.example` on `tracer-sidecar`; leave
   `cardano_node_master` unset.
-- [ ] T006 Bump the `tracer-sidecar` image tag to a branch commit SHA so
+- [X] T006 Bump the `tracer-sidecar` image tag to a branch commit SHA so
   `publish-images` rebuilds with the property (image-tag hygiene).
-- [ ] T007 `INTERNAL_NETWORK=false docker compose -f
+- [X] T007 `INTERNAL_NETWORK=false docker compose -f
   testnets/cardano_amaru/docker-compose.yaml config` validates; image-spelling
   constraint preserved.
 

--- a/specs/180-consumer-convergence-property/tasks.md
+++ b/specs/180-consumer-convergence-property/tasks.md
@@ -2,16 +2,16 @@
 
 ## Slice 1 — conditional convergence property + RED→GREEN tests
 
-- [ ] T001 RED: add tracer-sidecar test cases (hspec/golden) for the new
+- [X] T001 RED: add tracer-sidecar test cases (hspec/golden) for the new
   property — hit case (consumer advances + matches a producer tip), not-hit
   case (consumer stuck), no-consumer case (property not declared). Run and
   watch them FAIL (property absent). Record RED in WIP.md.
-- [ ] T002 `mkSpec` takes the consumer host (`Maybe Text`); `App.hs` reads
+- [X] T002 `mkSpec` takes the consumer host (`Maybe Text`); `App.hs` reads
   `AMARU_CONSUMER_HOST` and passes it.
-- [ ] T003 Extend `State` (`producerTipHashes`, `consumerFirstLen`) + the
+- [X] T003 Extend `State` (`producerTipHashes`, `consumerFirstLen`) + the
   updater rule + the `sometimes "amaru-served consumer reached producer tip"`
   property, added ONLY when a consumer host is configured.
-- [ ] T004 GREEN: `cd components/tracer-sidecar && cabal test` passes (all
+- [X] T004 GREEN: `cd components/tracer-sidecar && cabal test` passes (all
   three cases); `fourmolu`/`hlint`/`cabal-fmt` clean; existing golden stable.
   One bisect-safe commit (property + tests).
 

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -395,7 +395,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:5271661
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:e01ad90
     container_name: tracer-sidecar
     labels: *fault-exclude
     hostname: tracer-sidecar.example
@@ -404,6 +404,7 @@ services:
     environment:
       POOLS: "3"
       CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+      AMARU_CONSUMER_HOST: amaru-consumer.example
     volumes:
       - tracer:/opt/cardano-tracer
     restart: always


### PR DESCRIPTION
Closes #180 — second child of epic #182 (depends on merged #179).

## Status: code-complete, CI-green, locally proven. AC3 (surfaces in an Antithesis report) is the only remaining acceptance.

#179 made the amaru-consumer's convergence a **local** smoke check, not a scored property — a stuck consumer (amaru not serving) goes stale on the same chain, so the cluster-wide probes pass it green. #180 adds a scored property that fails when the consumer doesn't converge through amaru.

## Slice 1 — the conditional property (`e01ad90`)

A `sometimes "amaru-served consumer reached producer tip"` in `tracer-sidecar`'s `mkSpec`, firing once a consumer `AddedToCurrentChain` tip has advanced past its first observed length **and** matches a hash seen on a producer. **Conditional** on `mkSpec`'s `Maybe Text` consumer host (from `AMARU_CONSUMER_HOST`) — declared only when a consumer is configured, so it can't redden `cardano_node_master`. Proven RED→GREEN in the test suite (14/2 → 14/0, golden unchanged); cases: hit, not-hit (the scored failure), no-consumer (not declared).

## Slice 2 — wire it into the cluster (`9c90519`)

`AMARU_CONSUMER_HOST=amaru-consumer.example` on the `cardano_amaru` tracer-sidecar + image tag bumped to `e01ad90` so `publish-images` rebuilds the sidecar with the property. `cardano_node_master` untouched (gate-asserted).

## Evidence

- **Unit tests** (logic, synthetic logs): RED→GREEN; green in CI.
- **Real local cluster**: built `tracer-sidecar:e01ad90`, brought up `cardano_amaru`, the consumer converged to p1's exact tip (`seed_slot=431 → slot=586`, `hash=d897b634…` matching p1), and the tracer-sidecar — on **real cardano-node tracer logs** — emitted the property **declared and hit**:
  `{"antithesis_assert":{"assert_type":"sometimes","condition":true,"hit":true,"id":"amaru-served consumer reached producer tip","must_hit":true}}`
- **CI**: publish-images built the property image; the Compose smoke ran the cluster with it (SUCCESS); the property unit tests pass.

## Remaining — AC3

One launched run to confirm the property surfaces in the Antithesis **report** (the report-layer rendering, which the local SDK-jsonl evidence above doesn't produce). Can be a dedicated run or folded into #181's fault-scoped run.

## Artifacts

- [spec.md](https://github.com/cardano-foundation/cardano-node-antithesis/blob/feat/consumer-convergence-property/specs/180-consumer-convergence-property/spec.md) · [plan.md](https://github.com/cardano-foundation/cardano-node-antithesis/blob/feat/consumer-convergence-property/specs/180-consumer-convergence-property/plan.md) · [tasks.md](https://github.com/cardano-foundation/cardano-node-antithesis/blob/feat/consumer-convergence-property/specs/180-consumer-convergence-property/tasks.md)