### PR TITLE
ci: enforce the Amaru producer image contract

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -33,6 +33,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ github.event.inputs.ref_name || '' }}
+    - name: Check Amaru producer image contract
+      run: scripts/check-amaru-producer-image-refs.sh
     - uses: paolino/dev-assets/setup-nix@v0.0.1
       with:
         cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/gate.sh
+++ b/gate.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 
 git diff --check
 
+# Amaru producer-image contract (#202): every Compose reference must be
+# digest-pinned and all must be identical.
+scripts/check-amaru-producer-image-refs.sh
+
 # tracer-sidecar property tests (hspec + golden). Prefer the hermetic Nix build
 # and then execute the produced test binary from the component directory, which
 # the golden test uses as its working directory. Fall back to cabal otherwise.

--- a/scripts/check-amaru-producer-image-refs.sh
+++ b/scripts/check-amaru-producer-image-refs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Enforce the Amaru bootstrap producer image contract across Compose files.
+# Every discovered reference must be digest-pinned and all must be identical.
+#
+# Usage: scripts/check-amaru-producer-image-refs.sh [compose-root]
+#   compose-root  directory to search recursively (default: testnets)
+set -euo pipefail
+
+REPO='ghcr.io/lambdasistemi/amaru-bootstrap-producer'
+ROOT="${1:-testnets}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "FAIL: compose root '$ROOT' is not a directory" >&2
+  exit 1
+fi
+
+# Discover every image field referencing the producer repo in Compose files.
+refs=$(find "$ROOT" -type f \( -name '*.yaml' -o -name '*.yml' \) \
+  -exec grep -h "image:.*${REPO}" {} + 2>/dev/null \
+  | sed 's/.*image:[[:space:]]*//' \
+  | sort) || true
+
+count=$(printf '%s\n' "$refs" | grep -c . 2>/dev/null) || count=0
+
+if [ "$count" -eq 0 ]; then
+  echo "FAIL: zero producer-image references found below '$ROOT'" >&2
+  echo "An empty census cannot establish the contract." >&2
+  exit 1
+fi
+
+# Validate every discovered value: repository:tag@sha256:<64 hex>.
+bad_form=0
+while IFS= read -r ref; do
+  [ -z "$ref" ] && continue
+  if ! printf '%s\n' "$ref" \
+    | grep -Eq "^${REPO}:[^@[:space:]]+@sha256:[0-9a-f]{64}$"; then
+    echo "FAIL: reference lacks tagged digest-pinned form: $ref" >&2
+    bad_form=1
+  fi
+done <<< "$refs"
+
+if [ "$bad_form" -ne 0 ]; then
+  echo "Every producer image must be ${REPO}:<tag>@sha256:<64 hex>." >&2
+  exit 1
+fi
+
+# All validated references must be byte-for-byte identical.
+unique=$(printf '%s\n' "$refs" | grep . | sort -u)
+unique_count=$(printf '%s\n' "$unique" | grep -c .)
+
+if [ "$unique_count" -ne 1 ]; then
+  echo "FAIL: $unique_count distinct producer-image references found;" >&2
+  echo "all must be identical." >&2
+  printf '%s\n' "$unique" | while IFS= read -r u; do
+    echo "  $u" >&2
+  done
+  exit 1
+fi
+
+echo "OK: $count producer-image reference(s), all pinned to $unique"

