### PR TITLE
fix(cardano_amaru): score fatal amaru logs

### DIFF
--- a/components/tracer-sidecar/README.md
+++ b/components/tracer-sidecar/README.md
@@ -5,3 +5,46 @@ write antithesis [assertions](https://antithesis.com/docs/properties_assertions/
 
 The idea is to use it to test properties that a Cardano network should satisfy, as well as
 using sometimes-assertions to guide the fuzzer into finding more interesting scenarios more often.
+
+## Amaru stdout ingestion
+
+When the `AMARU_LOG_DIR` environment variable is set, the sidecar also watches
+that directory for two fixed relay log files (`amaru-relay-1.log` and
+`amaru-relay-2.log`) and ingests each plain line into the scored event
+pipeline. Files created after the watcher starts are discovered automatically.
+
+### Configuration
+
+| Variable | Required | Effect |
+|---|---|---|
+| `AMARU_LOG_DIR` | No | Enables Amaru ingestion when set to a directory path. When absent, neither Amaru-specific property is declared. |
+
+### Normalized event shape
+
+Each ingested line becomes a `LogMessage` with:
+
+- **source**: `amaru-container-stdout`
+- **host**: relay identity derived from the filename (e.g. `amaru-relay-1`)
+- **message**: the complete original line, newline stripped
+- **severity**: `Info` (cannot trip the existing `no critical logs` rule)
+
+### Scored properties
+
+When Amaru ingestion is enabled, two properties are declared:
+
+- **`amaru stdout observed`** (Sometimes, required) — hit on the first
+  normalized Amaru stdout event. Proves the route is alive; a disconnected
+  route cannot appear green.
+- **`no fatal amaru consensus logs`** (AlwaysOrUnreachable) — fails once when
+  either exact case-sensitive signature is observed:
+  - `Consensus died`
+  - `attempted roll back in the future`
+
+  The failure payload carries the source, relay identity, and complete
+  original line as evidence. Ordinary output does not fail this invariant.
+
+### Non-vacuity
+
+The required `amaru stdout observed` property prevents the fatal-consensus
+invariant from passing vacuously: if no Amaru line ever reaches the scored
+stream, the run reports a missing required property rather than a green board.

--- a/components/tracer-sidecar/src/App.hs
+++ b/components/tracer-sidecar/src/App.hs
@@ -8,9 +8,14 @@
 module App
     ( main
     , tailJsonLinesFromTracerLogDir
+    , tailAmaruLogDir
     )
 where
 
+import Cardano.Antithesis.LogMessage
+    ( LogMessage
+    , mkAmaruLogMessage
+    )
 import Cardano.Antithesis.Sdk
     ( sometimesTracesDeclaration
     , sometimesTracesReached
@@ -27,7 +32,7 @@ import Control.Concurrent
     , threadDelay
     )
 import Control.Concurrent.Async (async, link)
-import Control.Exception (SomeException, try)
+import Control.Exception (IOException, SomeException, try)
 import Control.Monad
     ( forM_
     , forever
@@ -48,7 +53,12 @@ import Data.Maybe (isJust)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
+import Data.Time
+    ( UTCTime
+    , defaultTimeLocale
+    , getCurrentTime
+    , parseTimeM
+    )
 import System.Directory
     ( listDirectory
     )
@@ -87,11 +97,22 @@ main = do
 
     (nPools :: Int) <- read <$> getEnv "POOLS"
     consumerHost <- fmap Text.pack <$> lookupEnv "AMARU_CONSUMER_HOST"
+    amaruLogDir <- lookupEnv "AMARU_LOG_DIR"
+    let amaruEnabled = isJust amaruLogDir
 
     writeSdkJsonl $ sometimesTracesDeclaration "find log files"
 
-    let spec = mkSpec nPools consumerHost
+    let spec = mkSpec nPools consumerHost amaruEnabled
     mvar <- newMVar =<< initialStateIO spec
+
+    forM_ amaruLogDir $ \logDir -> do
+        putStrLn $ "Tailing amaru log dir: " <> logDir
+        link
+            =<< async
+                ( tailAmaruLogDir
+                    logDir
+                    (modifyMVar_ mvar . flip (processMessageIO spec))
+                )
 
     -- Each cardano-node process gets its own subdirectory under `dir` once it
     -- handshakes with cardano-tracer. Those subdirectories appear over time
@@ -200,3 +221,83 @@ parsingNodeLogFile path = isJust $ do
         defaultTimeLocale
         "%Y-%m-%dT%H-%M-%S"
         timestamp
+
+-- | Watches a directory for the fixed Amaru relay log files
+-- (@amaru-relay-1.log@, @amaru-relay-2.log@) and ingests each
+-- appended line through 'mkAmaruLogMessage'.  Files created
+-- after the watcher starts are discovered on the next scan.
+-- Lines are read from the beginning of each file.
+tailAmaruLogDir
+    :: FilePath
+    -- ^ directory to watch
+    -> (LogMessage -> IO ())
+    -- ^ action on each normalized line
+    -> IO ()
+tailAmaruLogDir dir action = go mempty
+  where
+    relayFiles :: [FilePath]
+    relayFiles = ["amaru-relay-1.log", "amaru-relay-2.log"]
+
+    go :: Set FilePath -> IO ()
+    go seen = do
+        efiles <- try (listDirectory dir)
+        case efiles of
+            Left (e :: IOException) -> do
+                putStrLn
+                    $ "Error listing amaru log directory "
+                        <> dir
+                        <> ": "
+                        <> show e
+                threadDelay 1000000
+                go seen
+            Right files -> do
+                let current =
+                        Set.fromList
+                            $ filter (`elem` relayFiles) files
+                    new = current `Set.difference` seen
+                forM_ new $ \name -> do
+                    let path = dir </> name
+                    putStrLn $ "Tailing amaru log: " <> path
+                    link
+                        =<< async
+                            ( tailAmaruRelayFile
+                                path
+                                name
+                                action
+                            )
+                threadDelay 1000000
+                go (seen <> new)
+
+    tailAmaruRelayFile
+        :: FilePath
+        -> FilePath
+        -> (LogMessage -> IO ())
+        -> IO ()
+    tailAmaruRelayFile path name action = do
+        exited <- try
+            $ withFile path ReadMode
+            $ \h -> do
+                hSetBuffering h LineBuffering
+                forever $ do
+                    eof <- hIsEOF h
+                    if eof
+                        then threadDelay 10000
+                        else do
+                            l <- B8.hGetLine h
+                            now <- getCurrentTime
+                            action
+                                $ mkAmaruLogMessage
+                                    now
+                                    (Text.pack name)
+                                    (Text.pack $ B8.unpack l)
+        case exited of
+            Left (e :: SomeException) ->
+                putStrLn
+                    $ "Error reading amaru log "
+                        <> path
+                        <> ": "
+                        <> show e
+            Right _ ->
+                putStrLn
+                    $ "Finished reading amaru log: "
+                        <> path

--- a/components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs
+++ b/components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs
@@ -12,6 +12,7 @@ module Cardano.Antithesis.LogMessage
     , LogMessageData (..)
     , NewTipSelectView (..)
     , Severity (..)
+    , mkAmaruLogMessage
     ) where
 
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -19,14 +20,20 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson
     ( FromJSON (..)
     , Value (..)
+    , object
     , withObject
     , withText
     , (.:)
     , (.:?)
+    , (.=)
+    )
+import Data.Maybe
+    ( fromMaybe
     )
 import Data.Text
     ( Text
     )
+import qualified Data.Text as T
 import Data.Time
     ( UTCTime
     )
@@ -59,6 +66,13 @@ data LogMessageData
         }
     | ServerError
         { reason :: Text
+        }
+    | -- | A plain line ingested from an Amaru relay's container
+      -- stdout.  Carries the normalized evidence fields from
+      -- @contracts/amaru-log-event.md@.
+      AmaruStdout
+        { amaruSource :: Text
+        , amaruMessage :: Text
         }
     deriving (Show, Generic, Eq)
 
@@ -193,3 +207,48 @@ instance FromJSON Severity where
         "Error" -> pure SevError
         "Critical" -> pure Critical
         _ -> fail $ "Unknown severity: " <> show t
+
+-- Amaru stdout adapter --------------------------------------------------------
+
+-- | Normalize an ingested Amaru relay line into the event
+-- pipeline.  The relay filename loses its @.log@ suffix to
+-- become the host identity; the trailing newline (if present)
+-- is stripped from the message.  Severity is 'Info' so the
+-- line cannot trip the existing critical-node-log rule.
+mkAmaruLogMessage
+    :: UTCTime
+    -- ^ ingestion time
+    -> Text
+    -- ^ relay filename, e.g. @"amaru-relay-1.log"@
+    -> Text
+    -- ^ complete raw line
+    -> LogMessage
+mkAmaruLogMessage ingestionTime relayFilename rawLine =
+    LogMessage
+        { at = ingestionTime
+        , ns = "amaru"
+        , details =
+            AmaruStdout
+                { amaruSource = source
+                , amaruMessage = line
+                }
+        , sev = Info
+        , thread = "amaru-stdout"
+        , host = relayHost
+        , kind = "AmaruStdout"
+        , json = evidence
+        }
+  where
+    source = "amaru-container-stdout" :: Text
+    relayHost =
+        fromMaybe relayFilename
+            $ T.stripSuffix ".log" relayFilename
+    line =
+        fromMaybe rawLine
+            $ T.stripSuffix "\n" rawLine
+    evidence =
+        object
+            [ "source" .= source
+            , "host" .= relayHost
+            , "message" .= line
+            ]

