### PR TITLE
chore(cardano_amaru): repin producer image

### DIFF
--- a/specs/195-amaru-producer-repin/plan.md
+++ b/specs/195-amaru-producer-repin/plan.md
@@ -1,0 +1,43 @@
+# Plan — Issue 195
+
+## Technical context
+
+The consumed artifact appears exactly three times in
+`testnets/cardano_amaru/docker-compose.yaml`: the shared Amaru relay anchor,
+`bootstrap-producer`, and `amaru-consumer-seed`. The reference count matches
+the issue contract. No production file other than that Compose file is in the
+implementation fence.
+
+The repository's existing `gate.sh` validates the `cardano_amaru` Compose
+model and runs the fatal-log/property test suite. It is reused unchanged:
+changing findings-gate or constitution semantics requires escalation and is
+not part of this ticket.
+
+## Slice 1 — Repin all Compose consumers
+
+This is one mechanical, bisect-safe configuration commit.
+
+1. Prove the proposed exact-reference census is RED on the old pin while the
+   old-reference positive control finds exactly three entries.
+2. Replace all three old producer-image references with the binding
+   tag-plus-digest.
+3. Prove the new-reference count is exactly three and the old-reference count
+   is zero.
+4. Run Compose validation, `./gate.sh`, and
+   `./scripts/smoke-test.sh cardano_amaru 600`.
+5. Commit the reviewed YAML as
+   `chore(cardano_amaru): repin producer image` with `Tasks: T195`.
+
+## Post-merge operation
+
+After the milestone desk authorizes the merge on the file-protocol record:
+
+1. Merge the PR and identify the resulting `main` commit.
+2. Use the release MOOG binary and requester identity to launch a one-hour
+   `testnets/cardano_amaru` run at that merged commit.
+3. Wait for terminal Antithesis state, then pull the full property set through
+   the Antithesis REST API.
+4. Identify the fatal-consensus property as the expected red owned by
+   `pragma-org/amaru#1098`; triage every other red as a genuine finding.
+5. Report the run id, report URL, tested image, and pass/fail result for every
+   property to the milestone desk.

--- a/specs/195-amaru-producer-repin/spec.md
+++ b/specs/195-amaru-producer-repin/spec.md
@@ -1,0 +1,45 @@
+# Issue 195 — Repin the Amaru producer image and validate it
+
+## Priority story
+
+As the operator of the `cardano_amaru` Antithesis stack, I need every
+Compose consumer of the Amaru bootstrap producer to use the newly published,
+immutable producer artifact so the one-hour validation run tests one known
+image rather than a mixture of tags or digests.
+
+## Functional requirements
+
+- FR-001: All three `amaru-bootstrap-producer` image references in
+  `testnets/cardano_amaru/docker-compose.yaml` use:
+
+  `ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108`
+
+- FR-002: The Compose file contains zero producer-image references to the
+  previous tag or any other tag/digest.
+- FR-003: Docker Compose accepts the updated model.
+- FR-004: The repository gate and the `cardano_amaru` local smoke test pass.
+- FR-005: After the PR merges with desk authorization, a one-hour Antithesis
+  run is launched from the merged commit.
+- FR-006: The completed run report lists every property's pass/fail result.
+  The fatal-consensus signature owned by `pragma-org/amaru#1098` is an expected
+  red and must remain visible. Every other new red is triaged and reported.
+
+## Success criteria
+
+- The Compose reference census is exactly three and all three lines resolve to
+  the required tag and digest.
+- A positive control proves the census command can find the old references
+  before the edit; after the edit it finds three new references and zero old
+  Compose references.
+- Compose validation, the full gate, and the local smoke exit zero.
+- The one-hour run is launched only from the merged commit and its report is
+  delivered to the milestone desk.
+
+## Scope boundaries
+
+- Do not change findings-gate semantics, the constitution, assertion
+  exemptions, or fatal-log scoring.
+- Do not suppress or game the expected fatal-consensus red.
+- Do not change `amaru-bootstrap` or adopt any image other than the binding
+  tag-plus-digest above.
+- Merge only after the milestone desk records authorization.

--- a/specs/195-amaru-producer-repin/tasks.md
+++ b/specs/195-amaru-producer-repin/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1 — Repin all Compose consumers
 
-- [ ] T195 Replace exactly three producer-image references with the binding
+- [X] T195 Replace exactly three producer-image references with the binding
   tag-plus-digest; prove the old/new censuses in both directions; run Compose
   validation, the full gate, and the `cardano_amaru` smoke; land one reviewed
   bisect-safe commit.

