### PR TITLE
chore(cardano_amaru): adopt consensus-fix producer image

### DIFF
--- a/specs/200-amaru-consensus-fix-repin/plan.md
+++ b/specs/200-amaru-consensus-fix-repin/plan.md
@@ -1,0 +1,74 @@
+# Plan — Issue 200
+
+## Technical context
+
+The consumed artifact appears exactly three times in
+`testnets/cardano_amaru/docker-compose.yaml`: the shared Amaru relay anchor,
+`bootstrap-producer`, and `amaru-consumer-seed`. A Compose-tree fixed-string
+census on unchanged `origin/main` found exactly those three references, so
+the issue's expected count is not presently drifting.
+
+The current reference is the image validated by issue #195:
+
+`ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108`
+
+The replacement is the immutable image published after
+`lambdasistemi/amaru-bootstrap#74` merged:
+
+`ghcr.io/lambdasistemi/amaru-bootstrap-producer:cf657b918787c213c09ffef3879ac4a2552dd680@sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147`
+
+Only `testnets/cardano_amaru/docker-compose.yaml` is inside the
+implementation fence. The repository's tracked `gate.sh` is a permanent
+fatal-log/property and Compose gate from issue #193, not a resolve-ticket
+lifecycle sentinel; it is reused unchanged and must not be dropped.
+
+## Slice 1 — Repin all Compose consumers
+
+This is one mechanical, bisect-safe configuration commit executed by a Qwen
+driver and an independent navigator.
+
+1. Freeze RED evidence showing the new exact-reference count is zero while
+   the old-reference positive control finds exactly three Compose entries.
+2. Replace all three old producer-image references with the binding
+   tag-plus-digest.
+3. Freeze GREEN evidence showing the total producer-reference count is
+   three, the exact required-reference count is three, and the count on any
+   other tag or digest is zero.
+4. Run Compose validation, `./gate.sh`, and
+   `./scripts/smoke-test.sh cardano_amaru 600`.
+5. Commit the reviewed YAML as
+   `chore(cardano_amaru): repin producer image` with `Tasks: T200`.
+
+The ticket owner independently re-runs the census, gate, and smoke before
+accepting and pushing the commit.
+
+## PR and merge gate
+
+The draft PR records the old and new immutable references plus the exact
+three/three/zero census. The ticket owner asks the milestone desk for merge
+authorization through `/tmp/ms-1/cna-fix-run/questions/` and does not merge
+until the matching answer file explicitly authorizes it.
+
+## Post-merge decisive run
+
+After the authorized merge:
+
+1. Resolve the resulting `main` merge commit and use the release MOOG
+   procedure from issue #195 to submit a 60-minute fault-injection run for
+   `testnets/cardano_amaru`.
+2. Wait for terminal Antithesis state and retain run metadata, the complete
+   property payload, signature searches, and first failure moments.
+3. Prove the fatal-log search instrument can produce known hits against
+   retained #195 evidence before treating a zero-result search as absence.
+4. Require `no fatal amaru consensus logs` to score with zero
+   counterexamples and require both #1098 signatures to be absent.
+5. Treat the #1104 rewards panic/container exits as declared expected red and
+   the #140 stale-consumer fork-depth result as an expected artifact.
+6. Triage every other red as a genuine finding and file it upstream with
+   evidence when unowned.
+7. Deliver the full per-property report and explicit ABSENT/RED accounting to
+   the milestone desk.
+
+If either fatal signature appears, stop normal triage immediately, retain the
+raw evidence, and escalate to the desk: that outcome invalidates the
+supplier fix under fault injection.