--- a/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
+++ b/components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs
@@ -49,6 +49,7 @@ import Control.Arrow
     )
 import Control.Monad
     ( forM_
+    , when
     )
 import Control.Monad.Trans.Writer.Strict
     ( Writer
@@ -94,8 +95,8 @@ defaultK = 432
 defaultDepthCap :: Int
 defaultDepthCap = defaultK * 2
 
-mkSpec :: Int -> Maybe Text -> Spec
-mkSpec nPools consumerHost = do
+mkSpec :: Int -> Maybe Text -> Bool -> Spec
+mkSpec nPools consumerHost amaruEnabled = do
     mapM_
         sometimesTraces
         [ "TraceAddBlockEvent.SwitchedToAFork"
@@ -118,6 +119,22 @@ mkSpec nPools consumerHost = do
 
     forM_ consumerHost $ \host ->
         amaruConsumerConvergenceProbe nPools host
+
+    when amaruEnabled $ do
+        sometimes "amaru stdout observed" $ \_s LogMessage{details} ->
+            case details of
+                AmaruStdout{} -> True
+                _ -> False
+        alwaysOrUnreachable "no fatal amaru consensus logs"
+            $ \_s LogMessage{details} ->
+                case details of
+                    AmaruStdout{amaruMessage} ->
+                        not
+                            $ T.isInfixOf "Consensus died" amaruMessage
+                                || T.isInfixOf
+                                    "attempted roll back in the future"
+                                    amaruMessage
+                    _ -> True
   where
     -- Issue #123, Layer 2 was here — a "did the adversary appear in
     -- some producer's InboundGovernor stream" probe via substring
@@ -452,10 +469,10 @@ isProducerHost nPools host =
     let stem = hostStem host
     in  stem
             `Set.member` Set.fromList
-                ( [ "p" <> T.pack (show i) | i <- [1 :: Int .. nPools] ]
-                    ++ [ "relay" <> T.pack (show i) | i <- [1 :: Int .. nPools] ]
-                    ++ [ "amaru-relay-" <> T.pack (show i) | i <- [1 :: Int .. nPools] ]
-                    ++ [ "bootstrap-producer" ]
+                ( ["p" <> T.pack (show i) | i <- [1 :: Int .. nPools]]
+                    ++ ["relay" <> T.pack (show i) | i <- [1 :: Int .. nPools]]
+                    ++ ["amaru-relay-" <> T.pack (show i) | i <- [1 :: Int .. nPools]]
+                    ++ ["bootstrap-producer"]
                 )
 
 sameHost :: Text -> Text -> Bool

--- a/components/tracer-sidecar/test/Spec.hs
+++ b/components/tracer-sidecar/test/Spec.hs
@@ -9,12 +9,13 @@
 module Spec (spec)
 where
 
-import App (tailJsonLinesFromTracerLogDir)
+import App (tailAmaruLogDir, tailJsonLinesFromTracerLogDir)
 import Cardano.Antithesis.LogMessage
     ( LogMessage (..)
     , LogMessageData (..)
     , NewTipSelectView (..)
     , Severity (..)
+    , mkAmaruLogMessage
     )
 import Cardano.Antithesis.Sidecar
     ( Output (..)
@@ -37,6 +38,7 @@ import Data.Aeson
     , eitherDecodeStrict
     , encode
     , object
+    , (.=)
     )
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
@@ -81,7 +83,7 @@ spec = do
             let outputs =
                     sdkAssertions
                         $ runSynthetic
-                            (mkSpec 1 (Just "amaru-consumer.example"))
+                            (mkSpec 1 (Just "amaru-consumer.example") False)
                             [ addedToCurrentChain "amaru-consumer.example" 10 "seed"
                             , addedToCurrentChain "p1.example" 11 "producer-tip"
                             , addedToCurrentChain "amaru-consumer.example" 11 "producer-tip"
@@ -92,7 +94,7 @@ spec = do
             let outputs =
                     sdkAssertions
                         $ runSynthetic
-                            (mkSpec 1 (Just "amaru-consumer.example"))
+                            (mkSpec 1 (Just "amaru-consumer.example") False)
                             [ addedToCurrentChain "amaru-consumer.example" 10 "seed"
                             , addedToCurrentChain "amaru-relay-1.example" 11 "producer-tip"
                             , addedToCurrentChain "amaru-consumer.example" 11 "producer-tip"
@@ -103,7 +105,7 @@ spec = do
             let outputs =
                     sdkAssertions
                         $ runSynthetic
-                            (mkSpec 1 (Just "amaru-consumer.example"))
+                            (mkSpec 1 (Just "amaru-consumer.example") False)
                             [ addedToCurrentChain "amaru-consumer.example" 10 "seed"
                             , addedToCurrentChain "p1.example" 11 "producer-tip"
                             , addedToCurrentChain "amaru-consumer.example" 10 "seed"
@@ -116,15 +118,277 @@ spec = do
             let outputs =
                     sdkAssertions
                         $ runSynthetic
-                            (mkSpec 1 Nothing)
+                            (mkSpec 1 Nothing False)
                             [ addedToCurrentChain "p1.example" 11 "producer-tip"
                             ]
             outputs
                 `shouldNotSatisfy` any (assertionDeclared convergencePropertyName)
 
+    describe "amaru stdout scored properties" $ do
+        it "P1: Consensus died fails the fatal invariant with full evidence" $ do
+            let line = "ERROR amaru::cmd::node::run: Consensus died, restarting"
+                outputs = runAmaru [amaruEvent "amaru-relay-1" line]
+                failures = filter (assertionFailed "no fatal amaru consensus logs") outputs
+            failures `shouldSatisfy` (not . null)
+            case failures of
+                (f : _) ->
+                    assertionField "details" f
+                        `shouldBe` Just
+                            ( object
+                                [ "source" .= ("amaru-container-stdout" :: Text)
+                                , "host" .= ("amaru-relay-1" :: Text)
+                                , "message" .= line
+                                ]
+                            )
+                [] -> expectationFailure "no invariant failure emitted"
+
+        it
+            "P2: attempted roll back in the future fails on relay-2 with evidence"
+            $ do
+                let line = "WARN attempted roll back in the future by 3 slots"
+                    outputs = runAmaru [amaruEvent "amaru-relay-2" line]
+                    failures = filter (assertionFailed "no fatal amaru consensus logs") outputs
+                failures `shouldSatisfy` (not . null)
+                case failures of
+                    (f : _) ->
+                        assertionField "details" f
+                            `shouldBe` Just
+                                ( object
+                                    [ "source" .= ("amaru-container-stdout" :: Text)
+                                    , "host" .= ("amaru-relay-2" :: Text)
+                                    , "message" .= line
+                                    ]
+                                )
+                    [] -> expectationFailure "no invariant failure emitted"
+
+        it "P3: case-sensitive variant casings do not fail the invariant" $ do
+            let outputs =
+                    runAmaru
+                        [ amaruEvent "amaru-relay-1" "consensus died"
+                        , amaruEvent "amaru-relay-1" "CONSENSUS DIED"
+                        , amaruEvent "amaru-relay-1" "Attempted Roll Back In The Future"
+                        ]
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionFailed "no fatal amaru consensus logs")
+
+        it "P3b: near-miss words do not fail the invariant" $ do
+            let outputs =
+                    runAmaru
+                        [ amaruEvent "amaru-relay-1" "consensus layer started"
+                        , amaruEvent "amaru-relay-1" "rollback not needed"
+                        ]
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionFailed "no fatal amaru consensus logs")
+
+        it
+            "P4: ordinary line hits liveness; invariant declared but not failed"
+            $ do
+                let outputs =
+                        runAmaru [amaruEvent "amaru-relay-1" "INFO starting amaru node"]
+                outputs `shouldSatisfy` any (assertionHit "amaru stdout observed")
+                outputs
+                    `shouldSatisfy` any
+                        (assertionDeclared "no fatal amaru consensus logs")
+                outputs
+                    `shouldNotSatisfy` any
+                        (assertionFailed "no fatal amaru consensus logs")
+
+        it "P5: enabled mode declares both properties" $ do
+            let outputs =
+                    runAmaru [amaruEvent "amaru-relay-1" "INFO startup"]
+            outputs
+                `shouldSatisfy` any
+                    (assertionDeclared "amaru stdout observed")
+            outputs
+                `shouldSatisfy` any
+                    (assertionDeclared "no fatal amaru consensus logs")
+
+        it "P6: disabled mode declares neither property" $ do
+            let outputs =
+                    sdkAssertions
+                        $ runSynthetic
+                            (mkSpec 1 Nothing False)
+                            [addedToCurrentChain "p1.example" 11 "tip"]
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionDeclared "amaru stdout observed")
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionDeclared "no fatal amaru consensus logs")
+
+        it "P7: two fatal lines emit exactly one invariant failure" $ do
+            let outputs =
+                    runAmaru
+                        [ amaruEvent "amaru-relay-1" "Consensus died"
+                        , amaruEvent "amaru-relay-2" "Consensus died again"
+                        ]
+                failures =
+                    filter (assertionFailed "no fatal amaru consensus logs") outputs
+            length failures `shouldBe` 1
+
+        it "P8: amaru fatal line does not pollute existing properties" $ do
+            let outputs =
+                    runAmaru
+                        [ amaruEvent
+                            "amaru-relay-1"
+                            "ERROR Consensus died"
+                        ]
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionFailed "no critical logs")
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionFailed "cluster fork depth < k")
+
+    describe "amaru stdout adapter" $ do
+        it
+            "P10: adapter normalizes filename to host, strips newline, sets source"
+            $ do
+                let msg =
+                        mkAmaruLogMessage
+                            (UTCTime (fromGregorian 2026 7 28) 0)
+                            "amaru-relay-1.log"
+                            "INFO starting\n"
+                case msg of
+                    LogMessage{host = h, details = AmaruStdout{amaruSource, amaruMessage}} -> do
+                        h `shouldBe` "amaru-relay-1"
+                        amaruSource `shouldBe` "amaru-container-stdout"
+                        amaruMessage `shouldBe` "INFO starting"
+                    _ -> expectationFailure "expected AmaruStdout details"
+
+        it "P11: adapter severity does not manufacture a critical-log finding" $ do
+            let msg =
+                    mkAmaruLogMessage
+                        (UTCTime (fromGregorian 2026 7 28) 0)
+                        "amaru-relay-1.log"
+                        "ERROR something bad\n"
+                amaruSpec = mkSpec 1 Nothing True
+                outputs =
+                    sdkAssertions
+                        $ snd
+                        $ processMessages
+                            amaruSpec
+                            (initialState amaruSpec)
+                            [msg]
+            outputs
+                `shouldNotSatisfy` any
+                    (assertionFailed "no critical logs")
+
+    describe "amaru stdout file ingestion" $ do
+        it
+            "P12: file created after watcher startup is discovered and normalized"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir dir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 500000
+                writeFile (dir </> "amaru-relay-1.log") "INFO starting amaru\n"
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                case msgs of
+                    [LogMessage{host = h, details = AmaruStdout{amaruMessage}}] -> do
+                        amaruMessage `shouldBe` "INFO starting amaru"
+                        h `shouldBe` "amaru-relay-1"
+                    _ ->
+                        expectationFailure
+                            $ "expected exactly one AmaruStdout message, got "
+                                <> show (length msgs)
+
+        it "P13: line appended to already-followed file is ingested"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                let fp = dir </> "amaru-relay-1.log"
+                writeFile fp "INFO first line\n"
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir dir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 1500000
+                _ <- system $ "echo 'INFO second line' >> " <> fp
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                let lines_ =
+                        [ line
+                        | LogMessage{details = AmaruStdout{amaruMessage = line}} <-
+                            msgs
+                        ]
+                lines_ `shouldBe` ["INFO first line", "INFO second line"]
+
+        it "P14: pre-existing file is ingested from the beginning"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                writeFile (dir </> "amaru-relay-1.log") "INFO already here\n"
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir dir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                length msgs `shouldBe` 1
+
+        it "P15: both relay identities accepted with distinct hosts"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                writeFile (dir </> "amaru-relay-1.log") "INFO relay one\n"
+                writeFile (dir </> "amaru-relay-2.log") "INFO relay two\n"
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir dir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                let hosts = sort [h | LogMessage{host = h} <- msgs]
+                hosts `shouldBe` ["amaru-relay-1", "amaru-relay-2"]
+
+        it "P17: missing directory does not terminate the watcher"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                let watchDir = dir </> "not-yet-created"
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir watchDir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 1500000
+                _ <- system $ "mkdir -p " <> watchDir
+                writeFile
+                    (watchDir </> "amaru-relay-1.log")
+                    "INFO recovered\n"
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                length msgs `shouldBe` 1
+
+        it "P16: non-relay files are ignored"
+            $ withSystemTempDirectory "amaru-logs"
+            $ \dir -> do
+                writeFile (dir </> "other.log") "INFO not a relay\n"
+                writeFile (dir </> "amaru-relay-3.log") "INFO wrong relay\n"
+                r <- newMVar []
+                thread <-
+                    async
+                        $ tailAmaruLogDir dir
+                        $ \msg -> modifyMVar_ r $ \msgs -> pure (msgs <> [msg])
+                threadDelay 1500000
+                cancel thread
+                msgs <- readMVar r
+                length msgs `shouldBe` 0
+
     it "processMessages"
         $ let