--- a/specs/195-amaru-producer-repin/tasks.md
+++ b/specs/195-amaru-producer-repin/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — Issue 195
+
+## Slice 1 — Repin all Compose consumers
+
+- [ ] T195 Replace exactly three producer-image references with the binding
+  tag-plus-digest; prove the old/new censuses in both directions; run Compose
+  validation, the full gate, and the `cardano_amaru` smoke; land one reviewed
+  bisect-safe commit.
+
+## Orchestrator finalization
+
+- [ ] Record the three-reference/zero-legacy grep proof in the PR evidence.
+- [ ] Obtain milestone-desk merge authorization through the Q/A file protocol.
+- [ ] Merge only after that authorization is recorded.
+- [ ] Launch and report the one-hour post-merge Antithesis run.

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -44,7 +44,7 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
-  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
   entrypoint:
     - /bin/sh
   environment:
@@ -155,7 +155,7 @@ services:
       - tracer:/tracer
 
   bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
     container_name: bootstrap-producer
     labels: *fault-exclude
     hostname: bootstrap-producer.example
@@ -249,7 +249,7 @@ services:
     restart: on-failure
 
   amaru-consumer-seed:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:5b57873ae57e38e97773b047ed287206620a155a
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
     container_name: amaru-consumer-seed
     labels: *fault-exclude
     entrypoint: [/bin/sh, -ec]


### PR DESCRIPTION
## What this enables

This PR will move all three `cardano_amaru` consumers of the Amaru bootstrap
producer onto the newly published immutable artifact. That gives the follow-up
one-hour Antithesis run a single, auditable producer image across relay,
bootstrap, and consumer-seed roles.

The implementation is intentionally narrow: only the three image references in
the Compose stack change. Findings-gate semantics, the declared-property
exemption, fatal-log scoring, and the test constitution stay unchanged.

## Delivery

The issue contract, one-slice plan, and verification checklist are recorded in
`specs/195-amaru-producer-repin/`. The reviewed implementation changes only the
three producer-image literals in the Compose stack; shared service wiring and
commands are unchanged.

After local validation and review, this PR will remain unmerged until the
milestone desk records authorization. The one-hour run will be launched only
from the merged commit.

The known Amaru consensus-death signature remains an expected red because
`pragma-org/amaru#1098` is open and its fix is not in this image. The fatal-log
property must expose and score it; it must not be suppressed. Any other new red
will be triaged as a genuine finding.

## Validation

The unchanged branch baseline passed the repository gate: 32 tests passed with
zero failures, and Docker Compose accepted the `cardano_amaru` model.

Implementation evidence:

- exact-reference census: 3
- total producer-reference census: 3
- legacy-reference census: 0
- Docker Compose validation: passed
- repository gate: 32 tests passed, 0 failed
- local `cardano_amaru` smoke: passed independently at ticket-owner acceptance
- post-merge one-hour Antithesis run: pending

The paired worker's first smoke reached healthy producers, bootstrap, relays,
and seeding, but timed out waiting for the consumer to advance. Its one
unchanged retry passed. The ticket owner then ran a separate full smoke: the
consumer seeded at block 242, advanced to slot 1630, and matched `p1`; the
command exited zero and tore the stack down. The initial timeout remains
recorded here because it is relevant timing evidence, not something to hide.

## Technical contract / evidence

| Artifact | Source tag | Registry digest |
|---|---|---|
| Replaced producer image | `5b57873ae57e38e97773b047ed287206620a155a` | `sha256:7fde370dd7912821d1fb942317c46d70a81653572dae0ccfb9ed5b00547d9cfd` |
| Required producer image | `2d0f4451630b7587851e9238cb43a34e3200e8cf` | `sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108` |

The pre-edit Compose census found exactly three producer-image references, as
the contract expects. Registry inspection independently confirmed both tag to
digest mappings above.

The post-edit proof used fixed-string censuses on
`testnets/cardano_amaru/docker-compose.yaml`:

| Census | Expected | Observed |
|---|---:|---:|
| All `amaru-bootstrap-producer:` references | 3 | 3 |
| Exact required tag-plus-digest | 3 | 3 |
| Replaced legacy tag | 0 | 0 |

### Decision log

- Keep the fatal-consensus signature visible and scored while
  [pragma-org/amaru#1098](https://github.com/pragma-org/amaru/issues/1098)
  remains open.
- Rely on the already-merged declared-property exemption tracked in
  [cardano-node-antithesis#198](https://github.com/cardano-foundation/cardano-node-antithesis/issues/198);
  do not change findings-gate semantics in this PR.

Closes #195
