### PR TITLE
chore(cardano_amaru): repin consumer seed image

### DIFF
--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -249,7 +249,7 @@ services:
     restart: on-failure
 
   amaru-consumer-seed:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:03d2727b71e8d1fe7c793d5036dce3c3ce294f6c
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
     container_name: amaru-consumer-seed
     labels: *fault-exclude
     entrypoint: [/bin/sh, -ec]


### PR DESCRIPTION
This makes the Amaru consumer seed use the same validated bootstrap-producer image as the other Amaru services. Maintainers can now read the compose model without having to explain why one of three references points at older image contents.

The consumer seed’s only image pin now matches the `x-amaru` anchor and `bootstrap-producer`. Its command and data flow are unchanged: Compose still overrides the image entrypoint with `/bin/sh -ec` and copies the generated bootstrap bundle into the consumer state volume.

The newer `amaru-bootstrap/main` image was deliberately not adopted here. That image removed the emitter binary and has a different digest; unlike the selected image, it has not been exercised by the existing Antithesis validation run. Adopting it would be a behavioral testnet change requiring its own ticket and run, not this consistency fix.

## Verification

- All three full `amaru-bootstrap-producer` references are identical.
- The selected tag still resolves to the validated producer-image digest.
- `docker compose config -q` accepts the edited model.
- An isolated, unnamed `docker run --rm --entrypoint sh ... -ec` reproduced the seed service’s shell/copy behavior and copied a marker successfully.
- The full [Compose smoke test passed in PR CI](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/30359491187/job/90275651208), including the `cardano_amaru` seed and consumer-convergence path.
- The completed 60-minute Antithesis validation run for this testnet exercised the selected image digest in the deployed stack; `amaru-served consumer reached producer tip` passed with 21 examples and no counterexamples.

The documented local `scripts/smoke-test.sh` was deliberately not run on this shared host. The compose file uses fixed container names that collide with an unrelated three-day-old testnet, and the script’s EXIT trap executes `down --volumes --remove-orphans`; running it would destroy that live state. The full Compose smoke instead ran successfully on the PR’s isolated CI runner.

## Technical contract / evidence

- Changed service: `amaru-consumer-seed`
- Previous tag: `03d2727b71e8d1fe7c793d5036dce3c3ce294f6c`
- Selected tag: `5b57873ae57e38e97773b047ed287206620a155a`
- Selected digest: `sha256:7fde370dd7912821d1fb942317c46d70a81653572dae0ccfb9ed5b00547d9cfd`
- Deliberately excluded current-main tag: `4ea85238d8b80431fc0e3eb54e080210fac66ed1`
- Excluded current-main digest: `sha256:070060a978c6f269f4219303a3a4d53bef41ddc520a10fc2dc2ee3746564e72b`
- Antithesis evidence: completed run `5271f5ea22ddde7a6f674084905aa335-56-17` for `testnets/cardano_amaru`; the named consumer-convergence property passed.

Closes #192.