-            propSpec = mkSpec 3 Nothing
+            propSpec = mkSpec 3 Nothing False
             (_finalState, actualVals) = processMessages propSpec (initialState propSpec) msgs
             msgs = mapMaybe decodeStrict' input
           in
@@ -175,6 +439,12 @@ assertionDeclared = assertionIdIs
 assertionHit :: Text -> Value -> Bool
 assertionHit name v =
     assertionIdIs name v && assertionBool "hit" v == Just True
+
+assertionFailed :: Text -> Value -> Bool
+assertionFailed name v =
+    assertionIdIs name v
+        && assertionBool "hit" v == Just True
+        && assertionBool "condition" v == Just False
 
 assertionIdIs :: Text -> Value -> Bool
 assertionIdIs name v =
@@ -285,3 +555,38 @@ simulateRestartingNodeTracer nFiles nValues dir = do
     let files = generateFilenamesInLexicalOrder dir nFiles
     generateStreamOfFiles files $ \fp -> do
         generateAFileWithJSONLines fp [1 .. nValues]
+
+-- Amaru stdout RED-A surrogate helpers ----------------------------------------
+
+-- | Build a normalized Amaru stdout event for testing.
+amaruEvent :: Text -> Text -> LogMessage
+amaruEvent relay line =
+    LogMessage
+        { at = UTCTime (fromGregorian 2026 7 28) 0
+        , ns = "amaru"
+        , details =
+            AmaruStdout
+                { amaruSource = "amaru-container-stdout"
+                , amaruMessage = line
+                }
+        , sev = Info
+        , thread = "test"
+        , host = relay
+        , kind = "AmaruStdout"
+        , json = evidence
+        }
+  where
+    evidence =
+        object
+            [ "source" .= ("amaru-container-stdout" :: Text)
+            , "host" .= relay
+            , "message" .= line
+            ]
+
+-- | Run amaru events through the enabled spec and collect SDK
+-- assertions.
+runAmaru :: [LogMessage] -> [Value]
+runAmaru msgs =
+    sdkAssertions $ snd $ processMessages spec (initialState spec) msgs
+  where
+    spec = mkSpec 1 Nothing True

--- a/gate.sh
+++ b/gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Mechanical gate for the feat/consumer-convergence-property PR (#180).
-# The tracer-sidecar test suite is the RED->GREEN harness for the property.
+# Mechanical gate for amaru fatal-log ingestion and scoring (#193).
+# The tracer-sidecar test suite is the RED -> GREEN harness for the ingestion
+# path and property; compose validation protects the deployment wiring.
 set -euo pipefail
 
 git diff --check
@@ -13,14 +14,8 @@ else
   ( cd components/tracer-sidecar && cabal test --test-show-details=streaming )
 fi
 
-# Compose still validates with the tracer-sidecar env + image bump (slice 2).
+# The cardano_amaru deployment must remain valid as log routing evolves.
 INTERNAL_NETWORK=false docker compose \
   -f testnets/cardano_amaru/docker-compose.yaml config >/dev/null
-
-# master must NOT gain the consumer convergence env (would redden master runs).
-if grep -nE 'AMARU_CONSUMER_HOST' testnets/cardano_node_master/docker-compose.yaml >/dev/null 2>&1; then
-  echo "gate: cardano_node_master must not set AMARU_CONSUMER_HOST" >&2
-  exit 1
-fi
 
 echo "gate: OK"

--- a/gate.sh
+++ b/gate.sh
@@ -6,10 +6,15 @@ set -euo pipefail
 
 git diff --check
 
-# tracer-sidecar property tests (hspec + golden). Prefer the hermetic nix build
-# of the test derivation; fall back to cabal in the component dir.
+# tracer-sidecar property tests (hspec + golden). Prefer the hermetic Nix build
+# and then execute the produced test binary from the component directory, which
+# the golden test uses as its working directory. Fall back to cabal otherwise.
 if command -v nix >/dev/null 2>&1 && [ -f components/tracer-sidecar/flake.nix ]; then
-  ( cd components/tracer-sidecar && nix build --quiet '.#tracer-sidecar-tests' )
+  (
+    cd components/tracer-sidecar
+    test_out=$(nix build --quiet --no-link --print-out-paths '.#tracer-sidecar-tests')
+    "$test_out/bin/test"
+  )
 else
   ( cd components/tracer-sidecar && cabal test --test-show-details=streaming )
 fi

--- a/specs/193-amaru-fatal-log-ingestion/checklists/requirements.md
+++ b/specs/193-amaru-fatal-log-ingestion/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Score fatal Amaru container logs
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-07-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in user scenarios or success criteria
+- [x] Focused on operator and report-reader value
+- [x] Written for technical stakeholders without code-level prescriptions
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover failure, route integrity, and deployment
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] Code-level decisions are deferred to plan.md and contracts/
+
+## Notes
+
+- The ingestion decision and sink-failure construction were explicitly ruled
+  before this checklist was completed.

--- a/specs/193-amaru-fatal-log-ingestion/contracts/amaru-log-event.md
+++ b/specs/193-amaru-fatal-log-ingestion/contracts/amaru-log-event.md
@@ -1,0 +1,52 @@
+# Contract: normalized Amaru stdout event and assertions
+
+## Accepted files
+
+The Amaru log directory contains only per-relay files named:
+
+- `amaru-relay-1.log`
+- `amaru-relay-2.log`
+
+Other entries are ignored. Each complete line becomes one event; the newline is
+not part of `message`.
+
+## Normalized evidence object
+
+The SDK failure's `details` value must preserve this logical shape:
+
+```json
+{
+  "source": "amaru-container-stdout",
+  "host": "amaru-relay-1",
+  "message": "ERROR amaru::cmd::node::run: Consensus died, ..."
+}
+```
+
+Additional generic event fields may be present, but these three fields and their
+contents are normative.
+
+## Property identifiers
+
+### `amaru stdout observed`
+
+- Type: Sometimes
+- Required: yes
+- Declared only when Amaru ingestion is configured
+- Hit: first normalized Amaru stdout event
+
+### `no fatal amaru consensus logs`
+
+- Type: AlwaysOrUnreachable
+- Declared only when Amaru ingestion is configured
+- Fails on a case-sensitive substring match for either:
+  - `Consensus died`
+  - `attempted roll back in the future`
+- Failure details: the normalized evidence object above
+- Ordinary lines: no failure output
+
+## Configuration contract
+
+- Absence of the Amaru log-directory configuration means neither Amaru-specific
+  property is declared.
+- Presence means both properties are declared and the directory watcher starts.
+- Existing cardano-tracer event processing remains unchanged.