--- a/specs/200-amaru-consensus-fix-repin/spec.md
+++ b/specs/200-amaru-consensus-fix-repin/spec.md
@@ -1,0 +1,65 @@
+# Issue 200 — Adopt the Amaru consensus-fix producer image
+
+## Priority story
+
+As the operator of the `cardano_amaru` Antithesis stack, I need every
+Compose consumer of the Amaru bootstrap producer to use the immutable image
+that contains the upstream rollback fix so the decisive fault-injection run
+can establish whether the fatal consensus signature is absent.
+
+## Functional requirements
+
+- FR-001: All three `amaru-bootstrap-producer` image references in the
+  Compose tree use:
+
+  `ghcr.io/lambdasistemi/amaru-bootstrap-producer:cf657b918787c213c09ffef3879ac4a2552dd680@sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147`
+
+- FR-002: The Compose tree contains exactly three producer-image references
+  and zero producer-image references to any other tag or digest.
+- FR-003: Docker Compose accepts the updated model, the repository gate
+  passes, and the `cardano_amaru` local smoke passes.
+- FR-004: The PR remains unmerged until the milestone desk records explicit
+  authorization through the runtime Q/A protocol.
+- FR-005: After the authorized PR merges, a 60-minute Antithesis
+  fault-injection run is launched from the merged commit.
+- FR-006: `no fatal amaru consensus logs` is present and scoring with zero
+  counterexamples. Both `attempted roll back in the future` and
+  `Consensus died` are absent from the retained evidence.
+- FR-007: If either fatal signature appears, stop, retain raw evidence, and
+  escalate immediately; do not rationalize or reclassify the failure.
+- FR-008: The completed run report lists every property and explicitly
+  accounts for the declared `pragma-org/amaru#1104` rewards-panic/container
+  exit red and the `cardano-node-antithesis#140` stale-consumer fork-depth
+  artifact. Every other red is triaged as a genuine finding and filed
+  upstream when unowned.
+
+## Success criteria
+
+- A positive control proves the census method finds the three old references
+  before the edit.
+- After the edit, the same Compose-tree census finds exactly three producer
+  references, all equal to the required tag-plus-digest, and a complementary
+  search finds zero references on any other tag or digest.
+- Compose validation, the full gate, and the local smoke exit zero.
+- The one-hour run is launched only from the authorized merged commit.
+- The desk receives a complete per-property report whose ABSENT/RED
+  accounting distinguishes the required fatal-signature absence, declared
+  #1104 red, expected #140 artifact, and any genuine new finding.
+
+## Scope boundaries
+
+- Do not change findings-gate semantics, assertion code, declared-property
+  exemptions, the test constitution, or fatal-log scoring.
+- Do not suppress, weaken, or game any scored property.
+- Do not change `amaru-bootstrap`, Amaru source, or any artifact other than
+  the binding producer-image reference above.
+- Do not update non-Compose documentation image examples.
+- Merge only after the milestone desk records authorization.
+
+## Provenance
+
+This is the downstream acceptance run for
+`lambdasistemi/amaru-bootstrap#67`. The supplier image came from merged
+`lambdasistemi/amaru-bootstrap#74`, which adopted upstream Amaru fix
+`437ff6c4fb506e1347eee9e619271a5ccb55a401`. Issue #195 and PR #199 provide
+the previous repin and run-report pattern.

--- a/specs/200-amaru-consensus-fix-repin/tasks.md
+++ b/specs/200-amaru-consensus-fix-repin/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — Issue 200
+
+## Slice 1 — Repin all Compose consumers
+
+- [ ] T200 Replace exactly three producer-image references with the binding
+  tag-plus-digest; prove the old/new censuses in both directions; run Compose
+  validation, the full gate, and the `cardano_amaru` smoke; land one reviewed
+  bisect-safe commit.
+
+## Orchestrator finalization
+
+- [ ] Record the total/exact/other-reference grep proof in the PR evidence.
+- [ ] Obtain milestone-desk merge authorization through the Q/A file
+  protocol.
+- [ ] Merge only after that authorization is recorded.
+- [ ] Launch the 60-minute post-merge Antithesis fault-injection run.
+- [ ] Prove the fatal-log search instrument on retained #195 evidence before
+  accepting a zero-result signature search.
+- [ ] Deliver the complete per-property report with explicit fatal-signature
+  ABSENT, #1104 RED, #140 artifact, and genuine-new-finding accounting.

--- a/specs/200-amaru-consensus-fix-repin/tasks.md
+++ b/specs/200-amaru-consensus-fix-repin/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1 — Repin all Compose consumers
 
-- [ ] T200 Replace exactly three producer-image references with the binding
+- [X] T200 Replace exactly three producer-image references with the binding
   tag-plus-digest; prove the old/new censuses in both directions; run Compose
   validation, the full gate, and the `cardano_amaru` smoke; land one reviewed
   bisect-safe commit.

