### PR TITLE
chore(cardano_amaru): repin producer image to the published main tag

### DIFF
--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -44,7 +44,7 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
-  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b3c1286cff943c0ac73e435e7e7c5a3485cdc3f
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
   entrypoint:
     - /bin/sh
   environment:
@@ -155,7 +155,7 @@ services:
       - tracer:/tracer
 
   bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b3c1286cff943c0ac73e435e7e7c5a3485cdc3f
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
     container_name: bootstrap-producer
     labels: *fault-exclude
     hostname: bootstrap-producer.example


### PR DESCRIPTION
The `cardano_amaru` compose pinned `:5b3c1286…`, a tag hand-pushed to ghcr before lambdasistemi/amaru-bootstrap#49 was rebase-merged. That SHA no longer exists in amaru-bootstrap's history, so the pin was untraceable to any commit.

Repins to `:5b57873a…`, published by the *Publish bootstrap-producer image* workflow from amaru-bootstrap `main`.

**No behavioral change.** Both tags resolve to the same digest:

```
:5b3c1286cff943c0ac73e435e7e7c5a3485cdc3f -> sha256:7fde370dd7912821d1fb942317c46d70a81653572dae0ccfb9ed5b00547d9cfd
:5b57873ae57e38e97773b047ed287206620a155a -> sha256:7fde370dd7912821d1fb942317c46d70a81653572dae0ccfb9ed5b00547d9cfd
```

The post-merge commits touched only `nix/checks.nix` and `tests/`, which are not image inputs, so the nix-built image is byte-identical.

`amaru-consumer-seed` stays on `:03d2727b…` — that is a real commit in amaru-bootstrap history and the container only does a `cp -a`.