--- a/specs/193-amaru-fatal-log-ingestion/data-model.md
+++ b/specs/193-amaru-fatal-log-ingestion/data-model.md
@@ -1,0 +1,59 @@
+# Data model: Amaru fatal-log ingestion
+
+## Amaru stdout event
+
+One normalized event per complete relay-output line.
+
+| Field | Meaning | Validation |
+|---|---|---|
+| ingestion time | Time the sidecar read the line | Valid UTC timestamp |
+| namespace | Event family | Exactly `Amaru.Stdout` |
+| kind | Rule-dispatch tag | Exactly `AmaruStdout` |
+| source | Original transport | Exactly `amaru-container-stdout` |
+| host | Relay identity derived from the file name | `amaru-relay-1` or `amaru-relay-2` |
+| message | Original line | Preserved completely, excluding line terminator |
+
+The normalized event retains the existing generic log fields so it can pass
+through the current sidecar rule engine. Its generic severity is informational;
+the dedicated fatal-signature rule owns classification.
+
+## Assertion state
+
+The existing `unreachedAssertions` set provides one-shot state for both new
+rules:
+
+- `amaru stdout observed` starts unreached and emits its hit on the first Amaru
+  stdout event.
+- `no fatal amaru consensus logs` starts armed and emits its failure on the
+  first matching line.
+
+No new persistent state or external database is introduced.
+
+## Relay log files
+
+| File | Writer | Readers | Lifetime |
+|---|---|---|---|
+| `amaru-relay-1.log` | relay 1 PID 1 | mirror and tracer-sidecar | Docker volume lifetime |
+| `amaru-relay-2.log` | relay 2 PID 1 | mirror and tracer-sidecar | Docker volume lifetime |
+
+Files are append-only regular files. The mirror is never on the writer's file
+descriptor path.
+
+## State transitions
+
+```text
+no relay file
+  -> file created by relay command
+  -> Amaru appends line
+  -> mirror copies line to container stdout
+  -> tracer-sidecar normalizes line
+  -> route-liveness property hits (first event only)
+  -> fatal invariant either remains armed or fails (first signature only)
+```
+
+Mirror failure is an independent transition:
+
+```text
+mirror active -> mirror killed/paused -> Amaru keeps appending regular file
+              -> supervisor starts replacement -> stdout mirroring resumes
+```

--- a/specs/193-amaru-fatal-log-ingestion/plan.md
+++ b/specs/193-amaru-fatal-log-ingestion/plan.md
@@ -1,0 +1,206 @@
+# Implementation Plan: Score fatal Amaru container logs
+
+**Branch**: `fix/amaru-fatal-log-ingestion` | **Date**: 2026-07-28 | **Spec**: [spec.md](spec.md)
+**Input**: GitHub issue #193 and approved design research in [research.md](research.md)
+
+## Summary
+
+Extend tracer-sidecar with an optional plain-line Amaru input that normalizes
+per-relay output into the existing event/rule pipeline. When configured, the
+sidecar declares a required route-liveness property plus an invariant that
+fails on either accepted fatal consensus signature.
+
+In `cardano_amaru`, each relay writes stdout/stderr directly to a per-relay
+regular file on a shared volume. A supervised `tail -F` mirrors that file back
+to container stdout. The assertion service mounts the volume read-only. The
+regular-file primary removes SIGPIPE and pipe-backpressure coupling between
+Amaru and the mirror.
+
+## Technical Context
+
+**Language/Version**: Haskell 2010 on GHC 9.6; POSIX `/bin/sh` in the pinned Amaru image
+**Primary Dependencies**: existing `aeson`, `async`, `bytestring`, `text`, `time`; Docker Compose
+**Storage**: two append-only regular files on a named Docker volume
+**Testing**: Hspec, Nix-built tracer-sidecar test derivation, Docker Compose smoke, one-hour Antithesis run
+**Target Platform**: Linux containers in local Docker and Antithesis
+**Project Type**: event-processing sidecar plus testnet deployment configuration
+**Performance Goals**: line-at-a-time processing; combined three-hour log growth normally 4-6 MB
+**Constraints**: no Docker socket; no Amaru logging change; mirror death cannot kill or wedge Amaru; `amaru-consumer-seed` pin untouched
+**Scale/Scope**: two relay files, three-hour runs, conservative 250 MB burst-growth bound
+
+## Constitution Check
+
+### Pre-design
+
+- **I Composer-first workload**: PASS — no new workload or composer command.
+- **II SDK instrumentation**: PASS — input liveness and fatal invariant are
+  both explicit scored properties.
+- **III Short-running commands**: PASS — no composer commands or polling
+  validators are introduced.
+- **IV Duration-robust**: PASS — file discovery and tailing do not depend on
+  scheduling duration; growth is measured for three hours.
+- **V Realistic workload**: PASS — the route consumes real Amaru output.
+- **VI Bisect-safe commits**: PASS — code/tests land together, then deployment
+  wiring pins that preceding code commit.
+- **VII Image tag hygiene**: PASS — compose references the preceding code
+  commit, which exists at `components/tracer-sidecar/`.
+- **Custom testnet boundary**: PASS — all inputs are local named volumes.
+- **Minimal sidecar image**: PASS — no sidecar shell dependency is added.
+- **Hard gate**: REQUIRED — launch the one-hour Antithesis run exactly once,
+  compare its findings with baseline, and do not shop for a cleaner run.
+  Detector implementation can complete, but the PR remains draft/not-ready
+  pending the parent-owned governance decision.
+
+### Post-design
+
+All design checks remain PASS. The current local image-command discrepancy is
+tracked as #196; the final Nix-built image has the entrypoint contract expected
+by compose. This ticket neither weakens nor claims an exception from the
+repository's no-new-findings gate. Because that gate cannot distinguish a
+newly introduced regression from a newly exposed pre-existing failure, final
+readiness is explicitly handed to the parent for governance resolution.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/193-amaru-fatal-log-ingestion/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── amaru-log-event.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source and deployment
+
+```text
+components/tracer-sidecar/
+├── README.md
+├── src/
+│   ├── App.hs
+│   └── Cardano/Antithesis/
+│       ├── LogMessage.hs
+│       └── Sidecar.hs
+└── test/
+    └── Spec.hs
+
+testnets/cardano_amaru/
+└── docker-compose.yaml
+```
+
+**Structure Decision**: Reuse the existing tracer-sidecar package and rule
+engine. Do not add a collector service, dependency, or general-purpose Docker
+logging layer.
+
+## Event and rule design
+
+- Add an `AmaruStdout` payload to the existing log-message model.
+- Provide a deterministic adapter from ingestion time, relay filename, and raw
+  line to the existing generic event, preserving the normative evidence fields
+  in [contracts/amaru-log-event.md](contracts/amaru-log-event.md).
+- Read optional `AMARU_LOG_DIR` in `App.main`.
+- Generalize the existing file-following seam only as far as needed to discover
+  fixed `amaru-relay-[12].log` files and process appended lines.
+- Pass an Amaru-ingestion-enabled flag into `mkSpec`; when false, neither new
+  property is declared.
+- When true, add:
+  - `sometimes "amaru stdout observed"` on any `AmaruStdout`;
+  - `alwaysOrUnreachable "no fatal amaru consensus logs"` rejecting either
+    exact signature.
+- Keep existing cardano-tracer rules and golden output unchanged when ingestion
+  is disabled.
+
+## Routing design
+
+For each Amaru relay command:
+
+1. Create the shared log directory and its per-relay regular file.
+2. Start a background supervisor that launches `tail -n 0 -F` to the
+   container's original stdout, records the active mirror PID, waits for exit,
+   and restarts after one second.
+3. `exec /bin/amaru node run ... >>relay.log 2>&1`.
+
+Amaru remains PID 1 and owns a regular-file descriptor. The mirror reads the
+file; it is not on Amaru's writer path. Mount the new volume read-write into
+both relays and read-only into tracer-sidecar, and set `AMARU_LOG_DIR`.
+
+## Slices
+
+### Slice 1 - sidecar ingestion and scored properties
+
+**Owned files**:
+
+- `components/tracer-sidecar/src/App.hs`
+- `components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs`
+- `components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs`
+- `components/tracer-sidecar/test/Spec.hs`
+- `components/tracer-sidecar/README.md`
+
+**RED**: Add focused tests for ordinary, both fatal signatures, disabled
+configuration, and appended-file ingestion. Run them before implementation and
+preserve the failing raw output.
+
+**GREEN**: Implement the adapter, watcher, conditional declarations, and
+documentation. Run focused tests, formatting/lint, then `./gate.sh`.
+
+**Commit**: `fix(tracer-sidecar): score fatal amaru logs`
+
+### Slice 2 - fault-contained compose routing and image pin
+
+**Owned file**:
+
+- `testnets/cardano_amaru/docker-compose.yaml`
+
+**Dependency**: Slice 1 commit is pushed and its hash is used as the
+tracer-sidecar image tag.
+
+Implement the shared volume, regular-file primary, supervised stdout mirror,
+read-only sidecar mount, configuration, and image pin. Preserve the
+`amaru-consumer-seed` image line exactly.
+
+Verify compose resolution, build/load the Slice 1 image for local proof, rerun
+the mirror-kill proof against the final construction, prove both live ingestion
+directions, and run the mechanical gate. Push only after navigator approval and
+orchestrator verification.
+
+**Commit**: `fix(cardano_amaru): route amaru logs to sidecar`
+
+## Final verification
+
+1. Wait for all PR checks, including the standard `cardano_amaru` compose
+   smoke, to finish green.
+2. Independently rerun the final gate with raw evidence capture.
+3. Verify compose diff leaves the forbidden consumer-seed pin unchanged.
+4. Verify the final live route and mirror-kill evidence from raw files.
+5. Launch exactly one one-hour Antithesis run on the branch, confirm both
+   properties surface, and record `findings_new` against the accepted main
+   baseline. Never retry to select a clean schedule.
+6. Refresh the human-readable PR body, including the incidentally-correct
+   Nix-image pairing for #196.
+7. Run the finalization audit and leave `gate.sh` plus the PR's draft/not-ready
+   state in place. If the fatal property fires, report it as successful detector
+   evidence and hand the not-ready PR to the parent. If it does not, state that
+   the deterministic proofs—not the clean schedule—prove the detector. In
+   either case, await the parent-owned governance call; do not merge or close.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Fatal property passes vacuously | Required `amaru stdout observed` property |
+| Mirror death sends SIGPIPE or causes backpressure | Amaru writes a regular file; mirror is a separate reader |
+| Mirror dies permanently | Supervisor restarts it; kill proof checks recovery |
+| Log volume fills | Measured 4-6 MB expectation and <250 MB sustained-burst bound |
+| Sidecar starts before relay file | File watcher discovers files created later |
+| Sidecar restart rereads a fatal line | Failure remains failing; first-failure suppression resets only per process |
+| Wrong image runs | Compose pin references Slice 1 commit; publish-images gate |
+| Sibling #192 compose race | Diff-police and preserve `amaru-consumer-seed` line byte-for-byte |
+| Local/deployed image command mismatch | #196 owns discrepancy; final Nix image supplies expected entrypoint |
+| A real upstream fatal becomes a new finding | Run once, report it as detector success, keep the PR not-ready, and hand governance to the parent |