--- a/testnets/cardano_amaru/docker-compose.yaml
+++ b/testnets/cardano_amaru/docker-compose.yaml
@@ -44,7 +44,7 @@ x-cardano-relay-10-7-1: &cardano-relay-10-7-1
 x-amaru: &amaru
   # Amaru is relay-only in this testnet. It receives no stake pool keys,
   # no KES/VRF/opcert material, and no block-producing command.
-  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
+  image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:cf657b918787c213c09ffef3879ac4a2552dd680@sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147
   entrypoint:
     - /bin/sh
   environment:
@@ -155,7 +155,7 @@ services:
       - tracer:/tracer
 
   bootstrap-producer:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:cf657b918787c213c09ffef3879ac4a2552dd680@sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147
     container_name: bootstrap-producer
     labels: *fault-exclude
     hostname: bootstrap-producer.example
@@ -249,7 +249,7 @@ services:
     restart: on-failure
 
   amaru-consumer-seed:
-    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:2d0f4451630b7587851e9238cb43a34e3200e8cf@sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108
+    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:cf657b918787c213c09ffef3879ac4a2552dd680@sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147
     container_name: amaru-consumer-seed
     labels: *fault-exclude
     entrypoint: [/bin/sh, -ec]


### PR DESCRIPTION
## What this enables

This PR prepares the decisive one-hour Antithesis acceptance run for the
upstream Amaru rollback fix. Every Compose role that consumes the bootstrap
producer will use the same immutable image built after the fix landed, so the
run can test one auditable artifact under fault injection.

The implementation is deliberately narrow: only the three producer-image
references in the `cardano_amaru` Compose stack may change. Assertion code,
findings-gate semantics, declared-property handling, and non-Compose
documentation remain untouched.

## Delivery

The issue contract and one-slice plan are recorded in
`specs/200-amaru-consensus-fix-repin/`. A Qwen driver made the
three-reference repin and an independent navigator approved the frozen RED
and GREEN evidence before the one bisect-safe implementation commit.

This PR will remain unmerged until the milestone desk records explicit
authorization. After merge, the ticket owner will launch the 60-minute
fault-injection run and deliver the complete per-property report.

## Validation

The unchanged branch baseline passed the repository gate: 32 tests passed
with zero failures, and Docker Compose accepted the `cardano_amaru` model.

Implementation evidence:

- total producer-reference census: 3
- exact required-reference census: 3
- other producer-reference census: 0
- Docker Compose validation: passed
- paired repository gate: 32 tests passed, 0 failed
- paired local `cardano_amaru` smoke: passed on a real-exit retry
- ticket-owner repository gate: 32 tests passed, 0 failed
- ticket-owner local `cardano_amaru` smoke: passed independently
- post-merge one-hour Antithesis run: pending

The paired smoke's first shell wrapper expired during teardown after the
domain checks had run; this was not accepted as a verdict. Its fresh retry
returned exit zero and completed teardown. The ticket owner then started from
a fully torn-down stack and independently observed the consumer seed at slot
1298, convergence at slot 1603 matching `p1`, a passing verdict, and
successful teardown.

## Technical contract / evidence

| Artifact | Source tag | Registry digest |
|---|---|---|
| Replaced producer image | `2d0f4451630b7587851e9238cb43a34e3200e8cf` | `sha256:deff22e851d9703b344a75c20f5deeb8374258f3cc5716edf237e69d2f5ab108` |
| Required producer image | `cf657b918787c213c09ffef3879ac4a2552dd680` | `sha256:72906da307862ee5652a35d2e6569fcd929ddd5785ad6d633b42e4912faef147` |

The unchanged Compose-tree census found exactly three producer-image
references, all on the replaced immutable image. The post-edit fixed-string
census found exactly three producer-image references, all three equal to the
required tag-plus-digest, with zero references on any other producer tag or
digest.

The decisive run requires `no fatal amaru consensus logs` to score with zero
counterexamples and both #1098 signatures to be absent. The declared #1104
rewards-panic/container-exit red and the #140 stale-consumer fork-depth
artifact remain visible and separately accounted; every other red is a
genuine finding.

Closes #200