--- a/specs/202-amaru-producer-image-contract/plan.md
+++ b/specs/202-amaru-producer-image-contract/plan.md
@@ -1,0 +1,89 @@
+# Plan — Issue 202
+
+## Technical context
+
+The unchanged tree contains three active references to
+`ghcr.io/lambdasistemi/amaru-bootstrap-producer`, all in
+`testnets/cardano_amaru/docker-compose.yaml` and all currently identical and
+digest-pinned. That count and value are observations, not implementation
+constants.
+
+The repository convention already provides:
+
+- `scripts/` for mechanical shell checks,
+- a tracked root `gate.sh` for local acceptance, and
+- `.github/workflows/publish-images.yaml`, which runs for pull requests to
+  `main` and already owns the image/Compose CI boundary.
+
+The tracked `gate.sh` is a permanent project gate inherited from issue #193,
+not a resolve-ticket lifecycle sentinel. It remains tracked and is extended in
+place.
+
+## Slice 1 — Add and wire the contract check
+
+This is one bisect-safe implementation commit executed by the standing Qwen
+driver and an independent navigator.
+
+Owned implementation files:
+
+- `scripts/check-amaru-producer-image-refs.sh`
+- `gate.sh`
+- `.github/workflows/publish-images.yaml`
+
+The checker accepts an optional Compose-root argument for controlled evidence;
+the production default is `testnets/`. It recursively discovers Compose files,
+extracts matching image fields, rejects an empty census, validates every value
+as a tagged 64-hex SHA-256 digest reference, and rejects more than one unique
+value. Its success line prints the observed count and unique reference.
+
+The driver proves RED before GREEN with temporary copied Compose input outside
+the tracked tree:
+
+1. Change exactly one discovered reference to another syntactically valid
+   tag-plus-digest and require non-zero exit.
+2. Remove the digest from exactly one discovered reference and require
+   non-zero exit.
+3. Preserve raw stdout/stderr and exit codes under the lane evidence root;
+   delete neither evidence nor the temporary input until the ticket owner has
+   independently checked it, but never stage either.
+4. Run the checker on the unchanged repository tree and require success.
+5. Run `./gate.sh` and require success.
+
+The tracked gate invokes the checker directly. The existing PR-triggered
+publish-images workflow also invokes the checker directly before publishing,
+so CI reachability is visible in workflow source and in the PR check log.
+
+Commit subject:
+
+`ci: enforce Amaru producer image references`
+
+Commit trailer:
+
+`Tasks: T202`
+
+## Ticket-owner acceptance
+
+The ticket owner independently:
+
+1. Reviews the complete commit and verifies only the three owned files changed.
+2. Replays both seeded RED controls into fresh temporary directories.
+3. Runs the clean checker and full tracked gate.
+4. Confirms neither seed is present in the commit or worktree.
+5. Pushes the accepted slice and verifies the PR-triggered workflow log contains
+   the check's non-vacuous pass output.
+6. Updates the human-readable PR body with the evidence and requests merge
+   authorization from the Milestone 1 desk through
+   `/tmp/ms-1/cna-image-check/questions/`.
+
+## Post-merge Milestone 1 closeout
+
+After authorized merge, refresh final `main` and launch the closing 60-minute
+fault-injection Antithesis run using the report template at
+`/tmp/ms-1/cna-fix-run/run-report.md` and the MOOG procedure established by
+issue #200.
+
+The closing report must account for every property. Both #1098 fatal consensus
+signatures must be absent. The only expected reds are
+`pragma-org/amaru#1104` and `cardano-node-antithesis#140`; every other red is a
+genuine finding requiring evidence and ownership/filing.
+

--- a/specs/202-amaru-producer-image-contract/spec.md
+++ b/specs/202-amaru-producer-image-contract/spec.md
@@ -1,0 +1,63 @@
+# Issue 202 — Enforce the Amaru producer-image contract
+
+## Priority story
+
+As a maintainer changing Compose configuration, I need the local mechanical
+gate and pull-request CI to reject an Amaru bootstrap producer reference that
+drifts from its peers or loses its immutable digest, so the cross-repository
+producer/consumer contract cannot silently regress after the manual repair in
+#192.
+
+## Functional requirements
+
+- FR-001: A repository-conventional shell check discovers every image field
+  referencing `ghcr.io/lambdasistemi/amaru-bootstrap-producer` in Compose
+  files below `testnets/`.
+- FR-002: Discovery is dynamic. The check must not hardcode the present
+  reference count, current tag, or current digest.
+- FR-003: Discovery returning zero producer-image references is a failure,
+  because an empty census cannot establish the contract.
+- FR-004: Every discovered producer-image value has the complete form
+  `repository:tag@sha256:<64 hexadecimal characters>`.
+- FR-005: All discovered producer-image values are byte-for-byte identical.
+- FR-006: The passing output reports the discovered count and the one resolved
+  image value, making a real pass distinguishable from a vacuous invocation.
+- FR-007: The tracked repository `gate.sh` invokes the check.
+- FR-008: A workflow triggered for pull requests to `main` invokes the check
+  through an explicit, reviewable command.
+- FR-009: Mechanically captured evidence demonstrates failure against two
+  uncommitted temporary seeds: one valid-but-different producer reference and
+  one tag-only producer reference.
+
+## Success criteria
+
+- The unchanged tree passes and prints a non-zero producer-reference count plus
+  its unique digest-pinned value.
+- A temporary one-reference drift exits non-zero and identifies disagreement.
+- A temporary tag-only reference exits non-zero and identifies the missing
+  digest pin.
+- Neither seed appears in the committed diff.
+- Running the tracked local gate shows the new check was invoked and passed.
+- Pull-request CI reaches the explicit workflow step and its retained log shows
+  the same non-vacuous passing output.
+
+## Scope boundaries
+
+- Do not change any current producer image tag or digest.
+- Do not hardcode the current count, tag, or digest in the checker.
+- Do not change Compose service behavior.
+- Do not touch findings-gate behavior, declared-property handling,
+  constitution semantics, or Antithesis property scoring.
+- Do not introduce a second gate framework; extend the tracked project gate
+  and an existing pull-request workflow.
+- Merge only after the Milestone 1 desk records explicit authorization through
+  the runtime Q/A protocol.
+
+## Provenance
+
+Issue #192 records the producer-image drift that maintainers previously found
+and repaired by hand. The enforced contract is the repository side of the
+cross-repository boundary:
+
+`amaru-bootstrap publishes -> cardano-node-antithesis Compose pins`.
+