--- a/specs/193-amaru-fatal-log-ingestion/quickstart.md
+++ b/specs/193-amaru-fatal-log-ingestion/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: verify Amaru fatal-log ingestion
+
+All evidence commands use `set -o pipefail`, capture stdout and stderr to raw
+files, record real exit codes and UTC timestamps, and hash artifacts only after
+the producing command has completed.
+
+## Focused tests
+
+From `components/tracer-sidecar`:
+
+```bash
+nix develop -c just test "amaru stdout"
+nix develop -c just test "fatal amaru"
+```
+
+Required signals:
+
+- the route-liveness property is declared and hit for an ordinary line;
+- `Consensus died` emits the fatal invariant failure;
+- `attempted roll back in the future` emits the same failure;
+- an ordinary line emits no fatal invariant failure;
+- a line appended to a watched relay file is normalized with host and message.
+
+## Mechanical gate
+
+From the repository root:
+
+```bash
+./gate.sh
+```
+
+## Compose contract
+
+```bash
+INTERNAL_NETWORK=false docker compose \
+  -f testnets/cardano_amaru/docker-compose.yaml config >/dev/null
+```
+
+Verify the `amaru-consumer-seed` image line is byte-identical to the base.
+
+## Mirror fault proof
+
+On an isolated fresh project:
+
+1. Confirm PID 1 is `/bin/amaru node run`, stdout points to a regular file, and
+   restart count is zero.
+2. Read the active mirror PID and terminate only that process.
+3. Within five seconds, confirm a different mirror PID is alive.
+4. Confirm the container is still running, the Amaru host PID is unchanged,
+   restart count is still zero, and stdout still points to the regular file.
+5. Append a controlled marker to the shared file and confirm it appears in
+   Docker logs.
+
+## Live ingestion proof
+
+With the final image and compose route:
+
+1. Confirm an ordinary relay line exists in the shared file and the route
+   property is hit in `sdk.jsonl`.
+2. Append a controlled fatal fixture to a relay file through the mounted
+   boundary.
+3. Copy `sdk.jsonl` out of tracer-sidecar and confirm
+   `no fatal amaru consensus logs` has `hit=true` with source, host, and the
+   original line.
+4. Recreate the project without the fatal fixture and confirm the route property
+   hits while the fatal invariant emits no failure.
+
+## Deployment gates
+
+- `publish-images` green for the code-commit image.
+- `Compose smoke test` green for `cardano_amaru`.
+- Exactly one one-hour Antithesis run lists both properties and records
+  `findings_new` against the accepted baseline. Do not retry to select a clean
+  schedule. A naturally observed fatal-property failure is successful detector
+  evidence and leaves the PR not-ready for the parent-owned governance call;
+  a clean schedule does not replace the deterministic both-way proof.

--- a/specs/193-amaru-fatal-log-ingestion/research.md
+++ b/specs/193-amaru-fatal-log-ingestion/research.md
@@ -1,0 +1,105 @@
+# Research: Amaru fatal-log ingestion
+
+## Decision 1: shared regular-file route
+
+**Decision**: Each relay writes stdout and stderr directly to its own regular
+file on a shared Docker volume. Tracer-sidecar mounts that volume read-only and
+tails the files.
+
+**Rationale**: This stays within the repository's existing shared-volume
+sidecar pattern, needs no Docker control socket, and does not change Amaru's
+logging implementation.
+
+**Alternatives considered**:
+
+- Docker Engine API collector: rejected because it exposes the control socket,
+  assumes platform-specific availability, and adds reconnect/API complexity.
+- Docker logging driver receiver: rejected because daemon support is unproven
+  and it risks breaking the container-output stream Antithesis already indexes.
+- Upstream structured logging: rejected because changing Amaru is an explicit
+  non-goal.
+
+## Decision 2: regular file is primary; stdout is a supervised mirror
+
+**Decision**: Amaru's descriptors point to the regular file. A background
+supervisor runs `tail -F` to mirror new file content to the container's original
+stdout and restarts the mirror after exit.
+
+**Rationale**: A FIFO makes Amaru depend on a live reader: if `tee` dies, Amaru
+can receive `SIGPIPE`; if the reader pauses while a dummy descriptor keeps the
+FIFO open, the pipe can fill and wedge Amaru. A regular file removes both
+couplings. Killing or pausing the mirror affects only search visibility during
+that interval; scoring continues from the shared file.
+
+**Demonstrated result**: In an isolated fresh compose deployment, the active
+mirror was killed while real Amaru ran as PID 1. The mirror PID changed from 12
+to 171, Amaru retained the same host PID, the container remained running with
+restart count 0, its output descriptor remained a regular file, the file grew,
+and a post-restart marker reached Docker logs. The command exited 0.
+
+## Decision 3: normalize plain lines into the existing event pipeline
+
+**Decision**: Add an Amaru-stdout payload to the existing sidecar log-event
+model. The adapter supplies ingestion time, `Amaru.Stdout` namespace,
+source/host/raw-line evidence, and a non-critical generic severity. The existing
+rule engine processes the normalized event.
+
+**Rationale**: This reuses declaration, first-failure suppression, state, and
+SDK output without refactoring every existing node-log rule to a new sum type.
+The dedicated fatal property carries severity semantics; ordinary Amaru lines
+must not accidentally trip the existing cardano-node critical-log property.
+
+## Decision 4: guard against vacuous success
+
+**Decision**: When Amaru log ingestion is configured, declare both:
+
+- required Sometimes property `amaru stdout observed`; and
+- AlwaysOrUnreachable property `no fatal amaru consensus logs`.
+
+**Rationale**: The fatal invariant alone would pass if the route silently
+disconnected, recreating the defect. The required liveness property makes the
+input path itself scored.
+
+## Decision 5: two commits for image hygiene
+
+**Decision**:
+
+1. Land sidecar code, tests, and component documentation.
+2. Route compose logs and pin tracer-sidecar to the preceding code commit.
+
+**Rationale**: The image publisher resolves compose tags to commits. A compose
+commit cannot self-reference its own hash, so the image source must be a
+preceding commit.
+
+## Log growth
+
+Two measured samples bound the three-hour expectation:
+
+- Isolated fresh deployment: 27,695 combined relay bytes over 77 seconds,
+  projecting to 3,884,493 bytes over three hours.
+- Baseline Antithesis path: 388,368 combined relay bytes over 704 virtual
+  seconds, projecting to roughly 6.0 MB over three hours.
+
+The densest observed fatal burst produced 388,368 bytes in 20.7 seconds. If
+that burst rate were sustained continuously for three hours, it would be about
+203 MB. The plan uses 250 MB as a conservative stress bound.
+
+## Related live-boundary defect
+
+A fresh local deployment of the current `tracer-sidecar:e01ad90` compose/image
+pair cannot start the service because Compose replaces a full image `Cmd` with
+only the directory argument. The same compose shape worked in a validated
+Antithesis deployment, so the local/platform discrepancy is tracked separately
+as cardano-node-antithesis#196. This ticket uses the Nix-built image from its
+code commit, whose entrypoint contract matches the compose argument.
+
+## One-shot deployment evidence and readiness
+
+The required one-hour Antithesis run is launched exactly once. Retrying until a
+schedule omits the known upstream fatal would shop for green and manufacture a
+misleading readiness signal. If the new property catches the pre-existing
+failure, that is successful detector evidence even though the repository's
+no-new-findings gate keeps the PR not-ready. If it does not occur naturally,
+the controlled fixture and live-injection proofs remain authoritative. This
+ticket neither weakens the gate nor grants itself an exception; the parent owns
+the governance escalation and final readiness call.

