### PR TITLE
constitution: declared-property exemption for the findings gate

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -39,6 +39,8 @@ Every composer command must be executable locally via `docker compose -f testnet
 ### Hard gate: findings_new <= baseline
 A PR that changes the composer, a sidecar, or the testnet compose must run an Antithesis duration=1h on the branch before merge. If the run's `findings_new` is above the baseline on main (accounting for stable finding IDs that were already there), the PR does not merge.
 
+**Declared-property exemption.** A new finding does not count against the gate when it is produced by a property the PR itself intentionally adds, provided all of the following hold: the PR body names the property and states that its firing is the success signal; the failure it exposes is pre-existing (evidenced by an upstream issue or an event-stream search of a baseline run) rather than introduced by the PR; the property is proven both ways (a seeded or live failing case, and a clean passing case); and every other finding still satisfies `findings_new <= baseline`. Rationale: the gate exists to stop PRs *introducing* regressions; a property that *reveals* an existing failure is the observability this harness is for, and blocking it institutionalises blindness. The exemption is per-declared-property, never blanket — an undeclared new finding still blocks the merge.
+
 ## Development Workflow
 
 ### Ticket discipline


### PR DESCRIPTION
The `findings_new <= baseline` gate cannot distinguish *introduced* regressions from *revealed* pre-existing failures. PR #194's scored property fires on amaru consensus deaths that predate it (pragma-org/amaru#1095, ≥50/run in baseline event streams) — succeeding at its purpose trips the gate.

This adds a narrow exemption: a finding from a property the PR itself declares as its success signal does not count, iff (1) declared in the PR body, (2) the exposed failure is evidenced as pre-existing, (3) the property is proven both ways, (4) all other findings remain within baseline. Undeclared findings still block.

Milestone 1 arbitration (`milestones` branch, `.milestones/1/`); operator-approved. Doc-only — no composer/sidecar/compose change, so the 1h-run requirement does not apply to this PR itself.