### PR TITLE
docs: antithesis-wiki-report wiki upload skill

### DIFF
--- a/tools/antithesis-wiki-report/README.md
+++ b/tools/antithesis-wiki-report/README.md
@@ -1,0 +1,33 @@
+# antithesis-wiki-report
+
+Upload **weekly Antithesis platform status** pages to the
+[cardano-node-antithesis wiki](https://github.com/cardano-foundation/cardano-node-antithesis/wiki/Antithesis-Reports)
+(pragma engagement).
+
+**Cadence:** every **Thursday before the Discord meeting**.
+
+**Format:** owned by Antithesis. Generate the body with **their** skill;
+this tool only publishes the file, updates the index/sidebar, and enforces
+public-safety checks. CF does not ship a report template.
+
+## Quick start
+
+```bash
+# After Antithesis tooling wrote REPORT.md in their format:
+./scripts/upload-report.sh publish \
+  --week 2026-W31 \
+  --authors "Your Name (@github)" \
+  REPORT.md
+```
+
+Prints a single wiki URL on success.
+
+## Safety
+
+The script refuses bodies that look like authenticated Antithesis report
+URLs or session material. Use **run IDs** only. Structure is left unchanged.
+
+## Skill
+
+See [SKILL.md](./SKILL.md) for agent instructions. Symlink into
+`~/.claude/skills/antithesis-wiki-report` if you want slash-command discovery.

--- a/tools/antithesis-wiki-report/SKILL.md
+++ b/tools/antithesis-wiki-report/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: antithesis-wiki-report
+description: >
+  Publish weekly Antithesis platform status reports to the
+  cardano-node-antithesis GitHub wiki (pragma engagement). Use when asked
+  to "upload the wiki report", "publish weekly Antithesis report",
+  "Antithesis-Report", "platform status for pragma", or fill
+  Antithesis-Reports. Report body format is owned by Antithesis — this skill
+  only uploads. Runs tools/antithesis-wiki-report/scripts/upload-report.sh.
+compatibility: Requires bash, git, gh (Write on the repo/wiki), GNU date.
+metadata:
+  version: "2026-07-30"
+---
+
+# Antithesis weekly wiki report (upload only)
+
+Publishes **one markdown file per ISO week** to the project wiki:
+
+- Index: https://github.com/cardano-foundation/cardano-node-antithesis/wiki/Antithesis-Reports
+- Page: `Antithesis-Report-YYYY-Www`
+
+**Cadence:** every **Thursday before the Discord meeting**. If missed, publish before the next meeting.
+
+## Format — do not invent one
+
+**Antithesis owns the report format.** They generate the weekly body with **their own skill / tooling**. This CF skill must **not**:
+
+- Scaffold a CF template
+- Rewrite their sections into a CF outline
+- Ask them to match a CF layout
+
+Only accept their markdown file, run safety checks, and publish it under the wiki naming convention.
+
+This is **vendor status** (Antithesis / pragma), not the CF development logbook.
+
+## Prerequisites
+
+- **Write** on `cardano-foundation/cardano-node-antithesis` (wiki uses the same ACL)
+- `gh auth login` (HTTPS) or SSH that can push to `*.wiki.git`
+- Tools: `bash`, `git`, `gh`, GNU `date`, `sed`, `awk`
+- A finished report file from **Antithesis's** skill (any markdown structure)
+
+Install discoverability (optional, Claude Code):
+
+```bash
+# from repo root
+mkdir -p ~/.claude/skills
+ln -sfn "$(pwd)/tools/antithesis-wiki-report" ~/.claude/skills/antithesis-wiki-report
+```
+
+## Public-safety rules (enforced by the script)
+
+1. **No authenticated Antithesis report URLs** (no query-string report links).
+2. **No SSO cookies / PASETO / Bearer tokens.**
+3. Use **run IDs** only; CF opens reports in the tenant UI.
+
+`upload-report.sh check REPORT.md` validates before push; `publish` always checks.
+
+## Workflow
+
+### 1. Obtain their report body
+
+They (or their agent) run **Antithesis-owned** tooling to produce `REPORT.md` in **their** format. Do not substitute a CF template.
+
+### 2. Publish to the wiki
+
+```bash
+tools/antithesis-wiki-report/scripts/upload-report.sh publish \
+  --week 2026-W31 \
+  --authors "Luis Marcano (@LuisMarcano-antithesis)" \
+  path/to/their-report.md
+```
+
+If the filename is already `Antithesis-Report-YYYY-Www.md`, `--week` can be omitted (inferred).
+
+The script:
+
+1. Safety-checks the body (does not rewrite structure)  
+2. Clones the wiki shallowly via `gh`  
+3. Writes `Antithesis-Report-YYYY-Www.md` (content as provided)  
+4. Updates the index table on `Antithesis-Reports`  
+5. Links the week in `_Sidebar`  
+6. Commits and pushes  
+7. Prints the wiki page URL (only that URL to the terminal)
+
+Dry-run (no push):
+
+```bash
+tools/antithesis-wiki-report/scripts/upload-report.sh publish --dry-run --week 2026-W31 REPORT.md
+```
+
+## Agent procedure
+
+When the user asks to upload a weekly Antithesis report:
+
+1. Confirm **week** (`YYYY-Www`), **authors**, and path to **their** markdown body. Target **Thursday before Discord**.
+2. Do **not** reformat into a CF template. If they have no body yet, tell them to run **their** Antithesis skill first — then upload.
+3. Run `check`, then `publish` (ask before push if the environment is shared).
+4. Reply with the bare wiki URL only (no markdown link wrapping).
+
+Do **not** put report content in the CF `Logbook-*` pages.
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `ANTITHESIS_WIKI_REPO` | `cardano-foundation/cardano-node-antithesis` | `owner/repo` whose `.wiki` is updated |
+
+## Files
+
+| Path | Role |
+|---|---|
+| `scripts/upload-report.sh` | `publish` / `check` only (no CF template) |
+
+## Related
+
+- Wiki index (human): https://github.com/cardano-foundation/cardano-node-antithesis/wiki/Antithesis-Reports
+- `tools/antithesis-overview/` — multi-run digest for CF triage; not the weekly status format

--- a/tools/antithesis-wiki-report/scripts/upload-report.sh
+++ b/tools/antithesis-wiki-report/scripts/upload-report.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# Publish an Antithesis weekly platform report to the
+# cardano-node-antithesis GitHub wiki.
+#
+# Report body format is owned by Antithesis (their skill/tooling).
+# This script only safety-checks and uploads the file as-is.
+#
+# Usage:
+#   upload-report.sh publish [--week YYYY-Www] [--authors "..."] [--status filled] [--dry-run] REPORT.md
+#   upload-report.sh check  REPORT.md
+#
+# Requires: bash, git, gh (authenticated with write access to the wiki),
+#           GNU date, sed, awk, mktemp.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+DEFAULT_OWNER_REPO="cardano-foundation/cardano-node-antithesis"
+OWNER_REPO="${ANTITHESIS_WIKI_REPO:-$DEFAULT_OWNER_REPO}"
+WIKI_REMOTE="https://github.com/${OWNER_REPO}.wiki.git"
+INDEX_PAGE="Antithesis-Reports.md"
+SIDEBAR="_Sidebar.md"
+
+die() { echo "error: $*" >&2; exit 1; }
+info() { echo "$*" >&2; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+# ISO week string YYYY-Www for a given day (default: today UTC).
+current_week() {
+  date -u +%G-W%V
+}
+
+# Validate YYYY-Www
+parse_week() {
+  local w=$1
+  [[ "$w" =~ ^([0-9]{4})-W([0-9]{2})$ ]] || die "week must be YYYY-Www (got: $w)"
+  local year=${BASH_REMATCH[1]}
+  # force base-10 (avoid 08/09 octal)
+  local week=$((10#${BASH_REMATCH[2]}))
+  (( week >= 1 && week <= 53 )) || die "ISO week out of range: $w"
+  WEEK_YEAR=$year
+  WEEK_NUM=$week
+  WEEK_LABEL=$(printf '%s-W%02d' "$year" "$week")
+}
+
+# Monday..Sunday (UTC labels) of an ISO week. Uses GNU date + Jan-4 rule.
+week_period() {
+  local year=$1 week=$2
+  local d u mon sun
+  d=$(date -ud "${year}-01-04 +$((week - 1)) weeks" +%F)
+  u=$(date -ud "$d" +%u)
+  mon=$(date -ud "$d -$((u - 1)) days" +%F)
+  sun=$(date -ud "$mon +6 days" +%F)
+  PERIOD="${mon} → ${sun}"
+}
+
+page_name() {
+  echo "Antithesis-Report-${WEEK_LABEL}.md"
+}
+
+# Reject authenticated report URLs / obvious secrets in body.
+check_content() {
+  local file=$1
+  [[ -f "$file" ]] || die "file not found: $file"
+  local bad=0
+
+  if grep -nE 'antithesis\.com/report/[^[:space:]]+\?' "$file" >/dev/null 2>&1; then
+    info "forbidden: authenticated Antithesis report URL (query string / token)"
+    grep -nE 'antithesis\.com/report/' "$file" >&2 || true
+    bad=1
+  fi
+  if grep -nE '(PASETO|__Host-antithesis_sso_session|Bearer [A-Za-z0-9._-]{20,})' "$file" >/dev/null 2>&1; then
+    info "forbidden: session cookie / bearer / PASETO material"
+    bad=1
+  fi
+  if grep -nE 'token=[A-Za-z0-9._%-]{16,}' "$file" >/dev/null 2>&1; then
+    info "forbidden: URL token= parameter"
+    bad=1
+  fi
+  if (( bad )); then
+    die "report fails public-safety checks — use run IDs only, no report tokens"
+  fi
+  info "check: ok ($file)"
+}
+
+# Ensure index table has a row for this week; set status/authors when publishing.
+update_index() {
+  local wiki=$1 authors=$2 status=$3
+  local index="${wiki}/${INDEX_PAGE}"
+  [[ -f "$index" ]] || die "missing ${INDEX_PAGE} in wiki clone — run CF setup first"
+
+  week_period "$WEEK_YEAR" "$WEEK_NUM"
+  local page link authors_cell
+  page=$(page_name)
+  page=${page%.md}
+  link="[${WEEK_LABEL}](${page})"
+  authors_cell=${authors:-—}
+
+  if grep -qE "Antithesis-Report-${WEEK_LABEL}|\]\(Antithesis-Report-${WEEK_LABEL}\)" "$index"; then
+    # Rewrite the matching table row (best-effort; keeps other rows intact).
+    awk -v week="$WEEK_LABEL" -v link="$link" -v period="$PERIOD" \
+        -v authors="$authors_cell" -v status="$status" '
+      BEGIN { OFS="" }
+      {
+        if ($0 ~ ("\\[?" week "\\]?") && $0 ~ /^\|/) {
+          printf "| %s | %s | %s | %s |\n", link, period, authors, status
+          next
+        }
+        print
+      }
+    ' "$index" >"${index}.tmp"
+    mv "${index}.tmp" "$index"
+    info "index: updated row for $WEEK_LABEL"
+  else
+    # Insert a new row after the header separator line of the Index table.
+    awk -v row="| ${link} | ${PERIOD} | ${authors_cell} | ${status} |" '
+      BEGIN { done=0 }
+      {
+        print
+        if (!done && /^\|---/) {
+          # first separator after "| Week |" — insert after it
+          if (prev ~ /Week/) {
+            print row
+            done=1
+          }
+        }
+        prev=$0
+      }
+      END {
+        if (!done) {
+          print row > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$index" >"${index}.tmp" || die "could not insert index row (table shape unexpected)"
+    mv "${index}.tmp" "$index"
+    info "index: added row for $WEEK_LABEL"
+  fi
+}
+
+update_sidebar() {
+  local wiki=$1
+  local sidebar="${wiki}/${SIDEBAR}"
+  [[ -f "$sidebar" ]] || die "missing ${SIDEBAR} in wiki clone"
+  local page
+  page=$(page_name)
+  page=${page%.md}
+
+  if grep -qF "Antithesis-Report-${WEEK_LABEL}" "$sidebar"; then
+    info "sidebar: already lists $WEEK_LABEL"
+    return
+  fi
+
+  # Ensure year section + week bullet under **Antithesis reports**.
+  if ! grep -qF '**Antithesis reports**' "$sidebar"; then
+    cat >>"$sidebar" <<EOF
+
+**Antithesis reports**
+
+- [Index](Antithesis-Reports)
+- ${WEEK_YEAR}
+  - [W$(printf '%02d' "$WEEK_NUM")](${page})
+EOF
+    info "sidebar: created Antithesis reports section"
+    return
+  fi
+
+  if grep -qE "^- ${WEEK_YEAR}\$" "$sidebar"; then
+    # Insert week bullet after the year line (or after existing weeks for that year).
+    awk -v year="$WEEK_YEAR" -v num="$(printf '%02d' "$WEEK_NUM")" -v page="$page" '
+      BEGIN { in_year=0; done=0 }
+      {
+        if ($0 ~ ("^- " year "$")) {
+          print
+          in_year=1
+          next
+        }
+        if (in_year && $0 ~ /^  - \[W/) {
+          print
+          next
+        }
+        if (in_year && !done) {
+          printf "  - [W%s](%s)\n", num, page
+          done=1
+          in_year=0
+        }
+        if ($0 ~ /^\*\*/ || $0 ~ /^- [0-9]{4}$/) {
+          if (in_year && !done) {
+            printf "  - [W%s](%s)\n", num, page
+            done=1
+            in_year=0
+          }
+        }
+        print
+      }
+      END {
+        if (in_year && !done) {
+          printf "  - [W%s](%s)\n", num, page
+        }
+      }
+    ' "$sidebar" >"${sidebar}.tmp"
+    mv "${sidebar}.tmp" "$sidebar"
+  else
+    # Append year block at end of Antithesis section (end of file is fine).
+    cat >>"$sidebar" <<EOF
+- ${WEEK_YEAR}
+  - [W$(printf '%02d' "$WEEK_NUM")](${page})
+EOF
+  fi
+  info "sidebar: linked $WEEK_LABEL"
+}
+
+clone_wiki() {
+  local dest=$1
+  need git
+  need gh
+  info "cloning wiki ${OWNER_REPO}.wiki → $dest"
+  # gh uses the caller's credentials; works for HTTPS wiki remotes.
+  if ! gh repo clone "${OWNER_REPO}.wiki" "$dest" -- --depth 1 2>/dev/null; then
+    # Fallback: some gh versions want the bare .wiki URL via git.
+    git clone --depth 1 "$WIKI_REMOTE" "$dest" \
+      || die "failed to clone wiki (need Write on ${OWNER_REPO} and gh auth)"
+  fi
+}
+
+publish() {
+  local report=$1 authors=$2 status=$3 dry_run=$4
+  [[ -f "$report" ]] || die "report not found: $report"
+  check_content "$report"
+
+  local tmp page
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+
+  clone_wiki "$tmp/wiki"
+  page=$(page_name)
+  cp -- "$report" "$tmp/wiki/${page}"
+  update_index "$tmp/wiki" "$authors" "$status"
+  update_sidebar "$tmp/wiki"
+
+  git -C "$tmp/wiki" add -- "$page" "$INDEX_PAGE" "$SIDEBAR"
+  if git -C "$tmp/wiki" diff --cached --quiet; then
+    info "nothing to commit (wiki already up to date)"
+  else
+    local msg
+    msg="report: Antithesis platform ${WEEK_LABEL}"
+    if [[ -n "$authors" ]]; then
+      msg+=" (${authors})"
+    fi
+    git -C "$tmp/wiki" -c user.useConfigOnly=false \
+      commit -m "$msg" \
+      || die "commit failed (set git user.name / user.email if needed)"
+  fi
+
+  local url="https://github.com/${OWNER_REPO}/wiki/${page%.md}"
+
+  if (( dry_run )); then
+    info "dry-run: not pushing. Local clone: $tmp/wiki"
+    info "would publish: $url"
+    # keep tree for inspection — disable cleanup
+    trap - EXIT
+    return 0
+  fi
+
+  git -C "$tmp/wiki" push origin HEAD \
+    || die "push failed — confirm Write access on ${OWNER_REPO}"
+  info "published: $url"
+  echo "$url"
+}
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") publish [--week YYYY-Www] [--authors NAME] [--status TEXT] [--dry-run] REPORT.md
+  $(basename "$0") check   REPORT.md
+
+Report body format is owned by Antithesis — pass the markdown their skill produced.
+This tool only uploads as-is (plus public-safety checks) and updates the wiki index.
+
+Environment:
+  ANTITHESIS_WIKI_REPO   default ${DEFAULT_OWNER_REPO}
+
+Wiki pages:
+  Antithesis-Report-YYYY-Www.md   weekly report body (their format)
+  Antithesis-Reports.md           index table
+  _Sidebar.md                     navigation
+EOF
+}
+
+main() {
+  need bash
+  need date
+  need sed
+  need awk
+  need mktemp
+
+  local cmd=${1:-}
+  [[ -n "$cmd" ]] || { usage; exit 2; }
+  shift || true
+
+  local week="" week_explicit=0 authors="" status="filled" dry_run=0 report=""
+
+  case "$cmd" in
+    publish)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --week) week=$2; week_explicit=1; shift 2 ;;
+          --authors) authors=$2; shift 2 ;;
+          --status) status=$2; shift 2 ;;
+          --dry-run) dry_run=1; shift ;;
+          -h|--help) usage; exit 0 ;;
+          --) shift; break ;;
+          -*) die "unknown flag: $1" ;;
+          *)
+            if [[ -z "$report" ]]; then
+              report=$1; shift
+            else
+              die "unexpected argument: $1"
+            fi
+            ;;
+        esac
+      done
+      ;;
+    check)
+      report=${1:-}
+      [[ -n "$report" ]] || die "check requires REPORT.md"
+      check_content "$report"
+      exit 0
+      ;;
+    init)
+      die "init removed: Antithesis owns the report format. Generate the body with their skill, then: $0 publish REPORT.md"
+      ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) die "unknown command: $cmd (try publish|check)" ;;
+  esac
+
+  [[ -n "$report" ]] || die "publish requires REPORT.md"
+  if (( ! week_explicit )) && [[ "$report" =~ Antithesis-Report-([0-9]{4}-W[0-9]{2})\.md$ ]]; then
+    week="${BASH_REMATCH[1]}"
+  fi
+
+  if [[ -z "$week" ]]; then
+    week=$(current_week)
+  fi
+  parse_week "$week"
+
+  publish "$report" "$authors" "$status" "$dry_run"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `tools/antithesis-wiki-report/` skill + `upload-report.sh` for publishing weekly Antithesis platform status to the GitHub wiki.
- Format is owned by Antithesis; CF tool only safety-checks and uploads (Thursday before Discord).
- Unblocks wiki links that currently 404 on `main`.

## Test plan
- [x] `upload-report.sh check` rejects tokenized report URLs
- [x] `upload-report.sh publish --dry-run` clones wiki and updates index/sidebar
- [x] Merge; confirm https://github.com/cardano-foundation/cardano-node-antithesis/blob/main/tools/antithesis-wiki-report/SKILL.md resolves