--- a/specs/193-amaru-fatal-log-ingestion/spec.md
+++ b/specs/193-amaru-fatal-log-ingestion/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: Score fatal Amaru container logs
+
+**Feature Branch**: `fix/amaru-fatal-log-ingestion`
+**Created**: 2026-07-28
+**Status**: Approved
+**Input**: GitHub issue #193 under `lambdasistemi/amaru-bootstrap#55`
+
+## Context
+
+Amaru relays report fatal consensus events to container output, while the
+scored assertion service consumes a different structured event stream. This
+allows repeated consensus failures to coexist with a green property board when
+the process recovers without exiting.
+
+This feature establishes a durable path from each Amaru relay's output into the
+scored event stream. It also proves that the path is alive, fails the invariant
+for either known fatal signature, remains green for ordinary output, and does
+not make Amaru's survival depend on the auxiliary output mirror.
+
+## User Scenarios & Testing
+
+### User Story 1 - Fatal consensus output becomes a scored failure (Priority: P1)
+
+As an Antithesis report reader, I need a fatal Amaru consensus line to fail a
+named property even when the relay process and container stay alive, so a green
+report means the failure was not observed rather than merely hidden.
+
+**Why this priority**: This is the core visibility gap described by issue #193.
+
+**Independent Test**: Process one ordinary Amaru line and one line for each
+fatal signature. The ordinary line must not emit the invariant failure; each
+fatal line must emit it with the relay identity and original line attached.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Amaru relay emits `Consensus died`, **When** the line enters the
+   scored stream, **Then** the fatal-consensus invariant fails.
+2. **Given** an Amaru relay emits `attempted roll back in the future`, **When**
+   the line enters the scored stream, **Then** the same invariant fails.
+3. **Given** an Amaru relay emits ordinary startup or progress output, **When**
+   the line enters the scored stream, **Then** the invariant is declared but
+   does not fail.
+
+---
+
+### User Story 2 - The ingestion route is observable and fault-contained (Priority: P1)
+
+As a test operator, I need explicit evidence that Amaru output reaches the
+scored stream and that failure of the auxiliary output mirror cannot kill or
+wedge Amaru.
+
+**Why this priority**: A fatal-property check that never receives input would
+recreate the defect, while a mirror coupled to Amaru could manufacture false
+relay failures.
+
+**Independent Test**: Prove a normal relay line reaches the ingestion service,
+kill the mirror process, and observe that the same Amaru process remains
+running with no container restart while a replacement mirror resumes output.
+
+**Acceptance Scenarios**:
+
+1. **Given** Amaru output routing is configured, **When** any relay line is
+   ingested, **Then** a required route-liveness property is hit.
+2. **Given** Amaru is running and the output mirror is killed, **When** the
+   supervisor replaces it, **Then** Amaru keeps the same process identity, the
+   container restart count stays unchanged, and output mirroring resumes.
+3. **Given** the mirror is unavailable or paused, **When** Amaru writes output,
+   **Then** Amaru writes to a regular file without a pipe dependency and cannot
+   receive a broken-pipe signal from the mirror.
+
+---
+
+### User Story 3 - The deployed testnet runs the exact scored path (Priority: P1)
+
+As a maintainer, I need the `cardano_amaru` profile to use the new assertion
+image and routing in a fresh deployment, so source-only success cannot be
+mistaken for deployed coverage.
+
+**Why this priority**: A property that is absent from the pinned image or a
+route that exists only in fixtures provides no production evidence.
+
+**Independent Test**: A fresh testnet deployment uses the new image, passes its
+standard smoke test, proves the file-to-assertion boundary in the live
+containers, and surfaces the properties in a one-hour Antithesis run.
+
+**Acceptance Scenarios**:
+
+1. **Given** the code commit has been published as an image, **When** the
+   `cardano_amaru` profile starts, **Then** both relay logs are mounted into the
+   assertion service and the expected properties are declared.
+2. **Given** a controlled fatal line is introduced through the live shared-log
+   boundary, **When** the assertion service consumes it, **Then** its output
+   contains the scored invariant failure.
+3. **Given** no fatal signature occurs during a healthy smoke, **When** the
+   standard smoke finishes, **Then** the testnet is green.
+
+### Edge Cases
+
+- The mirror exits, is killed, or is paused while Amaru continues producing
+  output.
+- The assertion service starts before either relay log file exists.
+- The assertion service restarts and sees existing relay log files.
+- A relay restarts and appends to its existing per-run log file.
+- An ordinary line contains the words `consensus` or `rollback` without either
+  exact fatal signature.
+- A three-hour run includes a short, high-volume fatal burst.
+- A fresh local deployment resolves image command metadata differently from a
+  deployed Antithesis run; this separate defect is tracked as issue #196.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Both Amaru relay output streams MUST reach the scored assertion
+  event stream through a documented, persistent route.
+- **FR-002**: Existing container-output observability MUST remain available
+  after the route is added.
+- **FR-003**: The route MUST declare and hit a required liveness property after
+  observing any Amaru relay line, preventing a disconnected route from
+  appearing green.
+- **FR-004**: A scored invariant MUST fail on `Consensus died`.
+- **FR-005**: The same scored invariant MUST fail on
+  `attempted roll back in the future`.
+- **FR-006**: Ordinary Amaru output MUST NOT fail the fatal-consensus
+  invariant.
+- **FR-007**: A scored failure MUST retain the source type, relay identity, and
+  complete original line as evidence.
+- **FR-008**: Failure or suspension of the output mirror MUST NOT terminate,
+  restart, or block the Amaru process.
+- **FR-009**: Killing the mirror during a real Amaru run MUST be demonstrated
+  with unchanged Amaru process identity and container restart count, followed
+  by successful mirror recovery.
+- **FR-010**: The new assertion behavior and the file-ingestion boundary MUST
+  have automated tests that are observed failing before implementation and
+  passing afterward.
+- **FR-011**: The deployed assertion image MUST resolve to a commit in this
+  branch's history and contain the new behavior.
+- **FR-012**: A fresh `cardano_amaru` compose smoke MUST pass with the final
+  routing and image pairing.
+- **FR-013**: Exactly one one-hour Antithesis run MUST be launched. It MUST
+  surface the new properties, record `findings_new` against the accepted
+  baseline, and MUST NOT be retried to select a cleaner schedule. A naturally
+  observed fatal-property failure is successful detector evidence for this
+  ticket, while final PR readiness remains a separate governance decision.
+- **FR-014**: The `amaru-consumer-seed` image pin MUST remain unchanged by this
+  ticket.
+- **FR-015**: The change MUST NOT modify Amaru's own logging implementation,
+  the cluster-fork assertion, or anything in `amaru-bootstrap`.
+
+### Key Entities
+
+- **Amaru output event**: One complete line with its relay identity, source
+  type, ingestion time, and original text.
+- **Route-liveness property**: Required evidence that at least one Amaru output
+  event reached the scored stream.
+- **Fatal-consensus invariant**: A scored invariant that fails once when either
+  accepted fatal signature is observed.
+- **Relay log file**: A per-relay, per-testnet-run append-only regular file used
+  as the primary output target and assertion-service input.
+- **Output mirror**: An auxiliary, supervised reader that copies the regular
+  file to container output without owning Amaru's write path.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Each of the two accepted fatal signatures produces the named
+  scored failure in 100% of focused test cases.
+- **SC-002**: Ordinary lines produce zero fatal-consensus failures while still
+  hitting the route-liveness property.
+- **SC-003**: Killing the active mirror yields a replacement within five
+  seconds, with the same Amaru process identity and zero added container
+  restarts.
+- **SC-004**: The automated ingestion test observes a line appended after the
+  watcher starts and preserves its relay identity and full contents.
+- **SC-005**: The standard `cardano_amaru` compose smoke exits 0 on the final
+  image and routing.
+- **SC-006**: The single one-hour deployed run lists both new properties and
+  records its findings comparison honestly. If the fatal property fires, the
+  PR remains not-ready and the result is handed to the parent as successful
+  detector evidence; if it does not, the deterministic both-way proof remains
+  the evidence that the property works.
+- **SC-007**: Expected combined relay-file growth over three hours remains
+  approximately 4-6 MB based on measured samples; even continuously
+  extrapolating the observed peak fatal burst remains below 250 MB.
+
+## Assumptions
+
+- Docker volumes are fresh per testnet run and have substantially more than
+  250 MB available.
+- Relay log output is line-oriented and the two fatal signatures remain
+  stable upstream identifiers for issue #1095.
+- Re-reading earlier lines after an assertion-service restart may repeat the
+  first failure in the new process lifetime but cannot turn a failing run
+  green.
+- The image-pairing discrepancy tracked in #196 is independent of the
+  ingestion logic; this ticket pins the Nix-built image containing its code.
+- The repository's no-new-findings readiness gate does not distinguish a
+  newly introduced regression from a newly visible pre-existing failure.
+  This ticket does not weaken or except itself from that gate; the parent owns
+  escalation of the final readiness decision.
+
+## Out of Scope
+
+- Fixing `pragma-org/amaru#1095`.
+- The `cluster fork depth < k` assertion tracked by #140.
+- General Docker-log collection for arbitrary services.
+- Rotation or retention policy for logs beyond this testnet's run lifetime.

--- a/specs/193-amaru-fatal-log-ingestion/tasks.md
+++ b/specs/193-amaru-fatal-log-ingestion/tasks.md
@@ -37,10 +37,10 @@ and yields a replacement mirror; live ordinary/fatal fixtures reach SDK output.
 
 ## Finalization - orchestrator-owned verification and PR metadata
 