--- a/specs/202-amaru-producer-image-contract/tasks.md
+++ b/specs/202-amaru-producer-image-contract/tasks.md
@@ -1,0 +1,21 @@
+# Tasks — Issue 202
+
+## Slice 1 — Add and wire the contract check
+
+- [ ] T202 Implement the dynamic producer-image checker; prove seeded drift
+  and tag-only failures; prove the clean pass; wire the checker into the
+  tracked local gate and PR-triggered workflow; land one reviewed bisect-safe
+  commit.
+
+## Orchestrator finalization
+
+- [ ] Independently replay both RED controls and retain raw logs.
+- [ ] Independently run the clean checker and tracked gate.
+- [ ] Verify the PR workflow reaches the checker and retain its passing log.
+- [ ] Record complete evidence in the human-readable PR body.
+- [ ] Obtain Milestone 1 desk authorization through the Q/A file protocol.
+- [ ] Merge only after explicit authorization is recorded.
+- [ ] Launch the closing 60-minute Antithesis run from final `main`.
+- [ ] Deliver full per-property accounting: #1098 signatures absent, only
+  #1104 and #140 expected red, every other red treated as a genuine finding.
+

--- a/specs/202-amaru-producer-image-contract/tasks.md
+++ b/specs/202-amaru-producer-image-contract/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1 — Add and wire the contract check
 
-- [ ] T202 Implement the dynamic producer-image checker; prove seeded drift
+- [X] T202 Implement the dynamic producer-image checker; prove seeded drift
   and tag-only failures; prove the clean pass; wire the checker into the
   tracked local gate and PR-triggered workflow; land one reviewed bisect-safe
   commit.
@@ -18,4 +18,3 @@
 - [ ] Launch the closing 60-minute Antithesis run from final `main`.
 - [ ] Deliver full per-property accounting: #1098 signatures absent, only
   #1104 and #140 expected red, every other red treated as a genuine finding.
-


### PR DESCRIPTION
## What this enables

This PR turns the producer-image drift previously found by hand in #192 into an automatically enforced repository contract. Every active Compose image field below `testnets/` that references the Amaru bootstrap producer must remain one identical tagged, SHA-256-digest-pinned image.

The check discovers references dynamically. It does not encode the current reference count, image tag, or digest, and it refuses an empty census so removal cannot create a vacuous pass.

## Delivery

A strict Bash checker now validates the contract and prints the observed count plus the one resolved reference on success. The tracked local `gate.sh` calls it directly, and the existing pull-request `publish-images` workflow runs it immediately after checkout, before Nix setup and registry login.

The implementation landed as one reviewed, bisect-safe slice. A Qwen driver produced the RED and GREEN handoffs; an independent navigator approved both frozen diffs before commit and verified the stamped commit afterward.

No current image reference, Compose service behavior, findings-gate behavior, declared-property handling, property scoring, or constitution semantics changed.

## Validation

The checker was proven in both directions with temporary, uncommitted Compose roots:

| Control | Expected | Observed |
|---|---:|---:|
| zero producer references | fail | exit 1, diagnosed empty census |
| one valid but different tag-plus-digest | fail | exit 1, two conflicting values printed |
| one tag-only reference | fail | exit 1, missing digest form diagnosed |
| one 63-hex digest | fail | exit 1 |
| one 65-hex digest | fail | exit 1 |
| one digest with no tag | fail | exit 1 |
| one valid reference | pass | exit 0, observed count 1 |
| unchanged repository tree | pass | exit 0, observed count 3 |

The ticket owner independently replayed all eight controls from fresh temporary roots. Neither seed value nor temporary path appears in the commit.

The full tracked gate passed after wiring. Its first line was the non-vacuous producer-image result, followed by 32 test examples with zero failures and successful Compose validation.

CI reachability is demonstrated by the completed `publish-images` job in [workflow run 30456752985](https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/30456752985/job/90592172614). On the pull-request synthetic merge for head `94b8372`, GitHub Actions explicitly ran `scripts/check-amaru-producer-image-refs.sh` and logged the same count-3 unique-reference pass before Nix setup. The chained hosted Compose smoke remains the normal final merge condition.

## Technical contract / evidence

The normative contract and one-slice plan are recorded in `specs/202-amaru-producer-image-contract/`.

The check enforces:

1. at least one discovered producer-image field;
2. `repository:non-empty-tag@sha256:64-hex` form for every value; and
3. exactly one unique value across the dynamic census.

Closes #202