### PR TITLE
feat(amaru): adopt 037-vrf-investigation image + file-based era-history/global-parameters

### DIFF
--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -44,7 +44,7 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
-  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6258c39552604a1f458d74399358937a63485b9e
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6910d79c7f26c972f7121e36e1aa6aac5ff68de1
   entrypoint:
     - /bin/sh
   environment:
@@ -147,7 +147,7 @@ services:
       - tracer:/tracer
 
   bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6258c39552604a1f458d74399358937a63485b9e
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:6910d79c7f26c972f7121e36e1aa6aac5ff68de1
     container_name: bootstrap-producer
     labels: *fault-exclude
     hostname: bootstrap-producer.example
@@ -281,18 +281,12 @@ services:
         fi
         mkdir -p /startup
         printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > /startup/amaru-relay-1.started
-        export AMARU_GLOBAL_CONSENSUS_SECURITY_PARAM=20
-        export AMARU_GLOBAL_ACTIVE_SLOT_COEFF_INVERSE=5
-        export AMARU_GLOBAL_EPOCH_LENGTH_SCALE_FACTOR=4
-        export AMARU_GLOBAL_MAX_LOVELACE_SUPPLY=45000000000000000
-        export AMARU_GLOBAL_SLOTS_PER_KES_PERIOD=129600
-        export AMARU_GLOBAL_MAX_KES_EVOLUTION=62
-        export AMARU_GLOBAL_SYSTEM_START=0
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
-          --era-history /amaru-runtime/era-history.json \
+          --era-history-file /srv/amaru/era-history.json \
+          --global-parameters-file /srv/amaru/global-parameters.json \
           --listen-address 0.0.0.0:3001 \
           --peer-address relay1.example:3001
     volumes:
@@ -329,18 +323,12 @@ services:
         fi
         mkdir -p /startup
         printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > /startup/amaru-relay-2.started
-        export AMARU_GLOBAL_CONSENSUS_SECURITY_PARAM=20
-        export AMARU_GLOBAL_ACTIVE_SLOT_COEFF_INVERSE=5
-        export AMARU_GLOBAL_EPOCH_LENGTH_SCALE_FACTOR=4
-        export AMARU_GLOBAL_MAX_LOVELACE_SUPPLY=45000000000000000
-        export AMARU_GLOBAL_SLOTS_PER_KES_PERIOD=129600
-        export AMARU_GLOBAL_MAX_KES_EVOLUTION=62
-        export AMARU_GLOBAL_SYSTEM_START=0
         exec /bin/amaru run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
-          --era-history /amaru-runtime/era-history.json \
+          --era-history-file /srv/amaru/era-history.json \
+          --global-parameters-file /srv/amaru/global-parameters.json \
           --listen-address 0.0.0.0:3001 \
           --peer-address relay2.example:3001
     volumes:


### PR DESCRIPTION
Adopts the latest amaru fix work into `cardano_amaru`.

## What
- Bump `amaru-bootstrap-producer` image to `6910d79c` (037-vrf-investigation, amaru `bfe5b7ea`).
- Relays switch to file-based CLI: `--era-history-file` + `--global-parameters-file`, from the genesis-derived bundle.
- Drop the stale hand-authored `AMARU_GLOBAL_*` env exports and `--era-history /amaru-runtime/era-history.json` (epoch_size_slots 125 → wrong epoch mapping, see #188).

## Verified locally
Relays clear three previously-fatal walls and reach the live tip:
1. era-history epoch-length mismatch (#188)
2. `Insufficient leader stake` (amaru zero-active-stake)
3. `Invalid VRF proof: VerificationFailed` (#118 bug 3)

## Known remaining blocker
`Consensus died` / `contains_point was true but rollback failed` (#118 bug 2) still crash-loops the relays on fork rollback — not green yet, tracked upstream. Merging to exercise the fixed layers under Antithesis.

Refs #188, #118, #182.