-- [ ] T013 Verify all GitHub checks including `Compose smoke test` are green and preserve their URLs/results in the evidence record
-- [ ] T014 Independently rerun the final gate, audit raw mirror/ingestion proofs, and confirm the forbidden consumer-seed line is unchanged
-- [ ] T015 Launch exactly one one-hour `cardano_amaru` Antithesis run, confirm both new properties surface, record `findings_new` against the accepted main baseline, and never retry to select a cleaner schedule
-- [ ] T016 Refresh the human-readable PR body including #196's incidentally-correct image pairing; run finalization audit; retain `gate.sh` and draft/not-ready state; report the one-shot result and hand the readiness decision to the parent without merging
+- [X] T013 Verify all GitHub checks including `Compose smoke test` are green and preserve their URLs/results in the evidence record
+- [X] T014 Independently rerun the final gate, audit raw mirror/ingestion proofs, and confirm the forbidden consumer-seed line is unchanged
+- [X] T015 Launch exactly one one-hour `cardano_amaru` Antithesis run, confirm both new properties surface, record `findings_new` against the accepted main baseline, and never retry to select a cleaner schedule
+- [X] T016 Refresh the human-readable PR body including #196's incidentally-correct image pairing; run finalization audit; retain `gate.sh` and draft/not-ready state; report the one-shot result and hand the readiness decision to the parent without merging
 
 ## Dependencies and execution order
 

--- a/specs/193-amaru-fatal-log-ingestion/tasks.md
+++ b/specs/193-amaru-fatal-log-ingestion/tasks.md
@@ -12,13 +12,13 @@ route coverage and fatal-consensus failure.
 invariant; each fatal signature fails it; disabled ingestion declares neither;
 an appended relay-file line is normalized with exact host and message.
 
-- [ ] T001 [US1] RED: add failing ordinary-line and both-fatal-signature assertion tests in `components/tracer-sidecar/test/Spec.hs`
-- [ ] T002 [US2] RED: add failing disabled-configuration and appended-relay-file ingestion tests in `components/tracer-sidecar/test/Spec.hs`
-- [ ] T003 [US1] Add the normalized Amaru stdout payload and evidence adapter in `components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs`
-- [ ] T004 [US2] Add optional relay-file discovery and line following in `components/tracer-sidecar/src/App.hs`
-- [ ] T005 [US1] Add conditional `amaru stdout observed` and `no fatal amaru consensus logs` rules in `components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs`
-- [ ] T006 [US1] Document configuration, event details, signatures, and non-vacuity behavior in `components/tracer-sidecar/README.md`
-- [ ] T007 [US1] GREEN: run focused tests, `just format`, `just hlint`, and root `./gate.sh`; commit exactly `fix(tracer-sidecar): score fatal amaru logs`
+- [X] T001 [US1] RED: add failing ordinary-line and both-fatal-signature assertion tests in `components/tracer-sidecar/test/Spec.hs`
+- [X] T002 [US2] RED: add failing disabled-configuration and appended-relay-file ingestion tests in `components/tracer-sidecar/test/Spec.hs`
+- [X] T003 [US1] Add the normalized Amaru stdout payload and evidence adapter in `components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs`
+- [X] T004 [US2] Add optional relay-file discovery and line following in `components/tracer-sidecar/src/App.hs`
+- [X] T005 [US1] Add conditional `amaru stdout observed` and `no fatal amaru consensus logs` rules in `components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs`
+- [X] T006 [US1] Document configuration, event details, signatures, and non-vacuity behavior in `components/tracer-sidecar/README.md`
+- [X] T007 [US1] GREEN: run focused tests, `just format`, `just hlint`, and root `./gate.sh`; commit exactly `fix(tracer-sidecar): score fatal amaru logs`
 
 ## Slice 2 - fault-contained compose routing and image pin
 

--- a/specs/193-amaru-fatal-log-ingestion/tasks.md
+++ b/specs/193-amaru-fatal-log-ingestion/tasks.md
@@ -29,11 +29,11 @@ mirror.
 regular file; killing the active mirror preserves Amaru PID 1 and restart count
 and yields a replacement mirror; live ordinary/fatal fixtures reach SDK output.
 
-- [ ] T008 [US2] Route both relay stdout/stderr to per-relay regular files and supervise the stdout mirrors in `testnets/cardano_amaru/docker-compose.yaml`
-- [ ] T009 [US2] Add the shared log volume to both relays and mount it read-only with `AMARU_LOG_DIR` in tracer-sidecar in `testnets/cardano_amaru/docker-compose.yaml`
-- [ ] T010 [US3] Pin tracer-sidecar to the preceding Slice 1 commit without changing the `amaru-consumer-seed` image line in `testnets/cardano_amaru/docker-compose.yaml`
-- [ ] T011 [US2] Prove mirror kill/restart, unchanged Amaru PID 1/restart count, regular-file descriptor, and resumed stdout against the final compose construction
-- [ ] T012 [US3] Prove live ordinary and fatal file-to-SDK paths, run compose validation and root `./gate.sh`, and commit exactly `fix(cardano_amaru): route amaru logs to sidecar`
+- [X] T008 [US2] Route both relay stdout/stderr to per-relay regular files and supervise the stdout mirrors in `testnets/cardano_amaru/docker-compose.yaml`
+- [X] T009 [US2] Add the shared log volume to both relays and mount it read-only with `AMARU_LOG_DIR` in tracer-sidecar in `testnets/cardano_amaru/docker-compose.yaml`
+- [X] T010 [US3] Pin tracer-sidecar to the preceding Slice 1 commit without changing the `amaru-consumer-seed` image line in `testnets/cardano_amaru/docker-compose.yaml`
+- [X] T011 [US2] Prove mirror kill/restart, unchanged Amaru PID 1/restart count, regular-file descriptor, and resumed stdout against the final compose construction
+- [X] T012 [US3] Prove live ordinary and fatal file-to-SDK paths, run compose validation and root `./gate.sh`, and commit exactly `fix(cardano_amaru): route amaru logs to sidecar`
 
 ## Finalization - orchestrator-owned verification and PR metadata
 

--- a/specs/193-amaru-fatal-log-ingestion/tasks.md
+++ b/specs/193-amaru-fatal-log-ingestion/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Score fatal Amaru container logs (#193)
+
+**Input**: Design documents in `specs/193-amaru-fatal-log-ingestion/`
+**Tests**: RED -> GREEN is mandatory; raw evidence is part of acceptance.
+
+## Slice 1 - sidecar ingestion and scored properties
+
+**Goal**: Turn plain Amaru relay lines into scored events with non-vacuous
+route coverage and fatal-consensus failure.
+
+**Independent Test**: Ordinary output hits route liveness without failing the
+invariant; each fatal signature fails it; disabled ingestion declares neither;
+an appended relay-file line is normalized with exact host and message.
+
+- [ ] T001 [US1] RED: add failing ordinary-line and both-fatal-signature assertion tests in `components/tracer-sidecar/test/Spec.hs`
+- [ ] T002 [US2] RED: add failing disabled-configuration and appended-relay-file ingestion tests in `components/tracer-sidecar/test/Spec.hs`
+- [ ] T003 [US1] Add the normalized Amaru stdout payload and evidence adapter in `components/tracer-sidecar/src/Cardano/Antithesis/LogMessage.hs`
+- [ ] T004 [US2] Add optional relay-file discovery and line following in `components/tracer-sidecar/src/App.hs`
+- [ ] T005 [US1] Add conditional `amaru stdout observed` and `no fatal amaru consensus logs` rules in `components/tracer-sidecar/src/Cardano/Antithesis/Sidecar.hs`
+- [ ] T006 [US1] Document configuration, event details, signatures, and non-vacuity behavior in `components/tracer-sidecar/README.md`
+- [ ] T007 [US1] GREEN: run focused tests, `just format`, `just hlint`, and root `./gate.sh`; commit exactly `fix(tracer-sidecar): score fatal amaru logs`
+
+## Slice 2 - fault-contained compose routing and image pin
+
+**Goal**: Deploy the scored path without coupling Amaru survival to the output
+mirror.
+
+**Independent Test**: Fresh compose uses the Slice 1 image; each relay writes a
+regular file; killing the active mirror preserves Amaru PID 1 and restart count
+and yields a replacement mirror; live ordinary/fatal fixtures reach SDK output.
+
+- [ ] T008 [US2] Route both relay stdout/stderr to per-relay regular files and supervise the stdout mirrors in `testnets/cardano_amaru/docker-compose.yaml`
+- [ ] T009 [US2] Add the shared log volume to both relays and mount it read-only with `AMARU_LOG_DIR` in tracer-sidecar in `testnets/cardano_amaru/docker-compose.yaml`
+- [ ] T010 [US3] Pin tracer-sidecar to the preceding Slice 1 commit without changing the `amaru-consumer-seed` image line in `testnets/cardano_amaru/docker-compose.yaml`
+- [ ] T011 [US2] Prove mirror kill/restart, unchanged Amaru PID 1/restart count, regular-file descriptor, and resumed stdout against the final compose construction
+- [ ] T012 [US3] Prove live ordinary and fatal file-to-SDK paths, run compose validation and root `./gate.sh`, and commit exactly `fix(cardano_amaru): route amaru logs to sidecar`
+
+## Finalization - orchestrator-owned verification and PR metadata
+
+- [ ] T013 Verify all GitHub checks including `Compose smoke test` are green and preserve their URLs/results in the evidence record
+- [ ] T014 Independently rerun the final gate, audit raw mirror/ingestion proofs, and confirm the forbidden consumer-seed line is unchanged
+- [ ] T015 Launch exactly one one-hour `cardano_amaru` Antithesis run, confirm both new properties surface, record `findings_new` against the accepted main baseline, and never retry to select a cleaner schedule
+- [ ] T016 Refresh the human-readable PR body including #196's incidentally-correct image pairing; run finalization audit; retain `gate.sh` and draft/not-ready state; report the one-shot result and hand the readiness decision to the parent without merging
+
+## Dependencies and execution order
+
+1. Slice 1 is first because Slice 2 must pin its commit.
+2. Slice 2 begins only after Slice 1 is accepted and pushed.
+3. T013-T016 begin only after Slice 2 is accepted and pushed.
+4. The two behavior slices are intentionally sequential and each produces one
+   bisect-safe commit.
+
+## Task-to-requirement coverage
+
+- T001, T003, T005, T007 cover FR-004 through FR-007 and FR-010.
+- T002, T004, T005 cover FR-001, FR-003, FR-010, and the late-file edge case.
+- T006 covers the documented-path requirement in FR-001.
+- T008, T009, T011 cover FR-002, FR-008, and FR-009.
+- T010, T012, T013 cover FR-011 and FR-012.
+- T015 covers FR-013.
+- T010 and T014 cover FR-014.
+- Owned-file fences and review cover FR-015.

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -287,19 +287,34 @@ services:
           find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
           cp -rL /bundle/testnet_42/. /srv/amaru/
         fi
-        mkdir -p /startup
+        mkdir -p /startup /tmp /opt/amaru-logs
         printf '%s\n' "$${HOSTNAME:-amaru-relay-1.example}" > /startup/amaru-relay-1.started
+        log_file=/opt/amaru-logs/amaru-relay-1.log
+        touch "$$log_file"
+        mirror_log() {
+          while :; do
+            tail -n 0 -F "$$log_file" &
+            mirror_pid=$$!
+            printf '%s\n' "$$mirror_pid" > /tmp/amaru-log-mirror.pid
+            wait "$$mirror_pid" || true
+            sleep 1
+          done
+        }
+        mirror_log &
+        printf '%s\n' "$$!" > /tmp/amaru-log-mirror-supervisor.pid
         exec /bin/amaru node run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
           --era-history /srv/amaru/era-history.json \
           --listen-address 0.0.0.0:3001 \
-          --peer-address relay1.example:3001
+          --peer-address relay1.example:3001 \
+          >>"$$log_file" 2>&1
     volumes:
       - amaru-bundle:/bundle:ro
       - amaru-startup:/startup
       - a1-state:/srv/amaru
+      - amaru-logs:/opt/amaru-logs
     networks:
       default:
       amaru-consumer-net:
@@ -327,19 +342,34 @@ services:
           find /srv/amaru -mindepth 1 -maxdepth 1 -exec rm -rf {} +
           cp -rL /bundle/testnet_42/. /srv/amaru/
         fi
-        mkdir -p /startup
+        mkdir -p /startup /tmp /opt/amaru-logs
         printf '%s\n' "$${HOSTNAME:-amaru-relay-2.example}" > /startup/amaru-relay-2.started
+        log_file=/opt/amaru-logs/amaru-relay-2.log
+        touch "$$log_file"
+        mirror_log() {
+          while :; do
+            tail -n 0 -F "$$log_file" &
+            mirror_pid=$$!
+            printf '%s\n' "$$mirror_pid" > /tmp/amaru-log-mirror.pid
+            wait "$$mirror_pid" || true
+            sleep 1
+          done
+        }
+        mirror_log &
+        printf '%s\n' "$$!" > /tmp/amaru-log-mirror-supervisor.pid
         exec /bin/amaru node run \
           --network testnet_42 \
           --ledger-dir /srv/amaru/ledger.testnet_42.db \
           --chain-dir /srv/amaru/chain.testnet_42.db \
           --era-history /srv/amaru/era-history.json \
           --listen-address 0.0.0.0:3001 \
-          --peer-address relay2.example:3001
+          --peer-address relay2.example:3001 \
+          >>"$$log_file" 2>&1
     volumes:
       - amaru-bundle:/bundle:ro
       - amaru-startup:/startup
       - a2-state:/srv/amaru
+      - amaru-logs:/opt/amaru-logs
     networks:
       default:
       amaru-consumer-net:
@@ -391,7 +421,7 @@ services:
       - /tmp
 
   tracer-sidecar:
-    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:e01ad90
+    image: ghcr.io/cardano-foundation/cardano-node-antithesis/tracer-sidecar:a94197a
     container_name: tracer-sidecar
     labels: *fault-exclude
     hostname: tracer-sidecar.example
@@ -401,8 +431,10 @@ services:
       POOLS: "3"
       CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
       AMARU_CONSUMER_HOST: amaru-consumer.example
+      AMARU_LOG_DIR: /opt/amaru-logs
     volumes:
       - tracer:/opt/cardano-tracer
+      - amaru-logs:/opt/amaru-logs:ro
     restart: always
     depends_on:
       tracer:
@@ -436,6 +468,7 @@ volumes:
   a1-state:
   a2-state:
   amaru-consumer-state:
+  amaru-logs:
 
 networks:
   default:


### PR DESCRIPTION
Fatal Amaru consensus events currently live only in container output, while
tracer-sidecar scores a separate structured stream. That allowed the dashboard
to remain green after Amaru logged a fatal consensus event. This PR makes those
lines scored Antithesis evidence.

Closes #193.

## What changed

- tracer-sidecar optionally watches two fixed Amaru relay log files, normalizes
  each line with relay identity and source `amaru-container-stdout`, and scores:
  - required liveness property `amaru stdout observed`;
  - invariant `no fatal amaru consensus logs` for the exact case-sensitive
    signatures `Consensus died` and `attempted roll back in the future`.
- each Amaru relay writes stdout/stderr to its own regular file on a shared named
  volume;
- a supervised `tail -n 0 -F` mirrors that file back to the relay's original
  container stdout, preserving existing Logs Explorer visibility;
- tracer-sidecar mounts the shared volume read-only through `AMARU_LOG_DIR`;
- `cardano_amaru` pins tracer-sidecar to the preceding sidecar commit.

The two behavior changes are intentionally bisect-safe:

1. `fix(tracer-sidecar): score fatal amaru logs`
2. `fix(cardano_amaru): route amaru logs to sidecar`

## Safety and end-to-end proof

The relay's primary writer is a regular file, not a FIFO or pipe. Killing the
stdout mirror therefore cannot deliver SIGPIPE to Amaru or backpressure its
writer.

Against an isolated full `cardano_amaru` deployment:

- Amaru remained PID 1 with the same host PID and restart count 0 after the
  active mirror was killed;
- fd 1 and fd 2 both remained regular-file descriptors;
- the supervisor replaced the mirror, the file kept growing while the mirror
  was absent, and mirrored container output resumed;
- tracer-sidecar's mount was read-only while both relays' mounts were writable;
- ordinary relay output reached `sdk.jsonl` as
  `amaru stdout observed` with `hit=true` while the fatal invariant had no
  failure;
- a unique fatal fixture appended through relay-2's own `/proc/1/fd/1` appeared
  byte-for-byte in the relay file and Docker logs, then produced
  `no fatal amaru consensus logs` with `hit=true`, host `amaru-relay-2`, source
  `amaru-container-stdout`, and the complete original line;
- an actual `attempted roll back in the future` event was also scored during the
  isolated proof;
- targeted teardown left zero isolated containers, networks, or volumes; the
  operator independently verified and supplied the teardown comparison showing
  the protected canonical set intact at 22.

One failed proof-harness attempt also established an important boundary:
truncating a followed file can leave the sidecar handle beyond the new EOF.
Production never truncates these files—it uses `touch` and append-only `>>`—so
the deployed path does not exercise that failure mode.

Measured combined relay output projects to roughly 4–6 MB over three hours.
Continuously extrapolating the densest observed burst remains below the
conservative 250 MB three-hour bound.

## Verification

- root `./gate.sh`: 32 examples, 0 failures;
- service-specific rendered-compose contract: 17/17 assertions pass;
- all seven GitHub checks pass, including `publish-images` and the
  CI-published-image `Compose smoke test`;
- the `amaru-consumer-seed` image line reserved for #192 remains byte-identical;
- the canonical local smoke script was not run, because it would destroy the
  existing live 22-container cluster.

The locally built Nix image first proved
`Entrypoint=["tracer-sidecar"]` with no `Cmd`, so the existing compose command is
appended correctly. More importantly, `publish-images` and the downstream
`cardano_amaru` compose smoke both pass for the CI-published image at this PR's
pin. That resolves the concrete sidecar entrypoint/command pairing for this
profile described by #196; the historical fresh-local versus deployed-run
discrepancy remains documented on #196.

## One-shot Antithesis result

Exactly one fault-enabled one-hour run has been launched and will not be
retried:

- request: `c2e9ffa4a1d27d829119e456f6713cbae64e5359403bea9a0abc62ebb5def6a3`
- Antithesis run: `aefdc3b63312438bbf8c4be215004018-56-17`
- commit: `1879b9237ca6c6fb7fd2a5c5cfa86c6561cddd9f`
- status: completed
- properties: 33 total, 31 passing, 2 failing
- `amaru stdout observed`: passing, 60 examples
- `no fatal amaru consensus logs`: failing, 46 counterexamples

The accepted main baseline
`5271f5ea22ddde7a6f674084905aa335-56-17` had 31 properties, 30 passing,
with only `cluster fork depth < k` failing. The one-shot failing set adds
exactly `no fatal amaru consensus logs`, so `findings_new = 1`.

Natural `attempted roll back in the future` messages from both Amaru relays
fired the new invariant with `condition=false`, `hit=true`, source
`amaru-container-stdout`, and complete relay-host evidence in
tracer-sidecar's `sdk.jsonl`. This is successful detector evidence—not a reason
to retry for a cleaner schedule. The run was not retried. The PR remains
draft/not-ready because of the intentional new finding, and the readiness
decision stays with the parent governance owner.

## Scope

- No Amaru source changes and no attempted fix for `pragma-org/amaru#1095`.
- No change to the cluster-fork property tracked by #140.
- No change to the `amaru-consumer-seed` image pin owned by #192.
