### PR TITLE
ci: make Daily Amaru scheduled preflight explicit and fail loudly

### DIFF
--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -29,9 +29,11 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    # Exactly what the transport's same-repository operations declare they need.
     permissions:
       actions: write
-      contents: read
+      checks: read
+      contents: write
       issues: write
       pull-requests: write
     env:
@@ -43,8 +45,7 @@ jobs:
       - name: Check out exact main
         uses: actions/checkout@v6
 
-      # The stock runner carries neither ripgrep nor nix; the controller's own
-      # dependency preflight fails loudly if this provisioning ever regresses.
+      # The controller's preflight fails loudly if this ever regresses.
       - name: Provision the scheduled dependency census
         run: |
           set -euo pipefail
@@ -54,9 +55,8 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      # An absent variable, an absent secret, or an unsuccessful mint must still
-      # reach the controller with an empty bootstrap identity, so the failure is
-      # a stage of the state machine rather than a skipped setup step.
+      # An absent input or failed mint must still reach the controller with an
+      # empty identity, so the failure is a stage, not a skipped setup step.
       - name: Mint the dedicated bootstrap App identity
         id: app-token
         continue-on-error: true

--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -81,6 +81,8 @@ jobs:
         if: always()
         env:
           DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}
+          DAILY_AMARU_APP_ID: ${{ vars.DAILY_AMARU_APP_ID }}
+          DAILY_AMARU_APP_PRIVATE_KEY: ${{ secrets.DAILY_AMARU_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           scripts/daily-amaru.sh

--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out the exact candidate
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Exercise the controller through the fake transport
         run: tests/test-daily-amaru.sh
 
@@ -72,12 +74,15 @@ jobs:
           permission-pull-requests: write
           permission-metadata: read
 
+      # Always reached: a failed dependency or mint step must become a
+      # classified receipt, not a skipped controller. The controller derives
+      # the UTC day itself, so no external command stands before that boundary.
       - name: Run the once-daily state machine
+        if: always()
         env:
           DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          export DAILY_AMARU_DAY="$(date -u +%F)"
           scripts/daily-amaru.sh
 
       - name: Publish the local decision receipt
@@ -86,4 +91,4 @@ jobs:
         with:
           name: daily-amaru-receipt-${{ github.run_id }}
           path: ${{ runner.temp }}/daily-amaru/receipt
-          if-no-files-found: warn
+          if-no-files-found: error

--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -36,15 +36,54 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
-      DAILY_AMARU_IDENTITY: ${{ secrets.DAILY_AMARU_CROSS_REPO_TOKEN }}
       DAILY_AMARU_MODE: production
+      DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru
+      DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt
     steps:
       - name: Check out exact main
         uses: actions/checkout@v6
+
+      # The stock runner carries neither ripgrep nor nix; the controller's own
+      # dependency preflight fails loudly if this provisioning ever regresses.
+      - name: Provision the scheduled dependency census
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends ripgrep
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      # An absent variable, an absent secret, or an unsuccessful mint must still
+      # reach the controller with an empty bootstrap identity, so the failure is
+      # a stage of the state machine rather than a skipped setup step.
+      - name: Mint the dedicated bootstrap App identity
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DAILY_AMARU_APP_ID }}
+          private-key: ${{ secrets.DAILY_AMARU_APP_PRIVATE_KEY }}
+          owner: lambdasistemi
+          repositories: amaru-bootstrap
+          permission-actions: read
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
+          permission-metadata: read
+
       - name: Run the once-daily state machine
+        env:
+          DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           export DAILY_AMARU_DAY="$(date -u +%F)"
-          export DAILY_AMARU_STATE_DIR="$RUNNER_TEMP/daily-amaru"
-          export DAILY_AMARU_RECEIPT="$RUNNER_TEMP/daily-amaru/receipt"
           scripts/daily-amaru.sh
+
+      - name: Publish the local decision receipt
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: daily-amaru-receipt-${{ github.run_id }}
+          path: ${{ runner.temp }}/daily-amaru/receipt
+          if-no-files-found: warn

--- a/docs/daily-amaru.md
+++ b/docs/daily-amaru.md
@@ -36,7 +36,7 @@ command-line argument; the token is a step-scoped environment binding only.
 
 If an input or the mint step is unavailable, the mint is allowed to fail and the
 controller still runs with an empty identity, exiting non-zero at
-`stage=identity` with `error=missing-production-identity` before any bootstrap,
+`stage=identity` with `error=missing-credentials-<name>` before any bootstrap,
 image, repin, integration, or launch effect.
 
 Every receipt is written locally before external publication is requested, and

--- a/docs/daily-amaru.md
+++ b/docs/daily-amaru.md
@@ -6,6 +6,62 @@ It runs on one fixed UTC cron. Pull requests and manual dispatches execute the
 same state machine through the deterministic fake transport and cannot call
 the real launcher.
 
+## Scheduled runner contract
+
+The scheduled job provisions every non-shell command the production controller
+and transport can reach — `ripgrep` from the runner package index and `nix` from
+the shared setup action — on top of what the stock image already carries. Before
+the UTC day is claimed, the controller asks the transport to preflight that
+census. A missing command is a controller precondition failure, never a setup
+exception: the run exits non-zero at `stage=runner-preflight` with
+`error=missing-command-<name>`, and a preflight that reports nothing or reports
+an unparsable success is rejected as `error=malformed-dependency-evidence`.
+
+Each transport operation declares only the commands it uses, so publishing a
+failure receipt never depends on the command whose absence it reports.
+
+## Bootstrap App identity
+
+Production mints a short-lived token at runtime from a dedicated GitHub App,
+read from repository variable `DAILY_AMARU_APP_ID` and Actions secret
+`DAILY_AMARU_APP_PRIVATE_KEY`. The token is scoped to owner `lambdasistemi`,
+repository `amaru-bootstrap` alone, and exactly five permissions: actions read,
+checks read, contents write, pull requests write, and metadata read.
+
+That token authorizes the bootstrap boundary only. Same-repository work — the
+receipt issue, the consumer repin, consumer check observation, and the launch —
+uses the workflow's own short-lived repository token, which is a separate value
+and is never a substitute for the minted one.
+
+The private key and the minted token are never printed, written to a receipt or
+state artifact, exported through `$GITHUB_ENV`, committed, or reused outside the
+single controller step. The token reaches the transport as a step-scoped
+environment binding, never as a command-line argument.
+
+If the variable, the secret, or the mint step is unavailable, the mint step is
+allowed to fail and the controller still runs with an empty bootstrap identity.
+It then exits non-zero at `stage=identity` with
+`error=missing-production-identity` before any bootstrap proposal, image
+resolution, consumer repin, integration, or launch.
+
+## Durable failure receipts
+
+Every receipt is written to the local receipt file before external publication
+is requested, and the scheduled job uploads that file as an artifact on every
+outcome, including failure. A broken precondition therefore leaves the UTC day,
+the precise stage, `outcome=FAILED`, and a stable specific error behind even
+when the GitHub transport cannot publish its ordinary issue receipt.
+
+## Operator setup gate
+
+This repository implements the interface and the loud missing-input behavior
+only. Creating the App, installing it on `lambdasistemi/amaru-bootstrap`,
+approving its permissions, and placing `DAILY_AMARU_APP_ID` and
+`DAILY_AMARU_APP_PRIVATE_KEY` remain operator actions performed outside this
+repository. Until they are done, the scheduled run is expected to fail at
+`stage=identity`; that is the contract working, not a regression. No secret
+value is recorded here or anywhere in the repository.
+
 ## Decision and durable guards
 
 The GitHub transport first claims the UTC day in issue #210, resolves exactly
@@ -15,11 +71,6 @@ mutation or launch. A changed SHA must claim a no-retry attempt marker before
 any cross-repository mutation. Duplicate days, attempted SHAs, malformed or
 ambiguous observations, and every failed stage retain an honest `FAILED`
 receipt.
-
-Production requires `DAILY_AMARU_CROSS_REPO_TOKEN`, injected as both
-`DAILY_AMARU_IDENTITY` and `GH_TOKEN`. The repository neither creates nor
-defaults that credential. Without it, the controller fails before the
-bootstrap proposal, image publication, consumer repin, integration, or launch.
 
 ## Supervised changed path
 
@@ -62,3 +113,11 @@ tests/test-daily-amaru.sh
 It exercises changed, unchanged, malformed observations, exact-head check
 failures, non-vacuous #202 evidence, duplicate/no-retry guards, failure
 ordering, receipt honesty, and the counted zero-real-launch invariant.
+
+It also reproduces the 2026-08-02 and 2026-08-03 missing-`rg` incidents against
+the real transport in a hermetic seeded PATH, checks the dedicated App scope and
+credential non-persistence, counts the business effects both broken
+preconditions reach, and checks that pull-request CI runs this suite while the
+schedule runs the same controller contract. Every instrument in it — the receipt
+oracle, the seeded PATH, the dependency preflight, the identity boundary, and
+the secret scan — carries controls proving it can fail.

--- a/docs/daily-amaru.md
+++ b/docs/daily-amaru.md
@@ -8,59 +8,49 @@ the real launcher.
 
 ## Scheduled runner contract
 
-The scheduled job provisions every non-shell command the production controller
-and transport can reach — `ripgrep` from the runner package index and `nix` from
-the shared setup action — on top of what the stock image already carries. Before
-the UTC day is claimed, the controller asks the transport to preflight that
-census. A missing command is a controller precondition failure, never a setup
-exception: the run exits non-zero at `stage=runner-preflight` with
-`error=missing-command-<name>`, and a preflight that reports nothing or reports
-an unparsable success is rejected as `error=malformed-dependency-evidence`.
-
-Each transport operation declares only the commands it uses, so publishing a
-failure receipt never depends on the command whose absence it reports.
+The scheduled job provisions every non-shell command the controller and
+transport can reach: `ripgrep` and `nix` on top of the stock image. The
+controller checks the commands it needs to reach the transport at all using
+shell builtins, then has the transport preflight the full census — both before
+the UTC day is claimed. A missing command is a precondition failure, not a setup
+exception: exit non-zero at `stage=runner-preflight` with
+`error=missing-command-<name>`. A preflight reporting nothing or an unparsable
+success is `error=malformed-dependency-evidence`. Each transport operation
+declares only the commands it uses, so publishing a failure receipt never
+depends on the command whose absence it reports.
 
 ## Bootstrap App identity
 
-Production mints a short-lived token at runtime from a dedicated GitHub App,
-read from repository variable `DAILY_AMARU_APP_ID` and Actions secret
-`DAILY_AMARU_APP_PRIVATE_KEY`. The token is scoped to owner `lambdasistemi`,
-repository `amaru-bootstrap` alone, and exactly five permissions: actions read,
-checks read, contents write, pull requests write, and metadata read.
+Production mints a short-lived token from a dedicated GitHub App, named by
+repository variable `DAILY_AMARU_APP_ID` and secret
+`DAILY_AMARU_APP_PRIVATE_KEY`, scoped to owner `lambdasistemi`, repository
+`amaru-bootstrap` alone, and exactly five permissions: actions read, checks
+read, contents write, pull requests write, metadata read.
 
-That token authorizes the bootstrap boundary only. Same-repository work — the
-receipt issue, the consumer repin, consumer check observation, and the launch —
-uses the workflow's own short-lived repository token, which is a separate value
-and is never a substitute for the minted one.
+That token authorizes the bootstrap boundary only. Same-repository work — issue
+receipts, consumer repin, check observation, launch — uses the workflow's own
+repository token, granted exactly the permissions those operations declare. The
+two are never interchangeable, and neither the private key nor the minted token
+is printed, persisted, exported through `$GITHUB_ENV`, committed, or passed as a
+command-line argument; the token is a step-scoped environment binding only.
 
-The private key and the minted token are never printed, written to a receipt or
-state artifact, exported through `$GITHUB_ENV`, committed, or reused outside the
-single controller step. The token reaches the transport as a step-scoped
-environment binding, never as a command-line argument.
+If an input or the mint step is unavailable, the mint is allowed to fail and the
+controller still runs with an empty identity, exiting non-zero at
+`stage=identity` with `error=missing-production-identity` before any bootstrap,
+image, repin, integration, or launch effect.
 
-If the variable, the secret, or the mint step is unavailable, the mint step is
-allowed to fail and the controller still runs with an empty bootstrap identity.
-It then exits non-zero at `stage=identity` with
-`error=missing-production-identity` before any bootstrap proposal, image
-resolution, consumer repin, integration, or launch.
-
-## Durable failure receipts
-
-Every receipt is written to the local receipt file before external publication
-is requested, and the scheduled job uploads that file as an artifact on every
-outcome, including failure. A broken precondition therefore leaves the UTC day,
-the precise stage, `outcome=FAILED`, and a stable specific error behind even
-when the GitHub transport cannot publish its ordinary issue receipt.
+Every receipt is written locally before external publication is requested, and
+the scheduled job uploads that file on every outcome, so a broken precondition
+leaves the day, stage, `outcome=FAILED`, and a specific error behind even when
+the transport cannot publish its issue receipt.
 
 ## Operator setup gate
 
-This repository implements the interface and the loud missing-input behavior
-only. Creating the App, installing it on `lambdasistemi/amaru-bootstrap`,
-approving its permissions, and placing `DAILY_AMARU_APP_ID` and
-`DAILY_AMARU_APP_PRIVATE_KEY` remain operator actions performed outside this
-repository. Until they are done, the scheduled run is expected to fail at
-`stage=identity`; that is the contract working, not a regression. No secret
-value is recorded here or anywhere in the repository.
+Creating the App, installing it on `lambdasistemi/amaru-bootstrap`, approving
+its permissions, and placing the variable and secret are operator actions
+outside this repository. Until they are done the scheduled run is expected to
+fail at `stage=identity`; that is the contract working, not a regression. No
+secret value is recorded anywhere in this repository.
 
 ## Decision and durable guards
 
@@ -115,9 +105,8 @@ failures, non-vacuous #202 evidence, duplicate/no-retry guards, failure
 ordering, receipt honesty, and the counted zero-real-launch invariant.
 
 It also reproduces the 2026-08-02 and 2026-08-03 missing-`rg` incidents against
-the real transport in a hermetic seeded PATH, checks the dedicated App scope and
-credential non-persistence, counts the business effects both broken
-preconditions reach, and checks that pull-request CI runs this suite while the
-schedule runs the same controller contract. Every instrument in it — the receipt
-oracle, the seeded PATH, the dependency preflight, the identity boundary, and
-the secret scan — carries controls proving it can fail.
+the real transport in a hermetic seeded PATH, checks the App scope, credential
+non-persistence, and the token grant/use seam, counts the effects both broken
+preconditions reach, and checks that CI executably calls this suite while the
+schedule calls the controller. Every instrument carries controls proving it can
+fail.

--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -6,6 +6,20 @@ receipt_issue=${DAILY_AMARU_RECEIPT_ISSUE:-210}
 state_dir=${DAILY_AMARU_STATE_DIR:?DAILY_AMARU_STATE_DIR is required}
 bootstrap_repository=${DAILY_AMARU_BOOTSTRAP_REPOSITORY:-lambdasistemi/amaru-bootstrap}
 producer_image=ghcr.io/lambdasistemi/amaru-bootstrap-producer
+
+# The bootstrap App token authorizes lambdasistemi/amaru-bootstrap only. Every
+# same-repository operation uses the workflow's own short-lived repository
+# token instead; the two values are never interchangeable.
+bootstrap_identity=${DAILY_AMARU_IDENTITY:-}
+repository_identity=${GH_TOKEN:-}
+
+# Every non-shell command a reachable production operation needs. The scheduled
+# runner provisions this set and `preflight` reports the first absent member by
+# name, so a missing dependency becomes a controller precondition failure long
+# before any business effect.
+scheduled_command_census=(
+  gh git jq rg sed awk grep tail tr head seq sleep date docker nix
+)
 consumer_required_checks=(
   'Build and push component images for cardano-node testnet|publish-images'
   'Build and push component images for cardano-node testnet|Compose smoke test'
@@ -25,9 +39,15 @@ need_command() {
   command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
 }
 
-for command in gh git jq rg sed; do
-  need_command "$command"
-done
+# Each operation declares the commands it actually reaches for, so publishing a
+# failure receipt never depends on the command whose absence it reports.
+require_commands() {
+  local command
+  for command in "$@"; do
+    need_command "$command"
+  done
+}
+
 mkdir -p "$state_dir"
 
 issue_bodies() {
@@ -42,7 +62,7 @@ comment_issue() {
 with_identity() {
   local identity=$1
   shift
-  [ -n "$identity" ] || die 'cross-repository identity is empty'
+  [ -n "$identity" ] || die 'identity is empty'
   GH_TOKEN=$identity "$@"
 }
 
@@ -95,7 +115,25 @@ operation=${1:?transport operation is required}
 shift
 
 case "$operation" in
+  preflight)
+    requirements=()
+    if [ "$#" -gt 0 ]; then
+      requirements=("$@")
+    else
+      requirements=("${scheduled_command_census[@]}")
+    fi
+    for command in "${requirements[@]}"; do
+      if ! command -v "$command" >/dev/null 2>&1; then
+        printf 'MISSING-COMMAND %s\n' "$command"
+        die "missing command: $command"
+      fi
+    done
+    printf 'OK: %s scheduled dependencies present: %s\n' \
+      "${#requirements[@]}" "${requirements[*]}"
+    ;;
+
   claim-day)
+    require_commands gh grep
     day=${1:?day is required}
     marker="<!-- daily-amaru day=$day claim -->"
     if issue_bodies | grep -Fqx -- "$marker"; then
@@ -105,6 +143,7 @@ case "$operation" in
     ;;
 
   resolve-upstream)
+    require_commands git
     origin=${1:?origin is required}
     ref=${2:?ref is required}
     git ls-remote --heads "$origin" "$ref" |
@@ -114,12 +153,14 @@ case "$operation" in
     ;;
 
   last-success-sha)
+    require_commands gh sed tail
     issue_bodies |
       sed -nE 's/^<!-- daily-amaru last-success sha=([0-9a-f]{40}) -->$/\1/p' |
       tail -n 1
     ;;
 
   claim-sha-attempt)
+    require_commands gh grep
     sha=${1:?upstream SHA is required}
     marker="<!-- daily-amaru attempted-sha=$sha -->"
     if issue_bodies | grep -Fqx -- "$marker"; then
@@ -129,14 +170,14 @@ case "$operation" in
     ;;
 
   propose-bootstrap)
+    require_commands gh git jq nix
     upstream_sha=${1:?upstream SHA is required}
-    identity=${2:?identity is required}
     day=${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}
     directory=$state_dir/bootstrap
     branch="daily-amaru/bootstrap-$day-${upstream_sha:0:12}"
 
     [ ! -e "$directory" ] || die "bootstrap workspace already exists: $directory"
-    with_identity "$identity" gh repo clone "$bootstrap_repository" "$directory" -- --filter=blob:none
+    with_identity "$bootstrap_identity" gh repo clone "$bootstrap_repository" "$directory" -- --filter=blob:none
     git -C "$directory" checkout -b "$branch" origin/main
 
     # TODO(amaru-bootstrap#75): replace this crude stock-pin proposal with
@@ -172,20 +213,20 @@ case "$operation" in
     git -C "$directory" -c user.name='daily-amaru' \
       -c user.email='daily-amaru@users.noreply.github.com' \
       commit -m "chore: bump stock Amaru to $upstream_sha"
-    push_branch "$directory" "$branch" "$identity"
+    push_branch "$directory" "$branch" "$bootstrap_identity"
     pr_url=$(create_or_find_pr "$bootstrap_repository" "$branch" \
       "chore: bump stock Amaru to ${upstream_sha:0:12}" \
       "Daily Amaru controller proposal for exact upstream $upstream_sha." \
-      "$identity")
+      "$bootstrap_identity")
     printf '%s\n' "$pr_url" >"$state_dir/bootstrap-pr"
     git -C "$directory" rev-parse HEAD
     ;;
 
   require-bootstrap-checks)
+    require_commands gh jq awk
     candidate=${1:?bootstrap candidate is required}
-    identity=${DAILY_AMARU_IDENTITY:?DAILY_AMARU_IDENTITY is required}
     checks=${DAILY_AMARU_BOOTSTRAP_CHECKS:-Build,Run unit Tests,Check code quality,publish-images}
-    rows=$(collect_action_rows "$bootstrap_repository" "$candidate" "$identity")
+    rows=$(collect_action_rows "$bootstrap_repository" "$candidate" "$bootstrap_identity")
     IFS=',' read -r -a required <<<"$checks"
     for name in "${required[@]}"; do
       count=$(awk -F'|' -v n="$name" -v h="$candidate" \
@@ -197,6 +238,7 @@ case "$operation" in
     ;;
 
   resolve-image)
+    require_commands docker tr
     candidate=${1:?bootstrap candidate is required}
     image_tag="$producer_image:$candidate"
     digest=$(docker buildx imagetools inspect "$image_tag" \
@@ -206,14 +248,14 @@ case "$operation" in
     ;;
 
   prepare-consumer-repin)
+    require_commands gh git rg sed
     image_ref=${1:?image reference is required}
-    identity=${2:?identity is required}
     day=${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}
     directory=$state_dir/consumer
     branch="daily-amaru/consumer-$day"
 
     [ ! -e "$directory" ] || die "consumer workspace already exists: $directory"
-    with_identity "$identity" gh repo clone "$repository" "$directory" -- --filter=blob:none
+    with_identity "$repository_identity" gh repo clone "$repository" "$directory" -- --filter=blob:none
     git -C "$directory" checkout -b "$branch" origin/main
     mapfile -t producer_files < <(
       rg -l "image:.*$producer_image" "$directory/testnets" -g '*.yaml' -g '*.yml'
@@ -233,21 +275,21 @@ case "$operation" in
     git -C "$directory" -c user.name='daily-amaru' \
       -c user.email='daily-amaru@users.noreply.github.com' \
       commit -m "chore: repin Amaru producer to exact digest"
-    push_branch "$directory" "$branch" "$identity"
+    push_branch "$directory" "$branch" "$repository_identity"
     pr_url=$(create_or_find_pr "$repository" "$branch" \
       'chore: repin Amaru producer to exact digest' \
       "Daily Amaru controller repin to $image_ref. Integration is lane-supervised." \
-      "$identity")
+      "$repository_identity")
     printf '%s\n' "$pr_url" >"$state_dir/consumer-pr"
     git -C "$directory" rev-parse HEAD
     ;;
 
   require-consumer-checks)
+    require_commands gh jq awk
     candidate=${1:?consumer candidate is required}
-    identity=${DAILY_AMARU_IDENTITY:?DAILY_AMARU_IDENTITY is required}
     # TODO(cardano-node-antithesis#208): replace this explicit current-head
     # census with the complete exact-revision interface preflight.
-    rows=$(collect_action_rows "$repository" "$candidate" "$identity")
+    rows=$(collect_action_rows "$repository" "$candidate" "$repository_identity")
     for required in "${consumer_required_checks[@]}"; do
       workflow=${required%%|*}
       name=${required#*|}
@@ -261,6 +303,7 @@ case "$operation" in
     ;;
 
   run-producer-check)
+    require_commands git
     candidate=${1:?consumer candidate is required}
     directory=$state_dir/consumer
     [ "$(git -C "$directory" rev-parse HEAD)" = "$candidate" ] ||
@@ -272,12 +315,12 @@ case "$operation" in
     ;;
 
   await-supervised-integration)
+    require_commands gh jq
     candidate=${1:?consumer candidate is required}
-    identity=${DAILY_AMARU_IDENTITY:?DAILY_AMARU_IDENTITY is required}
     # TODO(cardano-node-antithesis#207): replace lane-supervised integration
     # and launch correlation after the guarded unattended platform exists.
     read -r pr_url <"$state_dir/consumer-pr"
-    pr_json=$(with_identity "$identity" gh pr view "$pr_url" -R "$repository" \
+    pr_json=$(with_identity "$repository_identity" gh pr view "$pr_url" -R "$repository" \
       --json state,headRefOid,mergeCommit)
     state=$(jq -r .state <<<"$pr_json")
     head=$(jq -r .headRefOid <<<"$pr_json")
@@ -285,7 +328,7 @@ case "$operation" in
     [ "$state" = MERGED ] || die 'consumer repin is awaiting guarded integration'
     [ "$head" = "$candidate" ] || die 'integrated PR head differs from the verified candidate'
     [[ "$merged" =~ ^[0-9a-f]{40}$ ]] || die 'missing merge commit SHA'
-    main_head=$(with_identity "$identity" gh api "repos/$repository/git/ref/heads/main" \
+    main_head=$(with_identity "$repository_identity" gh api "repos/$repository/git/ref/heads/main" \
       --jq .object.sha)
     [ "$main_head" = "$merged" ] || die 'merged consumer commit is not exact current main'
     printf '%s\n' "$merged"
@@ -302,24 +345,24 @@ case "$operation" in
     ;;
 
   real-launch)
+    require_commands gh date seq sleep head
     workflow=${1:?workflow is required}
     testnet=${2:?testnet is required}
     duration=${3:?duration is required}
     no_faults=${4:?fault setting is required}
     integrated=${5:?integrated SHA is required}
-    identity=${DAILY_AMARU_IDENTITY:?DAILY_AMARU_IDENTITY is required}
     [ "$workflow" = cardano-node.yaml ] && [ "$testnet" = cardano_amaru ] &&
       [ "$duration" = duration=1 ] && [ "$no_faults" = no-faults=false ] ||
       die 'real launch shape differs from the frozen contract'
-    main_head=$(with_identity "$identity" gh api "repos/$repository/git/ref/heads/main" \
+    main_head=$(with_identity "$repository_identity" gh api "repos/$repository/git/ref/heads/main" \
       --jq .object.sha)
     [ "$main_head" = "$integrated" ] || die 'real launch target is not exact main'
     started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    with_identity "$identity" gh workflow run cardano-node.yaml -R "$repository" \
+    with_identity "$repository_identity" gh workflow run cardano-node.yaml -R "$repository" \
       --ref "$integrated" -f test=cardano_amaru -f duration=1 -f no-faults=false
     run_id=''
     for _ in $(seq 1 30); do
-      run_id=$(with_identity "$identity" gh run list -R "$repository" \
+      run_id=$(with_identity "$repository_identity" gh run list -R "$repository" \
         --workflow cardano-node.yaml --commit "$integrated" --event workflow_dispatch \
         --limit 10 --json databaseId,createdAt \
         --jq ".[] | select(.createdAt >= \"$started\") | .databaseId" | head -n 1)
@@ -327,11 +370,14 @@ case "$operation" in
       sleep 2
     done
     [ -n "$run_id" ] || die 'launched workflow run was not observable'
-    with_identity "$identity" gh run watch "$run_id" -R "$repository" --exit-status
+    with_identity "$repository_identity" gh run watch "$run_id" -R "$repository" --exit-status
     printf 'https://github.com/%s/actions/runs/%s\n' "$repository" "$run_id"
     ;;
 
   receipt)
+    # Minimum dependency surface on purpose: external publication of a failure
+    # receipt must not require the command whose absence it is reporting.
+    require_commands gh
     # TODO(cardano-node-antithesis#206): replace issue-comment receipts with
     # complete per-property accounting and an independent missing-day alarm.
     body='<!-- daily-amaru receipt -->'

--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -7,16 +7,13 @@ state_dir=${DAILY_AMARU_STATE_DIR:?DAILY_AMARU_STATE_DIR is required}
 bootstrap_repository=${DAILY_AMARU_BOOTSTRAP_REPOSITORY:-lambdasistemi/amaru-bootstrap}
 producer_image=ghcr.io/lambdasistemi/amaru-bootstrap-producer
 
-# The bootstrap App token authorizes lambdasistemi/amaru-bootstrap only. Every
-# same-repository operation uses the workflow's own short-lived repository
-# token instead; the two values are never interchangeable.
+# The App token authorizes lambdasistemi/amaru-bootstrap only; same-repository
+# operations use the workflow's own token. The two are never interchangeable.
 bootstrap_identity=${DAILY_AMARU_IDENTITY:-}
 repository_identity=${GH_TOKEN:-}
 
-# Every non-shell command a reachable production operation needs. The scheduled
-# runner provisions this set and `preflight` reports the first absent member by
-# name, so a missing dependency becomes a controller precondition failure long
-# before any business effect.
+# D213-04: every non-shell command a reachable production operation needs.
+# `preflight` reports the first absent member by name.
 scheduled_command_census=(
   gh git jq rg sed awk grep tail tr head seq sleep date docker nix
 )
@@ -39,8 +36,8 @@ need_command() {
   command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
 }
 
-# Each operation declares the commands it actually reaches for, so publishing a
-# failure receipt never depends on the command whose absence it reports.
+# Per-operation, so publishing a failure receipt never depends on the command
+# whose absence it reports.
 require_commands() {
   local command
   for command in "$@"; do
@@ -133,6 +130,7 @@ case "$operation" in
     ;;
 
   claim-day)
+    # repository-token-permissions: issues=write
     require_commands gh grep
     day=${1:?day is required}
     marker="<!-- daily-amaru day=$day claim -->"
@@ -153,6 +151,7 @@ case "$operation" in
     ;;
 
   last-success-sha)
+    # repository-token-permissions: issues=read
     require_commands gh sed tail
     issue_bodies |
       sed -nE 's/^<!-- daily-amaru last-success sha=([0-9a-f]{40}) -->$/\1/p' |
@@ -160,6 +159,7 @@ case "$operation" in
     ;;
 
   claim-sha-attempt)
+    # repository-token-permissions: issues=write
     require_commands gh grep
     sha=${1:?upstream SHA is required}
     marker="<!-- daily-amaru attempted-sha=$sha -->"
@@ -248,6 +248,7 @@ case "$operation" in
     ;;
 
   prepare-consumer-repin)
+    # repository-token-permissions: contents=write pull-requests=write
     require_commands gh git rg sed
     image_ref=${1:?image reference is required}
     day=${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}
@@ -285,6 +286,7 @@ case "$operation" in
     ;;
 
   require-consumer-checks)
+    # repository-token-permissions: actions=read checks=read
     require_commands gh jq awk
     candidate=${1:?consumer candidate is required}
     # TODO(cardano-node-antithesis#208): replace this explicit current-head
@@ -315,6 +317,7 @@ case "$operation" in
     ;;
 
   await-supervised-integration)
+    # repository-token-permissions: contents=read pull-requests=read
     require_commands gh jq
     candidate=${1:?consumer candidate is required}
     # TODO(cardano-node-antithesis#207): replace lane-supervised integration
@@ -345,6 +348,7 @@ case "$operation" in
     ;;
 
   real-launch)
+    # repository-token-permissions: actions=write contents=read
     require_commands gh date seq sleep head
     workflow=${1:?workflow is required}
     testnet=${2:?testnet is required}
@@ -375,8 +379,8 @@ case "$operation" in
     ;;
 
   receipt)
-    # Minimum dependency surface on purpose: external publication of a failure
-    # receipt must not require the command whose absence it is reporting.
+    # repository-token-permissions: issues=write
+    # Minimum dependency surface on purpose.
     require_commands gh
     # TODO(cardano-node-antithesis#206): replace issue-comment receipts with
     # complete per-property accounting and an independent missing-day alarm.

--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ -n "${DAILY_AMARU_EFFECT_LOG:-}" ]; then
+  {
+    printf 'transport'
+    if [ "$#" -gt 0 ]; then
+      printf ' %s' "$@"
+    fi
+    printf '\n'
+  } >>"$DAILY_AMARU_EFFECT_LOG"
+fi
+
 repository=${DAILY_AMARU_REPOSITORY:-${GITHUB_REPOSITORY:-cardano-foundation/cardano-node-antithesis}}
 receipt_issue=${DAILY_AMARU_RECEIPT_ISSUE:-210}
 state_dir=${DAILY_AMARU_STATE_DIR:?DAILY_AMARU_STATE_DIR is required}

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-
 mode=${DAILY_AMARU_MODE:-production}
-transport=${DAILY_AMARU_TRANSPORT:-$script_dir/daily-amaru-github.sh}
-day=${DAILY_AMARU_DAY:-$(date -u +%F)}
 identity=${DAILY_AMARU_IDENTITY:-}
 state_dir=${DAILY_AMARU_STATE_DIR:-${RUNNER_TEMP:-/tmp}/daily-amaru}
 receipt_path=${DAILY_AMARU_RECEIPT:-$state_dir/receipt}
@@ -18,16 +14,23 @@ die() {
   exit 1
 }
 
-[[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
-  die "invalid UTC day: $day"
+# Builtin-only dirname: the failure receipt must stay reachable while the
+# external command set is still unverified, so nothing here may shell out.
+path_directory() {
+  local path=$1
+  if [[ "$path" != */* ]]; then
+    printf '.'
+    return 0
+  fi
+  path=${path%/*}
+  printf '%s' "${path:-/}"
+}
 
 case "$mode" in
   production | manual | pull_request | test) ;;
   *) die "unsupported mode: $mode" ;;
 esac
 
-[ -x "$transport" ] || die "transport is not executable: $transport"
-mkdir -p "$state_dir"
 export DAILY_AMARU_STATE_DIR=$state_dir
 export DAILY_AMARU_RECEIPT=$receipt_path
 
@@ -36,7 +39,6 @@ transport_call() {
 }
 
 declare -A receipt=()
-receipt[day]=$day
 receipt[upstream_origin]=$origin
 receipt[upstream_ref]=$ref
 
@@ -75,11 +77,14 @@ compose_receipt() {
   done
 }
 
-# The local receipt is refreshed before any external publication is requested,
-# so a transport whose own preconditions are broken cannot erase the only
-# record that the day produced a decision.
+# Refreshed before any external publication, so a transport whose own
+# preconditions are broken cannot erase the only record of the day.
 persist_local_receipt() {
-  mkdir -p "$(dirname "$receipt_path")"
+  local receipt_dir
+  receipt_dir=$(path_directory "$receipt_path")
+  if [ ! -d "$receipt_dir" ]; then
+    mkdir -p -- "$receipt_dir" 2>/dev/null || true
+  fi
   printf '%s\n' "${receipt_fields[@]}" >"$receipt_path"
 }
 
@@ -100,8 +105,33 @@ fail_stage() {
   die "$stage: $message"
 }
 
-# The scheduled runner contract is checked before the UTC day is claimed, so a
-# runner missing a required command costs neither the day nor a business effect.
+# First executable boundary: the commands needed to reach the transport at all,
+# checked with builtins only so absence is classified rather than crashing.
+bootstrap_command_census=(dirname mkdir)
+[ -n "${DAILY_AMARU_DAY:-}" ] || bootstrap_command_census+=(date)
+for command in "${bootstrap_command_census[@]}"; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf 'daily-amaru: missing command: %s\n' "$command" >&2
+    receipt[day]=${DAILY_AMARU_DAY:-unknown}
+    compose_receipt runner-preflight FAILED "error=missing-command-$command"
+    persist_local_receipt
+    die "runner-preflight: missing-command-$command"
+  fi
+done
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+transport=${DAILY_AMARU_TRANSPORT:-$script_dir/daily-amaru-github.sh}
+day=${DAILY_AMARU_DAY:-$(date -u +%F)}
+receipt[day]=$day
+
+[[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
+  die "invalid UTC day: $day"
+
+[ -x "$transport" ] || die "transport is not executable: $transport"
+mkdir -p "$state_dir"
+
+# The full census is checked before the UTC day is claimed, so a runner missing
+# a required command costs neither the day nor a business effect.
 preflight_rc=0
 preflight_output=$(transport_call preflight) || preflight_rc=$?
 if [ "$preflight_rc" -ne 0 ]; then
@@ -165,8 +195,7 @@ if [ "$mode" = production ]; then
 else
   identity=dry-run
 fi
-# The bootstrap identity reaches the transport through the process environment
-# only; it is never placed on a command line where any process could read it.
+# Process environment only: never a command-line argument any process can read.
 export DAILY_AMARU_IDENTITY=$identity
 
 if ! transport_call claim-sha-attempt "$observed_sha"; then

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -42,6 +42,7 @@ receipt[upstream_ref]=$ref
 
 receipt_keys=(
   day stage outcome error
+  dependency_census
   upstream_origin upstream_ref upstream_sha
   bootstrap_candidate_sha image_ref
   consumer_candidate_sha check_evidence producer_count producer_evidence
@@ -50,11 +51,12 @@ receipt_keys=(
   launch_request moog_request run_outcome
 )
 
-write_receipt() {
+receipt_fields=()
+
+compose_receipt() {
   local stage=$1
   local outcome=$2
   local pair key value
-  local -a fields=()
   shift 2
 
   receipt[stage]=$stage
@@ -65,20 +67,55 @@ write_receipt() {
     value=${pair#*=}
     receipt["$key"]=$value
   done
+  receipt_fields=()
   for key in "${receipt_keys[@]}"; do
     if [[ -v "receipt[$key]" ]]; then
-      fields+=("$key=${receipt[$key]}")
+      receipt_fields+=("$key=${receipt[$key]}")
     fi
   done
-  transport_call receipt "${fields[@]}"
+}
+
+# The local receipt is refreshed before any external publication is requested,
+# so a transport whose own preconditions are broken cannot erase the only
+# record that the day produced a decision.
+persist_local_receipt() {
+  mkdir -p "$(dirname "$receipt_path")"
+  printf '%s\n' "${receipt_fields[@]}" >"$receipt_path"
+}
+
+write_receipt() {
+  compose_receipt "$@"
+  persist_local_receipt
+  transport_call receipt "${receipt_fields[@]}"
 }
 
 fail_stage() {
   local stage=$1
   local message=$2
-  write_receipt "$stage" FAILED "error=$message"
+  compose_receipt "$stage" FAILED "error=$message"
+  persist_local_receipt
+  if ! transport_call receipt "${receipt_fields[@]}"; then
+    printf 'daily-amaru: external receipt publication failed: %s\n' "$stage" >&2
+  fi
   die "$stage: $message"
 }
+
+# The scheduled runner contract is checked before the UTC day is claimed, so a
+# runner missing a required command costs neither the day nor a business effect.
+preflight_rc=0
+preflight_output=$(transport_call preflight) || preflight_rc=$?
+if [ "$preflight_rc" -ne 0 ]; then
+  missing_command=''
+  while read -r marker name _; do
+    [ "$marker" = MISSING-COMMAND ] || continue
+    missing_command=$name
+  done <<<"$preflight_output"
+  [ -n "$missing_command" ] || missing_command=unreported
+  fail_stage runner-preflight "missing-command-$missing_command"
+fi
+[[ "$preflight_output" =~ ^OK:\ [1-9][0-9]*\ scheduled\ dependencies\ present:\ .+$ ]] ||
+  fail_stage runner-preflight malformed-dependency-evidence
+receipt[dependency_census]=$preflight_output
 
 if ! transport_call claim-day "$day"; then
   fail_stage day-claim duplicate-day
@@ -128,6 +165,9 @@ if [ "$mode" = production ]; then
 else
   identity=dry-run
 fi
+# The bootstrap identity reaches the transport through the process environment
+# only; it is never placed on a command line where any process could read it.
+export DAILY_AMARU_IDENTITY=$identity
 
 if ! transport_call claim-sha-attempt "$observed_sha"; then
   fail_stage launch-attempt sha-already-attempted
@@ -135,7 +175,7 @@ fi
 write_receipt launch-attempt CLAIMED
 
 bootstrap_sha=''
-if ! bootstrap_sha=$(transport_call propose-bootstrap "$observed_sha" "$identity"); then
+if ! bootstrap_sha=$(transport_call propose-bootstrap "$observed_sha"); then
   fail_stage bootstrap-proposal proposal-failed
 fi
 [[ "$bootstrap_sha" =~ ^[0-9a-f]{40}$ ]] ||
@@ -158,7 +198,7 @@ receipt[image_ref]=$image_ref
 write_receipt image-resolution VERIFIED
 
 consumer_sha=''
-if ! consumer_sha=$(transport_call prepare-consumer-repin "$image_ref" "$identity"); then
+if ! consumer_sha=$(transport_call prepare-consumer-repin "$image_ref"); then
   fail_stage consumer-repin preparation-failed
 fi
 [[ "$consumer_sha" =~ ^[0-9a-f]{40}$ ]] ||

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -210,7 +210,15 @@ if [ "$observed_sha" = "$last_success" ]; then
 fi
 
 if [ "$mode" = production ]; then
-  [ -n "$identity" ] || fail_stage identity missing-production-identity
+  if [ -z "$identity" ]; then
+    missing_creds=()
+    [ -n "${DAILY_AMARU_APP_ID:-}" ] || missing_creds+=(DAILY_AMARU_APP_ID)
+    [ -n "${DAILY_AMARU_APP_PRIVATE_KEY:-}" ] || missing_creds+=(DAILY_AMARU_APP_PRIVATE_KEY)
+    if [ "${#missing_creds[@]}" -gt 0 ]; then
+      fail_stage identity "missing-credentials-$(IFS=,; printf '%s' "${missing_creds[*]}")"
+    fi
+    fail_stage identity missing-production-identity
+  fi
 else
   identity=dry-run
 fi

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -26,6 +26,14 @@ path_directory() {
   printf '%s' "${path:-/}"
 }
 
+# Builtin-only UTC day: the failure receipt must still carry a real day when
+# the missing external command is `date` itself.
+utc_day() {
+  local day=${DAILY_AMARU_DAY:-}
+  [ -n "$day" ] || day=$(TZ=UTC0 printf '%(%Y-%m-%d)T' -1)
+  printf '%s' "$day"
+}
+
 case "$mode" in
   production | manual | pull_request | test) ;;
   *) die "unsupported mode: $mode" ;;
@@ -77,15 +85,26 @@ compose_receipt() {
   done
 }
 
+# Independently writable durable sink. An unreachable primary receipt path —
+# a nested parent the runner never created, with `mkdir` itself missing — must
+# not erase the machine-readable failure.
+publish_independent_receipt() {
+  printf '%s\n' "${receipt_fields[@]}" >&2
+}
+
 # Refreshed before any external publication, so a transport whose own
-# preconditions are broken cannot erase the only record of the day.
+# preconditions are broken cannot erase the only record of the day. The primary
+# receipt stays authoritative wherever it is writable.
 persist_local_receipt() {
   local receipt_dir
   receipt_dir=$(path_directory "$receipt_path")
   if [ ! -d "$receipt_dir" ]; then
     mkdir -p -- "$receipt_dir" 2>/dev/null || true
   fi
-  printf '%s\n' "${receipt_fields[@]}" >"$receipt_path"
+  if printf '%s\n' "${receipt_fields[@]}" >"$receipt_path"; then
+    return 0
+  fi
+  publish_independent_receipt
 }
 
 write_receipt() {
@@ -112,7 +131,7 @@ bootstrap_command_census=(dirname mkdir)
 for command in "${bootstrap_command_census[@]}"; do
   if ! command -v "$command" >/dev/null 2>&1; then
     printf 'daily-amaru: missing command: %s\n' "$command" >&2
-    receipt[day]=${DAILY_AMARU_DAY:-unknown}
+    receipt[day]=$(utc_day)
     compose_receipt runner-preflight FAILED "error=missing-command-$command"
     persist_local_receipt
     die "runner-preflight: missing-command-$command"

--- a/specs/213-daily-amaru-scheduled-preflight/data-model.md
+++ b/specs/213-daily-amaru-scheduled-preflight/data-model.md
@@ -1,0 +1,24 @@
+# Data model — Issue 213
+
+Artifact ceiling: 4,000 bytes and 100 lines.
+
+| ID | Data | Required fields / shape | Invariants |
+|---|---|---|---|
+| D213-01 | Failure receipt | `day` as UTC `YYYY-MM-DD`; precise `stage`; `outcome=FAILED`; specific stable `error`; existing observation/effect fields when known | INV-213-01, INV-213-02, INV-213-04 |
+| D213-02 | Bootstrap App interface | variable name `DAILY_AMARU_APP_ID`; secret name `DAILY_AMARU_APP_PRIVATE_KEY`; owner `lambdasistemi`; repository set containing only `amaru-bootstrap`; permissions exactly actions read, checks read, contents write, pull requests write, metadata read | INV-213-03, INV-213-05 |
+| D213-03 | Minted bootstrap identity | short-lived token output from D213-02; empty when configuration or minting is unavailable; step-scoped and secret-valued | INV-213-03 through INV-213-05 |
+| D213-04 | Scheduled dependency census | explicit non-shell command names required by every reachable production transport operation, including the incident command `rg`; each has provisioned and observed status | INV-213-01, INV-213-07, INV-213-09 |
+| D213-05 | Effect census | counts for attempt claim, bootstrap proposal, image resolution, consumer repin, supervised integration, fake launch, and real launch | INV-213-06 through INV-213-08 |
+| D213-06 | Incident evidence | base SHA `311dfc1d499277b23035a107eaf0ec097cf3d948`; days `2026-08-02` and `2026-08-03`; fingerprint `daily-amaru-github: missing command: rg`; exit, receipt, and D213-05 observations | INV-213-02, INV-213-07 |
+
+The stable precondition verdicts are `stage=runner-preflight` with
+`error=missing-command-rg`, and `stage=identity` with
+`error=missing-production-identity`.
+
+D213-02 and D213-03 authorize only the bootstrap repository. The workflow's
+default short-lived repository token is a separate value for cna issue and
+consumer operations and is never represented as D213-03.
+
+Failure receipts and intentional failure-publication bookkeeping are evidence,
+not business mutations. INV-213-06 forbids attempt/bootstrap/image/consumer/
+integration/launch effects while still requiring the failure evidence itself.

--- a/specs/213-daily-amaru-scheduled-preflight/functions-model.md
+++ b/specs/213-daily-amaru-scheduled-preflight/functions-model.md
@@ -1,0 +1,20 @@
+# Functions model — Issue 213
+
+Artifact ceiling: 4,000 bytes and 100 lines.
+
+This file defines only changed interface signatures and constraints. Shell
+values are UTF-8 strings unless a stricter type is named.
+
+| ID | Interface | Arguments | Result / effects | Constraints |
+|---|---|---|---|---|
+| FN-213-01 | `write_receipt` | `stage: Stage`, `outcome: Outcome`, `fields: ReceiptField[]` | `Status`; refreshes D213-01 and requests external publication | Local D213-01 must exist before transport publication is attempted |
+| FN-213-02 | `fail_stage` | `stage: Stage`, `error: ErrorCode` | Non-zero termination after FN-213-01 | Error is specific; failure cannot become unchanged/changed/success |
+| FN-213-03 | transport `preflight` operation | `requirements: CommandName[]` | Success with D213-04 evidence, or non-zero missing-command result | No claim, mutation, integration, or launch effect |
+| FN-213-04 | transport `receipt` operation | `fields: ReceiptField[]` | External receipt publication status | Minimum dependency surface; must not require the command whose absence it reports when an independent sink remains available |
+| FN-213-05 | `with_identity` | `identity: SecretToken`, `command: Command`, `arguments: String[]` | Command status and output | Token is process-environment-only and never printed or persisted |
+| FN-213-06 | transport `prepare-consumer-repin` operation | `image_ref: ImageRef` | Exact consumer candidate SHA | Uses the cna repository token, never D213-03 |
+
+`Stage` includes distinct scheduled dependency preflight and production
+identity values. `ErrorCode` distinguishes at least the missing command name
+and missing production identity. Existing transport operation signatures not
+listed here remain unchanged.

--- a/specs/213-daily-amaru-scheduled-preflight/modules-model.md
+++ b/specs/213-daily-amaru-scheduled-preflight/modules-model.md
@@ -1,0 +1,19 @@
+# Modules model — Issue 213
+
+Artifact ceiling: 4,000 bytes and 90 lines.
+
+Only changed responsibilities are listed. Data IDs refer to
+`data-model.md`; interface IDs refer to `functions-model.md`.
+
+| ID | Component | Changed responsibility | Depends on | Must not own |
+|---|---|---|---|---|
+| MOD-213-01 | `.github/workflows/daily-amaru.yaml` | Provision the scheduled command set; request D213-02 from the dedicated App interface; bind D213-03 only to the controller step; durably publish D213-01 on every outcome | MOD-213-02, GitHub Actions token minting | Controller policy, App creation/installation, secret persistence, real-run authorization |
+| MOD-213-02 | `scripts/daily-amaru.sh` | Enforce INV-213-01 and INV-213-04; maintain D213-01 locally before external publication; preserve existing ordered state-machine policy | FN-213-01, FN-213-02, MOD-213-03 | Repository-specific API mechanics or token minting |
+| MOD-213-03 | `scripts/daily-amaru-github.sh` | Validate D213-04; publish receipts with the minimum viable dependency surface; keep D213-02 and D213-03 on their distinct repository boundaries | FN-213-03 through FN-213-06 | Daily policy, App credentials, consumer self-merge, live authorization |
+| MOD-213-04 | `tests/test-daily-amaru.sh` and `tests/fixtures/daily-amaru/**` | Prove INV-213-01 through INV-213-09 with dated incident evidence, non-vacuous receipt validation, and explicit effect counts | MOD-213-01 through MOD-213-03 | Production credentials, network mutation, real launch |
+| MOD-213-05 | `docs/daily-amaru.md` | Describe the explicit runner/App interface, failure receipts, operator setup gate, and local proof | D213-01 through D213-04 | Secret values or claims that live setup is complete |
+
+Dependency direction is workflow → controller → transport. Proof observes all
+three but production never depends on proof code. Receipt durability belongs
+at the controller/workflow seam so a failed transport command cannot erase the
+only failure record.

--- a/specs/213-daily-amaru-scheduled-preflight/plan.md
+++ b/specs/213-daily-amaru-scheduled-preflight/plan.md
@@ -1,0 +1,94 @@
+# Plan — Issue 213 Daily Amaru scheduled preflight
+
+Artifact ceiling: 8,000 bytes and 180 lines.
+
+## Technical context
+
+The frozen and freshly revalidated base is
+`311dfc1d499277b23035a107eaf0ec097cf3d948`. The existing local ticket gate is
+green on that tree, while scheduled runs 30734090142 and 30787205335 failed
+before controller state with the exact missing-`rg` fingerprint. The same
+scheduled environment exposed no production identity.
+
+Parent answer A-001 selects a dedicated least-privilege GitHub App installed
+only on `lambdasistemi/amaru-bootstrap`. Local implementation is released;
+App creation/installation, secret placement, workflow dispatch, real launch,
+merge, and downstream ticket release remain forbidden.
+
+## Architecture
+
+The module responsibility changes are defined in `modules-model.md`; receipt
+and identity fields are defined in `data-model.md`; changed interfaces are
+defined in `functions-model.md`.
+
+The scheduled workflow owns explicit tool availability, dedicated App-token
+minting, short-lived token binding, and durable publication of the local
+receipt. The controller owns precondition ordering and receipt-first failure
+semantics. The GitHub transport owns command validation and enforces the
+bootstrap-versus-consumer identity boundary. Focused proof owns incident
+reproduction, negative controls, side-effect counts, and production wiring
+reachability.
+
+No new general orchestration framework is introduced. A focused receipt or
+preflight helper is permitted only if it has one responsibility already named
+by the module model and is required to keep the failure sink independent of
+the failed transport dependency.
+
+## Proof strategy
+
+The immutable slice gate binds INV-213-01 through INV-213-09 and the complete
+owned-path fence. Before implementation it must:
+
+- reproduce both exact dated missing-`rg` fingerprints on `311dfc1`;
+- demonstrate that the current path has no durable receipt for that failure;
+- reject missing, partial, non-failure, and vague receipt records;
+- positively accept a complete synthetic failure receipt so absence checks do
+  not rely on a broken instrument;
+- remain red until scheduled App wiring, identity separation, negative
+  controls, and explicit evidence signals exist.
+
+GREEN requires the focused suite, immutable slice gate, historical Daily
+Amaru ticket gate, shell analysis, producer-reference census, live entrypoint
+contract, and `git diff --check`. Gate output names evidence counts rather than
+passing silently.
+
+## Slice S213-01 — Scheduled preflight and identity boundary
+
+Topology is `OWNER`. The slice crosses workflow security, state-machine
+failure ordering, credential scope, and durable receipt semantics, so a
+mechanical LIGHT gate is insufficient.
+
+- Ticket owner: Codex, pane `%5294`.
+- Commit owner: fresh Claude Code using `claude-opus-5[1m]`, effort `high`.
+- Draft tool: `NONE`; qwen and agy are not authorized for this slice.
+- Commit auditor: fresh Codex using `gpt-5.6-sol`, effort `xhigh`, in a clean
+  detached worktree after each submission.
+- Audited submissions: maximum two; one findings-driven owner repair only.
+- Commit owner and auditor have no push, remote-publication, live-dispatch,
+  secret-setup, or merge authority.
+
+The owner creates one complete RED commit and one GREEN candidate, then parks
+write-idle. The auditor independently inspects the consolidated diff and
+reproduces every invariant. After acceptance, only the task stamp may differ
+from the audited tree before the owner creates the final squashed commit.
+
+Predetermined final commit:
+
+`fix(ci): harden Daily Amaru scheduled preflight`
+
+The body explains explicit scheduled dependencies, dedicated bootstrap App
+scope, and loud durable precondition receipts. The trailer is:
+
+`Tasks: T2131, T2132, T2133, T2134, T2135, T2136`
+
+## Verification and resource fence
+
+The complete ticket gate runs focused checks before the prior repository gate.
+Every expensive command records available bytes before and after. Scratch and
+audit worktrees live under `/code`; `/run` is not used for scratch. Stop if
+`/` falls below 30 GiB, a command consumes more than 8 GiB, or consumption
+continues unexplained after exit.
+
+No production workflow dispatch or real launcher is part of verification.
+Hosted checks are observed only on the exact pushed candidate head. The live
+App setup gate remains explicit in the final handoff.

--- a/specs/213-daily-amaru-scheduled-preflight/spec.md
+++ b/specs/213-daily-amaru-scheduled-preflight/spec.md
@@ -1,0 +1,115 @@
+# Issue 213 — Daily Amaru scheduled preflight
+
+Artifact ceiling: 8,000 bytes and 180 lines.
+
+## Priority story
+
+As the Amaru fault-injection desk, I need the scheduled Daily Amaru controller
+to enter its fail-closed state machine with an explicit dependency and
+short-lived identity contract, so every UTC day produces either a legitimate
+decision or a loud durable failure receipt.
+
+## Root causes
+
+- The scheduled job relied on the stock Ubuntu runner for `rg`; the transport
+  rejected the runner before its first operation, so neither the controller
+  nor its receipt state was reachable.
+- The scheduled job injected an absent repository secret as the single
+  cross-repository identity. No runtime-minted, repository-scoped App token
+  existed for `lambdasistemi/amaru-bootstrap`.
+- One identity value was conceptually shared across the bootstrap repository
+  boundary and same-repository consumer work, despite those boundaries having
+  different authorities.
+
+## Functional requirements
+
+- **FR-213-01 — Explicit runner contract.** The scheduled workflow provisions
+  every non-shell command required by the production controller and transport.
+  Missing commands are controller precondition failures, not setup exceptions.
+- **FR-213-02 — Exact incident reproduction.** Scheduled-context controls for
+  2026-08-02 and 2026-08-03 reproduce
+  `daily-amaru-github: missing command: rg` from base `311dfc1`, then prove the
+  repaired controller exits non-zero with a durable receipt for that same
+  missing-command condition.
+- **FR-213-03 — Dedicated App interface.** Production references repository
+  variable `DAILY_AMARU_APP_ID` and Actions secret
+  `DAILY_AMARU_APP_PRIVATE_KEY`, and mints a runtime token restricted to
+  `lambdasistemi/amaru-bootstrap` with only `actions:read`, `checks:read`,
+  `contents:write`, `pull_requests:write`, and `metadata:read`.
+- **FR-213-04 — Identity separation.** The dedicated App token is usable only
+  for the bootstrap boundary. Same-repository comments, consumer preparation,
+  and consumer observation use the workflow's short-lived repository token.
+- **FR-213-05 — Missing identity is RED.** Absent App inputs or an unsuccessful
+  token-mint step leave the bootstrap identity empty and still invoke the
+  controller. The controller exits non-zero at the identity stage and emits a
+  specific failure receipt before any bootstrap/consumer mutation or launch.
+- **FR-213-06 — Receipt durability.** Every broken precondition records UTC
+  day, precise stage, `outcome=FAILED`, and a specific error in a local receipt
+  that the workflow publishes durably even when the GitHub transport cannot
+  publish its ordinary issue receipt.
+- **FR-213-07 — No secret persistence.** The App private key and minted token
+  are never printed, placed in a receipt/state artifact, written through
+  `$GITHUB_ENV`, committed, or reused outside the scheduled controller step.
+- **FR-213-08 — Side-effect exclusion.** Missing-tool and missing-identity
+  controls reach zero bootstrap proposal, image, consumer-repin,
+  integration, fake-launch, and real-launch operations.
+- **FR-213-09 — Fixed-path census.** The repaired changed path performs exactly
+  one fake launch and zero real launches in verification. Existing unchanged,
+  duplicate-day, attempted-SHA, exact-head, fail-closed stage, and positive
+  producer-census controls remain green.
+- **FR-213-10 — CI reachability.** Pull-request CI executes the scheduled
+  context contract and its negative controls on the exact candidate head.
+  Presence of workflow text without an executing proof is insufficient.
+- **FR-213-11 — Resource and live boundaries.** Verification records `/` and
+  `/run` byte deltas, stops below 30 GiB free on `/`, stops a command consuming
+  more than 8 GiB, uses `/code` for scratch, and performs no workflow dispatch
+  or real launch.
+
+## Invariant mandate
+
+- **INV-213-01 — Preflight precedes business effects.** A dependency failure is
+  observed before attempt claim, bootstrap/image/consumer mutation,
+  integration, or launch; its failure receipt is still reachable.
+- **INV-213-02 — A silent failure cannot pass.** A missing receipt, missing
+  required field, `outcome` other than `FAILED`, vague error, or zero exit from
+  a broken precondition makes the gate red.
+- **INV-213-03 — App scope is singular.** The minted bootstrap token names one
+  owner and one repository and cannot authorize the cna consumer boundary.
+- **INV-213-04 — Identity failure remains inside the state machine.** Missing
+  or unusable App configuration becomes `stage=identity` with a specific
+  error, not a skipped step, setup-only exception, or inferred success.
+- **INV-213-05 — Credentials are ephemeral.** Only a step output-to-step-env
+  binding carries the minted token; no durable output can contain it.
+- **INV-213-06 — Broken paths cannot launch.** Both broken-precondition
+  controls prove zero fake and real launch reachability and zero business
+  mutation reachability.
+- **INV-213-07 — The fixed path is non-vacuous.** Passing evidence reports the
+  exact two seeded days, required receipt fields, dependency census, mutation
+  census, one fake launch, and zero real launches.
+- **INV-213-08 — Existing safety contracts survive.** Bare origin/ref,
+  exact-SHA/day-cap semantics, exact-head checks, producer census, failure
+  ordering, fault duration, and protected launch shape are unchanged.
+- **INV-213-09 — Production wiring executes the proof.** The pull-request job
+  invokes the focused suite and the scheduled job invokes the same controller
+  contract; orphaned assertions are red.
+
+## Rejection behavior
+
+The controller must reject missing commands, missing identity, malformed
+observations, duplicate/attempted work, invalid exact-head evidence, zero
+producer census, failed integration, and launch failure with a non-zero exit
+and stage-specific receipt. A precondition failure may write its failure
+receipt and concurrency bookkeeping; it may not reach bootstrap, image,
+consumer, integration, or launch effects.
+
+## Scope
+
+Owned implementation is limited to the Daily Amaru workflow, controller,
+GitHub transport, focused tests/fixtures, and Daily Amaru documentation.
+`testnets/**`, compose/image pins, MOOG/Antithesis workflows, cna#212,
+amaru-bootstrap#75, and cna#206–#208 behavior are excluded.
+
+The dedicated App's creation, installation, permission approval, secret
+placement, and live proof remain an operator gate. This ticket implements the
+interface and loud missing-input behavior only; it does not satisfy or bypass
+that external gate.

--- a/specs/213-daily-amaru-scheduled-preflight/tasks.md
+++ b/specs/213-daily-amaru-scheduled-preflight/tasks.md
@@ -1,0 +1,26 @@
+# Tasks — Issue 213 Daily Amaru scheduled preflight
+
+Artifact ceiling: 4,000 bytes and 90 lines.
+
+## Slice S213-01 — Scheduled preflight and identity boundary
+
+- [ ] **T2131** Commit a complete executable RED proof covering both dated
+  missing-`rg` incidents, silent-receipt rejection, missing identity, App
+  wiring, credential non-persistence, effect counts, and CI reachability.
+- [ ] **T2132** Make the scheduled dependency census explicit and ensure a
+  missing required command exits non-zero with D213-01 before business effects.
+- [ ] **T2133** Implement the dedicated D213-02 token-mint interface and keep
+  D213-03 separate from same-repository identity without creating, installing,
+  or configuring the App.
+- [ ] **T2134** Preserve all existing controller guards while proving broken
+  preconditions have zero business mutations/launches and the repaired changed
+  path has exactly one fake and zero real launches.
+- [ ] **T2135** Document the scheduled runner contract, dedicated App setup
+  names/scope, loud failure behavior, secret handling, and still-open live gate.
+- [ ] **T2136** Pass the immutable slice gate, full ticket gate, fresh Codex
+  audit, final commit/tree proof, hosted exact-head checks, and resource census
+  without a live dispatch or real launch.
+
+The ticket owner checks these entries only after an exact candidate receives a
+fresh `AUDIT-PASS`. The parked commit owner then includes the task stamp in the
+single final squashed behavior commit.

--- a/tests/fixtures/daily-amaru/fake-gh.sh
+++ b/tests/fixtures/daily-amaru/fake-gh.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic stand-in for the `gh` CLI inside the scheduled-runner controls.
+# It performs no network call and records every invocation so a proof can count
+# the business effects a broken precondition was allowed to reach.
+log_file=${DAILY_AMARU_FAKE_GH_LOG:?DAILY_AMARU_FAKE_GH_LOG is required}
+
+{
+  printf 'gh'
+  if [ "$#" -gt 0 ]; then
+    printf ' %s' "$@"
+  fi
+  printf '\n'
+} >>"$log_file"

--- a/tests/fixtures/daily-amaru/fake-gh.sh
+++ b/tests/fixtures/daily-amaru/fake-gh.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Deterministic stand-in for the `gh` CLI inside the scheduled-runner controls.
-# It performs no network call and records every invocation so a proof can count
-# the business effects a broken precondition was allowed to reach.
+# Deterministic `gh` stand-in: no network call, and every invocation recorded so
+# a proof can count the effects a broken precondition was allowed to reach.
 log_file=${DAILY_AMARU_FAKE_GH_LOG:?DAILY_AMARU_FAKE_GH_LOG is required}
 
 {

--- a/tests/fixtures/daily-amaru/fake-transport.sh
+++ b/tests/fixtures/daily-amaru/fake-transport.sh
@@ -32,10 +32,38 @@ increment() {
   printf '%s\n' "$((count + 1))" >"$file"
 }
 
+identity_marker() {
+  if [ -n "${DAILY_AMARU_IDENTITY:-}" ]; then
+    printf 'identity-present'
+  else
+    printf 'identity-absent'
+  fi
+}
+
 operation=${1:?transport operation is required}
 shift
 
 case "$operation" in
+  preflight)
+    log preflight "$@"
+    case "$scenario" in
+      missing-tool)
+        printf 'MISSING-COMMAND rg\n'
+        printf 'daily-amaru-github: missing command: rg\n' >&2
+        exit 1
+        ;;
+      silent-preflight)
+        ;;
+      malformed-preflight)
+        printf 'dependencies look fine\n'
+        ;;
+      *)
+        printf 'OK: 15 scheduled dependencies present: %s\n' \
+          'gh git jq rg sed awk grep tail tr head seq sleep date docker nix'
+        ;;
+    esac
+    ;;
+
   claim-day)
     day=${1:?day is required}
     log claim-day "$day"
@@ -90,8 +118,9 @@ case "$operation" in
 
   propose-bootstrap)
     sha=${1:?upstream SHA is required}
-    identity=${2:?identity is required}
-    log mutation:bootstrap "$sha" "$identity"
+    # The minted bootstrap identity travels in the process environment only, so
+    # the log records its presence and never its value.
+    log mutation:bootstrap "$sha" "$(identity_marker)"
     if [ "$scenario" = failed-stage ]; then
       printf 'bootstrap proposal failed\n' >&2
       exit 1
@@ -113,8 +142,7 @@ case "$operation" in
 
   prepare-consumer-repin)
     image=${1:?image is required}
-    identity=${2:?identity is required}
-    log mutation:repin "$image" "$identity"
+    log mutation:repin "$image"
     printf '%s\n' "$consumer_sha"
     ;;
 

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 controller="$repo_root/scripts/daily-amaru.sh"
+transport="$repo_root/scripts/daily-amaru-github.sh"
+workflow="$repo_root/.github/workflows/daily-amaru.yaml"
 fake_transport="$repo_root/tests/fixtures/daily-amaru/fake-transport.sh"
+fake_gh="$repo_root/tests/fixtures/daily-amaru/fake-gh.sh"
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT
 
@@ -14,6 +17,14 @@ fail() {
 
 pass() {
   printf 'PASS %s\n' "$1"
+}
+
+count_matches() {
+  grep -Ec -- "$2" "$1" || true
+}
+
+count_literal() {
+  grep -Fc -- "$2" "$1" || true
 }
 
 assert_file_contains() {
@@ -35,7 +46,7 @@ assert_log_count() {
   local expected=$1
   local pattern=$2
   local actual
-  actual=$(grep -Ec -- "$pattern" "$case_log" || true)
+  actual=$(count_matches "$case_log" "$pattern")
   [ "$actual" -eq "$expected" ] ||
     fail "scenario=$case_name expected $expected log matches for $pattern, found $actual"
 }
@@ -53,6 +64,83 @@ assert_honest_failure_receipt() {
   assert_file_contains "$case_receipt" "stage=$stage"
   assert_file_contains "$case_receipt" 'outcome=FAILED'
   assert_file_lacks "$case_receipt" 'outcome=(UNCHANGED|CHANGED|SUCCESS)|run_outcome=success|findings_complete=true'
+}
+
+assert_workflow_literal_once() {
+  local literal=$1
+  local actual
+  actual=$(count_literal "$workflow" "$literal")
+  [ "$actual" -eq 1 ] ||
+    fail "workflow must declare exactly once (found $actual): $literal"
+}
+
+# --- D213-01 receipt oracle ------------------------------------------------
+# A broken precondition is only proved loud when a receipt naming the UTC day,
+# the precise stage, `outcome=FAILED`, and a stable specific error exists while
+# no business effect was reached. The oracle is exercised in both directions
+# below before any verdict it produces is believed.
+receipt_oracle() {
+  local receipt=$1
+  local day=$2
+  local stage=$3
+  local error=$4
+  local effects=$5
+  local field forbidden
+
+  [ -f "$receipt" ] && [ ! -L "$receipt" ] && [ -s "$receipt" ] || return 1
+  for field in "day=$day" "stage=$stage" 'outcome=FAILED' "error=$error"; do
+    grep -Fqx -- "$field" "$receipt" || return 1
+  done
+  if grep -Eq '^(outcome=(UNCHANGED|CHANGED|SUCCESS)|run_outcome=(success|requested))$' \
+    "$receipt"; then
+    return 1
+  fi
+  for forbidden in 'repo clone' 'pr create' 'pr merge' 'workflow run' 'run watch'; do
+    if grep -Fq -- "$forbidden" "$effects"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# --- Hermetic scheduled-runner PATH ---------------------------------------
+# Every non-shell command the scheduled production transport can reach, minus
+# the incident command `rg`. Seeding an exclusive PATH makes a missing-command
+# verdict caused by absence rather than by an unrelated broken harness.
+scheduled_seed_commands=(
+  bash dirname mkdir git jq sed awk grep tail tr head seq sleep date docker nix
+)
+
+seed_scheduled_path() {
+  local bin_dir=$1
+  local include_rg=$2
+  local command target
+  mkdir -p "$bin_dir"
+  for command in "${scheduled_seed_commands[@]}"; do
+    if target=$(command -v "$command" 2>/dev/null) &&
+      [ "${target:0:1}" = / ] && [ -x "$target" ]; then
+      ln -sf "$target" "$bin_dir/$command"
+    else
+      printf '#!/bin/sh\nexit 0\n' >"$bin_dir/$command"
+      chmod +x "$bin_dir/$command"
+    fi
+  done
+  ln -sf "$fake_gh" "$bin_dir/gh"
+  if [ "$include_rg" = with-rg ]; then
+    printf '#!/bin/sh\nexit 0\n' >"$bin_dir/rg"
+    chmod +x "$bin_dir/rg"
+  else
+    rm -f "$bin_dir/rg"
+  fi
+
+  # Positive control: an exclusive PATH that resolves nothing would report every
+  # command as missing and prove nothing at all.
+  PATH="$bin_dir" command -v gh >/dev/null ||
+    fail "seeded PATH cannot resolve a command that is present: $bin_dir"
+  if [ "$include_rg" = without-rg ] &&
+    PATH="$bin_dir" command -v rg >/dev/null 2>&1; then
+    fail "seeded PATH still resolves rg: $bin_dir"
+  fi
 }
 
 case_number=0
@@ -91,6 +179,88 @@ run_case() {
     "$controller" >"$case_stdout" 2>"$case_stderr" || case_rc=$?
 }
 
+run_scheduled_incident() {
+  local day=$1
+  scheduled_dir="$tmp_root/scheduled-$day"
+  scheduled_state="$scheduled_dir/state"
+  scheduled_receipt="$scheduled_dir/receipt"
+  scheduled_effects="$scheduled_dir/effects"
+  mkdir -p "$scheduled_state"
+  : >"$scheduled_effects"
+  seed_scheduled_path "$scheduled_dir/bin" without-rg
+
+  scheduled_rc=0
+  env \
+    PATH="$scheduled_dir/bin" \
+    DAILY_AMARU_FAKE_GH_LOG="$scheduled_effects" \
+    DAILY_AMARU_MODE=production \
+    DAILY_AMARU_DAY="$day" \
+    DAILY_AMARU_IDENTITY=seed-non-empty-identity \
+    DAILY_AMARU_STATE_DIR="$scheduled_state" \
+    DAILY_AMARU_RECEIPT="$scheduled_receipt" \
+    "$controller" \
+    >"$scheduled_dir/stdout" 2>"$scheduled_dir/stderr" || scheduled_rc=$?
+}
+
+run_transport_preflight() {
+  local bin_dir=$1
+  local root=$2
+  local label=$3
+  shift 3
+  preflight_rc=0
+  preflight_stdout=$root/$label.stdout
+  preflight_stderr=$root/$label.stderr
+  env \
+    PATH="$bin_dir" \
+    DAILY_AMARU_FAKE_GH_LOG="$root/effects" \
+    DAILY_AMARU_STATE_DIR="$root/state" \
+    DAILY_AMARU_RECEIPT="$root/state/receipt" \
+    "$transport" preflight "$@" \
+    >"$preflight_stdout" 2>"$preflight_stderr" || preflight_rc=$?
+}
+
+# Extract one transport `case` branch body so identity boundaries can be
+# checked per operation rather than across the whole file.
+transport_branch() {
+  local file=$1
+  local operation=$2
+  awk -v op="$operation" '
+    $0 == "  " op ")" { inside = 1; next }
+    inside && $0 == "    ;;" { inside = 0 }
+    inside { print }
+  ' "$file"
+}
+
+bootstrap_boundary_operations=(propose-bootstrap require-bootstrap-checks)
+repository_boundary_operations=(
+  claim-day last-success-sha claim-sha-attempt prepare-consumer-repin
+  require-consumer-checks await-supervised-integration real-launch receipt
+)
+
+# INV-213-03 — the minted bootstrap token must not be reachable from any
+# same-repository operation, and the bootstrap operations must not silently
+# fall back to the repository token.
+identity_boundary_holds() {
+  local file=$1
+  local operation body
+  for operation in "${bootstrap_boundary_operations[@]}"; do
+    body=$(transport_branch "$file" "$operation")
+    [ -n "$body" ] || return 1
+    grep -q 'bootstrap_identity' <<<"$body" || return 1
+    if grep -q 'repository_identity' <<<"$body"; then
+      return 1
+    fi
+  done
+  for operation in "${repository_boundary_operations[@]}"; do
+    body=$(transport_branch "$file" "$operation")
+    [ -n "$body" ] || return 1
+    if grep -q 'bootstrap_identity\|DAILY_AMARU_IDENTITY' <<<"$body"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
 require_success() {
   [ "$case_rc" -eq 0 ] ||
     fail "scenario=$case_name expected success, exit=$case_rc: $(tr '\n' ' ' <"$case_stderr")"
@@ -104,16 +274,128 @@ if [ ! -x "$fake_transport" ]; then
   fail "fake transport is absent or not executable: $fake_transport"
 fi
 
+if [ ! -x "$fake_gh" ]; then
+  fail "fake gh is absent or not executable: $fake_gh"
+fi
+
 # Intentional first RED: the deterministic transport exists, but production
 # behavior does not. No PASS line may be emitted before this check flips.
 if [ ! -x "$controller" ]; then
   fail "controller behavior absent: expected executable $controller"
 fi
 
+if [ ! -x "$transport" ]; then
+  fail "production transport absent: expected executable $transport"
+fi
+
+if [ ! -f "$workflow" ]; then
+  fail "scheduled workflow absent: expected regular file $workflow"
+fi
+
+# --- Receipt oracle controls ----------------------------------------------
+oracle_root="$tmp_root/receipt-oracle"
+mkdir -p "$oracle_root"
+: >"$oracle_root/clean-effects"
+printf 'gh repo clone lambdasistemi/amaru-bootstrap\n' >"$oracle_root/dirty-effects"
+
+printf 'day=2026-08-02\nstage=runner-preflight\noutcome=FAILED\nerror=missing-command-rg\n' \
+  >"$oracle_root/valid"
+receipt_oracle "$oracle_root/valid" 2026-08-02 runner-preflight missing-command-rg \
+  "$oracle_root/clean-effects" ||
+  fail 'receipt oracle rejected its positive control'
+
+printf 'day=2026-08-02\nstage=runner-preflight\noutcome=FAILED\n' >"$oracle_root/no-error"
+if receipt_oracle "$oracle_root/no-error" 2026-08-02 runner-preflight missing-command-rg \
+  "$oracle_root/clean-effects"; then
+  fail 'receipt oracle accepted a missing specific error'
+fi
+
+printf 'day=2026-08-02\nstage=runner-preflight\noutcome=CHANGED\nerror=missing-command-rg\n' \
+  >"$oracle_root/success-like"
+if receipt_oracle "$oracle_root/success-like" 2026-08-02 runner-preflight missing-command-rg \
+  "$oracle_root/clean-effects"; then
+  fail 'receipt oracle accepted a success-like outcome'
+fi
+
+if receipt_oracle "$oracle_root/absent" 2026-08-02 runner-preflight missing-command-rg \
+  "$oracle_root/clean-effects"; then
+  fail 'receipt oracle accepted silence'
+fi
+
+if receipt_oracle "$oracle_root/valid" 2026-08-02 runner-preflight missing-command-rg \
+  "$oracle_root/dirty-effects"; then
+  fail 'receipt oracle accepted a reached business effect'
+fi
+printf 'RECEIPT-ORACLE-CONTROLS positive=1 negative=4\n'
+pass receipt-oracle-controls
+
+# --- FN-213-03 dependency preflight controls -------------------------------
+preflight_root="$tmp_root/preflight-controls"
+mkdir -p "$preflight_root/state"
+: >"$preflight_root/effects"
+seed_scheduled_path "$preflight_root/complete" with-rg
+seed_scheduled_path "$preflight_root/incomplete" without-rg
+
+run_transport_preflight "$preflight_root/complete" "$preflight_root" complete
+[ "$preflight_rc" -eq 0 ] ||
+  fail "complete dependency census was rejected: $(tr '\n' ' ' <"$preflight_stderr")"
+census_evidence=$(cat "$preflight_stdout")
+[[ "$census_evidence" =~ ^OK:\ ([1-9][0-9]*)\ scheduled\ dependencies\ present:\ (.+)$ ]] ||
+  fail "preflight success evidence does not name the census: $census_evidence"
+census_count=${BASH_REMATCH[1]}
+census_list=${BASH_REMATCH[2]}
+[ "$census_count" -eq "$(wc -w <<<"$census_list")" ] ||
+  fail "declared census count $census_count differs from the named commands"
+[[ " $census_list " == *" rg "* ]] ||
+  fail "dependency census omits the incident command rg: $census_list"
+
+run_transport_preflight "$preflight_root/incomplete" "$preflight_root" incomplete
+[ "$preflight_rc" -ne 0 ] || fail 'preflight accepted a runner without rg'
+grep -Fqx 'daily-amaru-github: missing command: rg' "$preflight_stderr" ||
+  fail 'preflight did not name the exact missing command on stderr'
+grep -Fqx 'MISSING-COMMAND rg' "$preflight_stdout" ||
+  fail 'preflight did not report the missing command machine-readably'
+
+# The verdict must belong to a property class, not to the single `rg` instance.
+run_transport_preflight "$preflight_root/complete" "$preflight_root" probe \
+  t213-absent-probe
+[ "$preflight_rc" -ne 0 ] ||
+  fail 'preflight accepted an explicitly required absent command'
+grep -Fqx 'daily-amaru-github: missing command: t213-absent-probe' "$preflight_stderr" ||
+  fail 'preflight did not name the absent explicit requirement'
+
+[ ! -s "$preflight_root/effects" ] ||
+  fail 'dependency preflight reached a GitHub effect'
+printf 'DEPENDENCY-CENSUS count=%s rg=required effects=0\n' "$census_count"
+pass scheduled-preflight-controls
+
+# --- FR-213-02 dated incident reproduction ---------------------------------
+scheduled_effect_logs=()
+for incident_day in 2026-08-02 2026-08-03; do
+  run_scheduled_incident "$incident_day"
+  [ "$scheduled_rc" -ne 0 ] ||
+    fail "scenario=scheduled-$incident_day expected a non-zero scheduled exit"
+  grep -Fqx 'daily-amaru-github: missing command: rg' "$scheduled_dir/stderr" ||
+    fail "scenario=scheduled-$incident_day lacks the exact incident fingerprint"
+  receipt_oracle "$scheduled_receipt" "$incident_day" runner-preflight \
+    missing-command-rg "$scheduled_effects" ||
+    fail "scenario=scheduled-$incident_day lacks a loud durable failure receipt"
+  # A broken runner must not even consume the UTC day.
+  if grep -Fq "daily-amaru day=$incident_day claim" "$scheduled_effects"; then
+    fail "scenario=scheduled-$incident_day claimed the UTC day behind a broken runner"
+  fi
+  scheduled_effect_logs+=("$scheduled_effects")
+  printf 'INCIDENT day=%s base=311dfc1 fingerprint=%s exit=%s business_effects=0\n' \
+    "$incident_day" 'daily-amaru-github: missing command: rg' "$scheduled_rc"
+  pass "scheduled-missing-rg-$incident_day"
+done
+
+# --- Existing controller contract ------------------------------------------
 run_case changed
 require_success
 assert_file_contains "$case_receipt" 'outcome=CHANGED'
 assert_file_contains "$case_receipt" 'upstream_sha=1111111111111111111111111111111111111111'
+assert_log_count 1 '^preflight'
 assert_log_count 1 '^resolve-upstream '
 assert_log_count 1 '^claim-sha-attempt '
 assert_log_count 1 '^fake-launch cardano-node.yaml cardano_amaru duration=1 no-faults=false 4444444444444444444444444444444444444444$'
@@ -142,7 +424,37 @@ assert_log_count 0 '^claim-sha-attempt '
 assert_no_mutation
 assert_no_launch
 assert_honest_failure_receipt identity
+assert_file_contains "$case_receipt" 'day=2026-07-31'
+assert_file_contains "$case_receipt" 'error=missing-production-identity'
+identity_control_log=$case_log
 pass missing-identity
+
+# The controller owns the precondition order: a transport-reported missing
+# command becomes stage=runner-preflight before the day is even claimed.
+run_case missing-tool production seed-non-empty-identity
+require_failure
+assert_log_count 0 '^claim-day '
+assert_log_count 0 '^claim-sha-attempt '
+assert_no_mutation
+assert_no_launch
+assert_honest_failure_receipt runner-preflight
+assert_file_contains "$case_receipt" 'day=2026-07-31'
+assert_file_contains "$case_receipt" 'error=missing-command-rg'
+tool_control_log=$case_log
+pass missing-tool
+
+# INV-213-02 — a preflight that reports nothing, or reports an unparsable
+# success, cannot be read as a satisfied dependency contract.
+for vacuous in silent-preflight malformed-preflight; do
+  run_case "$vacuous" production seed-non-empty-identity
+  require_failure
+  assert_log_count 0 '^claim-day '
+  assert_no_mutation
+  assert_no_launch
+  assert_honest_failure_receipt runner-preflight
+  assert_file_contains "$case_receipt" 'error=malformed-dependency-evidence'
+  pass "$vacuous"
+done
 
 for check_case in missing-check wrong-head-check ambiguous-check pending-check failed-check; do
   run_case "$check_case"
@@ -213,6 +525,7 @@ assert_file_contains "$case_receipt" 'launch_workflow=cardano-node.yaml'
 assert_file_contains "$case_receipt" 'launch_test=cardano_amaru'
 assert_file_contains "$case_receipt" 'launch_duration=1'
 assert_file_contains "$case_receipt" 'launch_no_faults=false'
+assert_file_contains "$case_receipt" 'dependency_census=OK: 15 scheduled dependencies present: gh git jq rg sed awk grep tail tr head seq sleep date docker nix'
 pass complete-fake-launch-once
 
 assert_log_count 1 '^await-supervised-integration '
@@ -227,3 +540,129 @@ for observation in malformed-observation wrong-origin-observation wrong-ref-obse
   assert_honest_failure_receipt resolve-upstream
   pass "$observation"
 done
+
+# --- INV-213-06 counted effect census over both broken preconditions -------
+for broken_log in "${scheduled_effect_logs[@]}"; do
+  for forbidden in 'repo clone' 'pr create' 'pr merge' 'workflow run' 'run watch'; do
+    if grep -Fq -- "$forbidden" "$broken_log"; then
+      fail "missing-command control reached a business effect: $forbidden"
+    fi
+  done
+done
+for broken_log in "$tool_control_log" "$identity_control_log"; do
+  for pattern in \
+    '^claim-sha-attempt ' \
+    '^mutation:' \
+    '^await-supervised-integration ' \
+    '^fake-launch ' \
+    '^real-launch '
+  do
+    actual=$(count_matches "$broken_log" "$pattern")
+    [ "$actual" -eq 0 ] ||
+      fail "broken precondition reached $actual effects matching $pattern"
+  done
+done
+printf 'EFFECT-CENSUS controls=2 attempts=0 mutations=0 integrations=0 fake_launches=0 real_launches=0\n'
+pass broken-preconditions-no-business-effects
+
+# --- D213-02 dedicated bootstrap App interface -----------------------------
+for literal in \
+  'uses: actions/create-github-app-token@v1' \
+  'app-id: ${{ vars.DAILY_AMARU_APP_ID }}' \
+  'private-key: ${{ secrets.DAILY_AMARU_APP_PRIVATE_KEY }}' \
+  'owner: lambdasistemi' \
+  'repositories: amaru-bootstrap' \
+  'permission-actions: read' \
+  'permission-checks: read' \
+  'permission-contents: write' \
+  'permission-pull-requests: write' \
+  'permission-metadata: read'
+do
+  assert_workflow_literal_once "$literal"
+done
+app_permissions=$(count_matches "$workflow" '^[[:space:]]*permission-[a-z-]+:')
+[ "$app_permissions" -eq 5 ] ||
+  fail "bootstrap App permission census must be exactly five, found $app_permissions"
+
+identity_boundary_holds "$transport" ||
+  fail 'the minted bootstrap identity is not confined to the bootstrap boundary'
+
+# Prove the boundary check can fail: a mutant that reaches for the bootstrap
+# identity inside a same-repository operation must be rejected, and a mutant
+# that drops it from the bootstrap boundary must be rejected too. Each mutation
+# verifies its own application so a silently unapplied edit cannot report a
+# caught defect.
+mutant_root="$tmp_root/identity-mutants"
+mkdir -p "$mutant_root"
+
+sed 's#^  receipt)$#  receipt)\n    leak="$bootstrap_identity"#' "$transport" \
+  >"$mutant_root/leaked.sh"
+grep -Fq 'leak="$bootstrap_identity"' "$mutant_root/leaked.sh" ||
+  fail 'identity-leak mutation did not apply'
+if identity_boundary_holds "$mutant_root/leaked.sh"; then
+  fail 'boundary check accepted a bootstrap identity inside a repository operation'
+fi
+
+sed 's#bootstrap_identity#repository_identity#g' "$transport" \
+  >"$mutant_root/downgraded.sh"
+if grep -Fq 'bootstrap_identity' "$mutant_root/downgraded.sh"; then
+  fail 'identity-downgrade mutation did not apply'
+fi
+if identity_boundary_holds "$mutant_root/downgraded.sh"; then
+  fail 'boundary check accepted a bootstrap operation without the minted identity'
+fi
+printf 'IDENTITY-BOUNDARY bootstrap_ops=%s repository_ops=%s mutants_rejected=2\n' \
+  "${#bootstrap_boundary_operations[@]}" "${#repository_boundary_operations[@]}"
+pass dedicated-app-scope
+
+# --- INV-213-05 the minted token is ephemeral ------------------------------
+for forbidden in DAILY_AMARU_CROSS_REPO_TOKEN MOOG_GITHUB_PAT GITHUB_ENV; do
+  if grep -Fq -- "$forbidden" "$workflow" "$controller" "$transport"; then
+    fail "forbidden credential path remains: $forbidden"
+  fi
+done
+assert_workflow_literal_once 'DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}'
+assert_workflow_literal_once '${{ steps.app-token.outputs.token }}'
+
+secret_value=t213-bootstrap-secret-token-value
+run_case failed-stage production "$secret_value"
+require_failure
+assert_log_count 1 '^mutation:bootstrap '
+assert_no_launch
+assert_honest_failure_receipt bootstrap-proposal
+leaked_artifacts=0
+scanned_artifacts=0
+while IFS= read -r artifact; do
+  scanned_artifacts=$((scanned_artifacts + 1))
+  if grep -Fq -- "$secret_value" "$artifact"; then
+    printf 'LEAK %s\n' "$artifact" >&2
+    leaked_artifacts=$((leaked_artifacts + 1))
+  fi
+done < <(find "$case_dir" -type f)
+[ "$scanned_artifacts" -gt 0 ] ||
+  fail 'secret persistence scan inspected no artifact at all'
+[ "$leaked_artifacts" -eq 0 ] ||
+  fail "minted bootstrap identity persisted into $leaked_artifacts artifact(s)"
+
+# Positive control: the same search finds the value where it is genuinely
+# present, so the zero above is absence rather than a broken instrument.
+printf '%s\n' "$secret_value" >"$case_dir/leak-probe"
+grep -Fq -- "$secret_value" "$case_dir/leak-probe" ||
+  fail 'leak search cannot detect a known-present secret'
+printf 'SECRET-PERSISTENCE artifacts_scanned=%s leaks=0 probe=detected\n' \
+  "$scanned_artifacts"
+pass bootstrap-token-not-persisted
+
+# --- INV-213-09 production wiring executes this proof ----------------------
+assert_workflow_literal_once 'run: tests/test-daily-amaru.sh'
+assert_workflow_literal_once 'scripts/daily-amaru.sh'
+assert_workflow_literal_once 'DAILY_AMARU_MODE: production'
+assert_workflow_literal_once 'uses: actions/upload-artifact@v6'
+assert_workflow_literal_once 'if: always()'
+assert_workflow_literal_once 'continue-on-error: true'
+[ "$(count_literal "$workflow" 'ripgrep')" -ge 1 ] ||
+  fail 'the scheduled runner does not provision the incident command'
+[ "$(count_literal "$workflow" 'setup-nix')" -ge 1 ] ||
+  fail 'the scheduled runner does not provision nix for the bootstrap proposal'
+printf 'WIRING pull_request_proof=1 scheduled_controller=1 receipt_upload=1\n'
+pass workflow-wires-scheduled-proof

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -174,11 +174,22 @@ bash_binary=$(command -v bash)
 # from an otherwise complete seeded PATH, or empty to seed nothing at all. An
 # absolute interpreter keeps even an empty PATH reaching the first boundary.
 run_hermetic_case() {
-  local label=$1 omit=$2 day=$3 script=${4:-$controller}
+  local label=$1 omit=$2 day=$3 script=${4:-$controller} parent=${5:-existing}
+  local day_env=(DAILY_AMARU_DAY="$day")
   hermetic_dir="$tmp_root/hermetic-$label"
-  hermetic_receipt="$hermetic_dir/receipt"
+  hermetic_state="$hermetic_dir/state"
+  # Production nests the receipt under a directory no step pre-creates, so the
+  # absent-parent class must be reachable without the harness building it.
+  [ "$parent" = existing ] || hermetic_state="$hermetic_dir/never-created/state"
+  hermetic_receipt="$hermetic_state/receipt"
   hermetic_effects="$hermetic_dir/effects"
-  mkdir -p "$hermetic_dir/state" "$hermetic_dir/bin"
+  # An unset day is the production shape: the controller, not the workflow,
+  # must derive the UTC day, so `date` becomes a first-boundary requirement.
+  [ -n "$day" ] || day_env=()
+  mkdir -p "$hermetic_dir/bin"
+  if [ "$parent" = existing ]; then
+    mkdir -p "$hermetic_state"
+  fi
   : >"$hermetic_effects"
   if [ -n "$omit" ]; then
     seed_scheduled_path "$hermetic_dir/bin" with-rg
@@ -192,12 +203,26 @@ run_hermetic_case() {
     PATH="$hermetic_dir/bin" \
     DAILY_AMARU_FAKE_GH_LOG="$hermetic_effects" \
     DAILY_AMARU_MODE=production \
-    DAILY_AMARU_DAY="$day" \
+    "${day_env[@]}" \
     DAILY_AMARU_IDENTITY=seed-non-empty-identity \
-    DAILY_AMARU_STATE_DIR="$hermetic_dir/state" \
+    DAILY_AMARU_STATE_DIR="$hermetic_state" \
     DAILY_AMARU_RECEIPT="$hermetic_receipt" \
     "$bash_binary" "$script" \
     >"$hermetic_dir/stdout" 2>"$hermetic_dir/stderr" || hermetic_rc=$?
+}
+
+# The primary receipt is authoritative while it is writable; an unreachable
+# primary must not erase the machine-readable failure, so the durable runner
+# stream is read exactly as the scheduled job would read it.
+hermetic_sink() {
+  hermetic_sink_kind=primary
+  hermetic_sink_path="$hermetic_dir/sink"
+  if [ -f "$hermetic_receipt" ]; then
+    cp "$hermetic_receipt" "$hermetic_sink_path"
+  else
+    hermetic_sink_kind=independent
+    cat "$hermetic_dir/stdout" "$hermetic_dir/stderr" >"$hermetic_sink_path"
+  fi
 }
 
 run_transport_preflight() {
@@ -350,8 +375,10 @@ pass scheduled-preflight-controls
 # F1: the transport preflight cannot classify the commands needed to reach the
 # transport itself. The census is read from the controller source, so a later
 # addition to it is covered here automatically.
+# Both the unconditional assignment and every conditional append, so a member
+# the controller only sometimes requires cannot escape the census claim.
 mapfile -t bootstrap_census < <(
-  sed -nE 's/^bootstrap_command_census=\((.*)\)$/\1/p' "$controller" |
+  sed -nE 's/.*bootstrap_command_census\+?=\((.+)\).*/\1/p' "$controller" |
     tr ' ' '\n' | sed '/^$/d'
 )
 [ "${#bootstrap_census[@]}" -ge 1 ] ||
@@ -366,18 +393,57 @@ receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
   fail 'empty-PATH control produced no classified durable receipt'
 [ ! -s "$hermetic_effects" ] ||
   fail 'empty-PATH control reached a GitHub effect'
+# Every effective census member, over both production receipt-parent states.
+# `date` is only required when nothing pre-computes the day, so it is exercised
+# in exactly the shape that makes it a first-boundary requirement.
+boundary_sink_kinds=()
 for omitted in "${bootstrap_census[@]}"; do
-  run_hermetic_case "omit-$omitted" "$omitted" 2026-08-02
-  [ "$hermetic_rc" -ne 0 ] ||
-    fail "controller accepted a runner without $omitted"
-  grep -Fqx "daily-amaru: missing command: $omitted" "$hermetic_dir/stderr" ||
-    fail "absent $omitted was not named on stderr"
-  receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
-    "missing-command-$omitted" "$hermetic_effects" ||
-    fail "absent $omitted produced no classified durable receipt"
-  [ ! -s "$hermetic_effects" ] ||
-    fail "absent $omitted reached a GitHub effect"
+  for parent in existing absent; do
+    boundary_day=2026-08-02
+    [ "$omitted" != date ] || boundary_day=''
+    run_hermetic_case "omit-$omitted-$parent" "$omitted" "$boundary_day" \
+      "$controller" "$parent"
+    [ "$hermetic_rc" -ne 0 ] ||
+      fail "controller accepted a runner without $omitted (parent=$parent)"
+    grep -Fqx "daily-amaru: missing command: $omitted" "$hermetic_dir/stderr" ||
+      fail "absent $omitted was not named on stderr (parent=$parent)"
+    hermetic_sink
+    boundary_expected_day=$boundary_day
+    if [ -z "$boundary_expected_day" ]; then
+      boundary_expected_day=$(
+        sed -nE 's/^day=([0-9]{4}-[0-9]{2}-[0-9]{2})$/\1/p' "$hermetic_sink_path" |
+          head -1
+      )
+      [ -n "$boundary_expected_day" ] ||
+        fail "absent $omitted left no valid UTC day in the sink (parent=$parent)"
+    fi
+    receipt_oracle "$hermetic_sink_path" "$boundary_expected_day" \
+      runner-preflight "missing-command-$omitted" "$hermetic_effects" ||
+      fail "absent $omitted (parent=$parent) left no classified durable sink"
+    [ ! -s "$hermetic_effects" ] ||
+      fail "absent $omitted (parent=$parent) reached a GitHub effect"
+    boundary_sink_kinds+=("$hermetic_sink_kind")
+  done
 done
+# Both sink paths must actually occur: a harness that pre-created every parent
+# would report the absent class green while never leaving the primary receipt.
+[[ " ${boundary_sink_kinds[*]} " == *" primary "* ]] ||
+  fail 'no first-boundary case reached the authoritative primary receipt'
+[[ " ${boundary_sink_kinds[*]} " == *" independent "* ]] ||
+  fail 'no first-boundary case exercised the independent durable sink'
+# Negative control for the independent sink: a controller that can only write
+# the primary receipt loses the verdict exactly when its parent is absent.
+sinkless_mutant="$tmp_root/controller-sinkless.sh"
+sed 's|^  publish_independent_receipt$|  : suppressed-independent-sink|' \
+  "$controller" >"$sinkless_mutant"
+grep -Fq ': suppressed-independent-sink' "$sinkless_mutant" ||
+  fail 'independent-sink mutation did not apply'
+run_hermetic_case sinkless-mutant mkdir 2026-08-02 "$sinkless_mutant" absent
+hermetic_sink
+if receipt_oracle "$hermetic_sink_path" 2026-08-02 runner-preflight \
+  missing-command-mkdir "$hermetic_effects"; then
+  fail 'a controller with no independent sink still published the failure'
+fi
 # Prove the control can fail: an empty boundary crashes instead of classifying.
 bootstrap_mutant="$tmp_root/controller-unguarded.sh"
 sed -E 's/^bootstrap_command_census=\(.*\)$/bootstrap_command_census=()/' \
@@ -389,8 +455,10 @@ if receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
   "missing-command-${bootstrap_census[0]}" "$hermetic_effects"; then
   fail 'a controller without a bootstrap boundary still classified the failure'
 fi
-printf 'BOOTSTRAP-BOUNDARY census=%s members=%s empty_path_control=1 mutants_rejected=1\n' \
+printf 'BOOTSTRAP-BOUNDARY census=%s members=%s empty_path_control=1 mutants_rejected=2\n' \
   "${#bootstrap_census[@]}" "${bootstrap_census[*]}"
+printf 'FIRST-BOUNDARY-CONTROLS commands=%s parent_modes=existing,absent effects=0\n' \
+  "$(IFS=,; printf '%s' "${bootstrap_census[*]}")"
 pass bootstrap-command-boundary
 
 scheduled_effect_logs=()
@@ -753,7 +821,8 @@ assert_workflow_literal_once "if: github.event_name != 'schedule'"
 assert_workflow_literal_once "if: github.event_name == 'schedule'"
 assert_workflow_literal_once 'DAILY_AMARU_MODE: production'
 assert_workflow_literal_once 'uses: actions/upload-artifact@v6'
-assert_workflow_literal_once 'if: always()'
+[ "$(count_literal "$workflow" 'if: always()')" -eq 2 ] ||
+  fail 'the scheduled job must always reach both the controller and the publisher'
 assert_workflow_literal_once 'continue-on-error: true'
 [ "$(count_literal "$workflow" 'ripgrep')" -ge 1 ] ||
   fail 'the scheduled runner does not provision the incident command'
@@ -771,3 +840,71 @@ reject_mutant wiring-scheduled.yaml "$workflow" \
   'an orphaned scheduled controller caller' wiring_holds
 printf 'WIRING pull_request_proof=1 scheduled_controller=1 receipt_upload=1 mutants_rejected=2\n'
 pass workflow-wires-scheduled-proof
+
+# A named step's own lines, so a declaration belonging to a neighbouring step
+# can never be read as this one's.
+workflow_step() {
+  awk -v header="      - name: $2" '
+    $0 == header { inside = 1 }
+    inside && $0 != header && /^      - (name|uses):/ { exit }
+    inside { print }
+  ' "$1"
+}
+
+# INV-213-09: pull-request CI must execute the focused proof from the exact
+# candidate head, not from whatever ref the event happens to supply.
+pr_head_holds() {
+  local checkout
+  checkout=$(workflow_step "$1" 'Check out the exact candidate')
+  grep -Eq '^          ref: .*github\.event\.pull_request\.head\.sha' \
+    <<<"$checkout" || return 1
+  wiring_holds "$1"
+}
+
+# INV-213-02: the scheduled controller is reached whatever an earlier step did,
+# no external date stands before it, and an absent receipt fails the always-run
+# publisher instead of warning.
+receipt_publication_holds() {
+  local controller_step publisher
+  controller_step=$(workflow_step "$1" 'Run the once-daily state machine')
+  publisher=$(workflow_step "$1" 'Publish the local decision receipt')
+  grep -Eq '^        if: always\(\)$' <<<"$controller_step" || return 1
+  grep -Eq '^        if: always\(\)$' <<<"$publisher" || return 1
+  grep -Eq '^          if-no-files-found: error$' <<<"$publisher" || return 1
+  if awk '!/^[[:space:]]*#/' <<<"$controller_step" |
+    grep -Eq '(^|[^[:alnum:]_-])date([^[:alnum:]_-]|$)'; then
+    return 1
+  fi
+  return 0
+}
+
+pr_head_holds "$workflow" ||
+  fail 'pull-request CI does not run the focused proof from the exact candidate head'
+# shellcheck disable=SC2016
+reject_mutant pr-head-redirect.yaml "$workflow" \
+  's/github\.event\.pull_request\.head\.sha/github.sha/' 'github.sha' \
+  'a checkout redirected away from the candidate head' pr_head_holds
+reject_mutant pr-head-commented.yaml "$workflow" \
+  's|^          ref: |          # ref: |' '          # ref: ' \
+  'a commented-out candidate-head binding' pr_head_holds
+reject_mutant pr-head-caller-noop.yaml "$workflow" \
+  "s|^        run: tests/test-daily-amaru.sh\$|        # run: tests/test-daily-amaru.sh\n        run: 'true'|" \
+  "        run: 'true'" 'a no-op focused caller under a bound head' pr_head_holds
+printf 'PR-HEAD-WIRING explicit=1 focused_caller=1 mutants_rejected=3\n'
+pass pull-request-proof-runs-candidate-head
+
+receipt_publication_holds "$workflow" ||
+  fail 'the scheduled receipt is not always produced and fatally published'
+reject_mutant controller-not-always.yaml "$workflow" \
+  '0,/^        if: always()$/{s//        if: success()/}' '        if: success()' \
+  'a controller skipped after an earlier step failed' receipt_publication_holds
+reject_mutant receipt-warning.yaml "$workflow" \
+  's/^          if-no-files-found: error$/          if-no-files-found: warn/' \
+  '          if-no-files-found: warn' 'a receipt whose absence only warns' \
+  receipt_publication_holds
+reject_mutant controller-pre-date.yaml "$workflow" \
+  '/^          scripts\/daily-amaru.sh$/i\          date -u +%F >/dev/null' \
+  'date -u +%F' 'an external date invocation before controller entry' \
+  receipt_publication_holds
+printf 'RECEIPT-PUBLICATION controller_always=1 missing_artifact=fatal\n'
+pass scheduled-receipt-always-published

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -202,6 +202,7 @@ run_hermetic_case() {
   env \
     PATH="$hermetic_dir/bin" \
     DAILY_AMARU_FAKE_GH_LOG="$hermetic_effects" \
+    DAILY_AMARU_EFFECT_LOG="$hermetic_effects" \
     DAILY_AMARU_MODE=production \
     "${day_env[@]}" \
     DAILY_AMARU_IDENTITY=seed-non-empty-identity \
@@ -908,3 +909,51 @@ reject_mutant controller-pre-date.yaml "$workflow" \
   receipt_publication_holds
 printf 'RECEIPT-PUBLICATION controller_always=1 missing_artifact=fatal\n'
 pass scheduled-receipt-always-published
+
+# INV-213-E01 / INV-213-E02 / INV-213-E03 / INV-213-E04:
+# Effect-stream discriminability: positive controls on gh and non-gh transport,
+# negative control on early transport before boundary, and negative control on disabled logger.
+
+# Positive controls for gh and non-gh transport operations.
+gh_probe="$tmp_root/gh-positive.probe"
+: >"$gh_probe"
+DAILY_AMARU_FAKE_GH_LOG="$gh_probe" "$fake_gh" api repos/example >/dev/null
+[ -s "$gh_probe" ] && grep -Fq 'gh api repos/example' "$gh_probe" ||
+  fail 'fake-gh positive control probe failed to record gh operation'
+
+transport_probe="$tmp_root/transport-positive.probe"
+: >"$transport_probe"
+DAILY_AMARU_EFFECT_LOG="$transport_probe" "$transport" preflight gh git jq rg sed awk grep tail tr head seq sleep date docker nix >/dev/null 2>&1 || true
+[ -s "$transport_probe" ] && grep -Fq 'transport preflight' "$transport_probe" ||
+  fail 'transport effect logger positive control failed to record non-gh operation'
+
+# Negative control: disabling the logger must fail the positive probe.
+disabled_probe="$tmp_root/disabled-logger.probe"
+: >"$disabled_probe"
+disabled_mutant="$tmp_root/fake-gh-disabled.sh"
+sed 's|} >>"$log_file"|} >/dev/null # effect-stream-logger-disabled|' "$fake_gh" >"$disabled_mutant"
+chmod +x "$disabled_mutant"
+DAILY_AMARU_FAKE_GH_LOG="$disabled_probe" "$disabled_mutant" api repos/example >/dev/null
+if [ -s "$disabled_probe" ]; then
+  fail 'disabled logger mutant unexpectedly recorded to probe'
+fi
+
+# Negative control: early transport before boundary must be observable in effect stream.
+early_mutant="$tmp_root/controller-early-transport.sh"
+awk '
+  { print }
+  $0 == "[ -n \"${DAILY_AMARU_DAY:-}\" ] || bootstrap_command_census+=(date)" {
+    print "if command -v bash >/dev/null 2>&1; then"
+    print "  early_transport=\"${BASH_SOURCE[0]%/*}/daily-amaru-github.sh\""
+    print "  \"$early_transport\" preflight >/dev/null 2>&1 || true"
+    print "fi # effect-stream-early-transport"
+  }
+' "$controller" >"$early_mutant"
+chmod +x "$early_mutant"
+run_hermetic_case early-transport-check '' 2026-08-02 "$early_mutant"
+grep -Fq 'transport preflight' "$hermetic_effects" ||
+  fail 'early transport before boundary was not recorded in the effect stream'
+
+printf 'EFFECT-STREAM gh=1 non_gh=1 positive_control=1 logger_required=1\n'
+pass effect-stream-discriminability
+

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -137,6 +137,8 @@ run_case() {
   case_name=$1
   local mode=${2:-test}
   local identity=${3-test-identity}
+  local app_id=${4-}
+  local app_key=${5-}
   case_number=$((case_number + 1))
   case_dir="$tmp_root/$case_number-$case_name"
   case_state="$case_dir/state"
@@ -162,6 +164,8 @@ run_case() {
     DAILY_AMARU_MODE="$mode" \
     DAILY_AMARU_DAY=2026-07-31 \
     DAILY_AMARU_IDENTITY="$identity" \
+    DAILY_AMARU_APP_ID="$app_id" \
+    DAILY_AMARU_APP_PRIVATE_KEY="$app_key" \
     DAILY_AMARU_STATE_DIR="$case_state" \
     DAILY_AMARU_RECEIPT="$case_receipt" \
     DAILY_AMARU_ALLOW_REAL=1 \
@@ -516,9 +520,20 @@ assert_no_mutation
 assert_no_launch
 assert_honest_failure_receipt identity
 assert_file_contains "$case_receipt" 'day=2026-07-31'
-assert_file_contains "$case_receipt" 'error=missing-production-identity'
+assert_file_contains "$case_receipt" 'error=missing-credentials-DAILY_AMARU_APP_ID,DAILY_AMARU_APP_PRIVATE_KEY'
 identity_control_log=$case_log
 pass missing-identity
+
+for cred_case in 'missing-app-id|DAILY_AMARU_APP_ID||key-present' 'missing-app-key|DAILY_AMARU_APP_PRIVATE_KEY|id-present|'; do
+  IFS='|' read -r cname cmissing cid ckey <<<"$cred_case"
+  run_case "$cname" production '' "$cid" "$ckey"
+  require_failure
+  assert_no_mutation
+  assert_no_launch
+  assert_honest_failure_receipt identity
+  assert_file_contains "$case_receipt" "error=missing-credentials-$cmissing"
+  pass "$cname"
+done
 
 # A reported missing command, silence, and an unparsable success all become
 # stage=runner-preflight before the day is claimed. INV-213-01, INV-213-02.
@@ -958,3 +973,31 @@ grep -Fq 'transport preflight' "$hermetic_effects" ||
 
 printf 'EFFECT-STREAM gh=1 non_gh=1 positive_control=1 logger_required=1\n'
 pass effect-stream-discriminability
+
+# INV-213-C05: a generic-only identity error must not satisfy the proof.
+generic_id_dir="$tmp_root/generic-id-mutant"
+mkdir -p "$generic_id_dir"
+generic_id_controller="$generic_id_dir/daily-amaru.sh"
+sed 's/fail_stage identity .*/fail_stage identity missing-production-identity/' "$controller" >"$generic_id_controller"
+chmod +x "$generic_id_controller"
+generic_id_effects="$generic_id_dir/effects"
+: >"$generic_id_effects"
+generic_id_rc=0
+env \
+  PATH="$PATH" \
+  FAKE_SCENARIO=missing-identity \
+  FAKE_LOG="$generic_id_dir/transport.log" \
+  DAILY_AMARU_TRANSPORT="$fake_transport" \
+  DAILY_AMARU_MODE=production \
+  DAILY_AMARU_DAY=2026-07-31 \
+  DAILY_AMARU_IDENTITY="" \
+  DAILY_AMARU_STATE_DIR="$generic_id_dir/state" \
+  DAILY_AMARU_RECEIPT="$generic_id_dir/receipt" \
+  DAILY_AMARU_ALLOW_REAL=1 \
+  "$generic_id_controller" >/dev/null 2>&1 || generic_id_rc=$?
+if [ "$generic_id_rc" -eq 0 ] || grep -Fqx 'error=missing-credentials-DAILY_AMARU_APP_ID,DAILY_AMARU_APP_PRIVATE_KEY' "$generic_id_dir/receipt" 2>/dev/null; then
+  fail 'generic identity mutant unexpectedly passed named credential check'
+fi
+
+printf 'IDENTITY-CREDENTIALS named=1 set_exact=1 generic_rejected=1 effects=0\n'
+pass identity-named-credentials

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -918,19 +918,22 @@ pass scheduled-receipt-always-published
 gh_probe="$tmp_root/gh-positive.probe"
 : >"$gh_probe"
 DAILY_AMARU_FAKE_GH_LOG="$gh_probe" "$fake_gh" api repos/example >/dev/null
-[ -s "$gh_probe" ] && grep -Fq 'gh api repos/example' "$gh_probe" ||
+if [ ! -s "$gh_probe" ] || ! grep -Fq 'gh api repos/example' "$gh_probe"; then
   fail 'fake-gh positive control probe failed to record gh operation'
+fi
 
 transport_probe="$tmp_root/transport-positive.probe"
 : >"$transport_probe"
 DAILY_AMARU_EFFECT_LOG="$transport_probe" "$transport" preflight gh git jq rg sed awk grep tail tr head seq sleep date docker nix >/dev/null 2>&1 || true
-[ -s "$transport_probe" ] && grep -Fq 'transport preflight' "$transport_probe" ||
+if [ ! -s "$transport_probe" ] || ! grep -Fq 'transport preflight' "$transport_probe"; then
   fail 'transport effect logger positive control failed to record non-gh operation'
+fi
 
 # Negative control: disabling the logger must fail the positive probe.
 disabled_probe="$tmp_root/disabled-logger.probe"
 : >"$disabled_probe"
 disabled_mutant="$tmp_root/fake-gh-disabled.sh"
+# shellcheck disable=SC2016
 sed 's|} >>"$log_file"|} >/dev/null # effect-stream-logger-disabled|' "$fake_gh" >"$disabled_mutant"
 chmod +x "$disabled_mutant"
 DAILY_AMARU_FAKE_GH_LOG="$disabled_probe" "$disabled_mutant" api repos/example >/dev/null
@@ -940,20 +943,18 @@ fi
 
 # Negative control: early transport before boundary must be observable in effect stream.
 early_mutant="$tmp_root/controller-early-transport.sh"
-awk '
+awk -v transport="$transport" '
   { print }
   $0 == "[ -n \"${DAILY_AMARU_DAY:-}\" ] || bootstrap_command_census+=(date)" {
     print "if command -v bash >/dev/null 2>&1; then"
-    print "  early_transport=\"${BASH_SOURCE[0]%/*}/daily-amaru-github.sh\""
-    print "  \"$early_transport\" preflight >/dev/null 2>&1 || true"
+    print "  \"" transport "\" preflight >/dev/null 2>&1 || true"
     print "fi # effect-stream-early-transport"
   }
 ' "$controller" >"$early_mutant"
 chmod +x "$early_mutant"
-run_hermetic_case early-transport-check '' 2026-08-02 "$early_mutant"
+run_hermetic_case early-transport-check dirname 2026-08-02 "$early_mutant"
 grep -Fq 'transport preflight' "$hermetic_effects" ||
   fail 'early transport before boundary was not recorded in the effect stream'
 
 printf 'EFFECT-STREAM gh=1 non_gh=1 positive_control=1 logger_required=1\n'
 pass effect-stream-discriminability
-

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -67,27 +67,19 @@ assert_honest_failure_receipt() {
 }
 
 assert_workflow_literal_once() {
-  local literal=$1
-  local actual
+  local literal=$1 actual
   actual=$(count_literal "$workflow" "$literal")
   [ "$actual" -eq 1 ] ||
     fail "workflow must declare exactly once (found $actual): $literal"
 }
 
-# --- D213-01 receipt oracle ------------------------------------------------
-# A broken precondition is only proved loud when a receipt naming the UTC day,
-# the precise stage, `outcome=FAILED`, and a stable specific error exists while
-# no business effect was reached. The oracle is exercised in both directions
-# below before any verdict it produces is believed.
+# D213-01, exercised in both directions before any verdict it gives is believed.
 receipt_oracle() {
-  local receipt=$1
-  local day=$2
-  local stage=$3
-  local error=$4
-  local effects=$5
+  local receipt=$1 day=$2 stage=$3 error=$4 effects=$5
   local field forbidden
 
-  [ -f "$receipt" ] && [ ! -L "$receipt" ] && [ -s "$receipt" ] || return 1
+  [ -f "$receipt" ] && [ ! -L "$receipt" ] && [ -s "$receipt" ] && [ -f "$effects" ] ||
+    return 1
   for field in "day=$day" "stage=$stage" 'outcome=FAILED' "error=$error"; do
     grep -Fqx -- "$field" "$receipt" || return 1
   done
@@ -103,17 +95,18 @@ receipt_oracle() {
   return 0
 }
 
-# --- Hermetic scheduled-runner PATH ---------------------------------------
-# Every non-shell command the scheduled production transport can reach, minus
-# the incident command `rg`. Seeding an exclusive PATH makes a missing-command
-# verdict caused by absence rather than by an unrelated broken harness.
+# An exclusive PATH makes a missing-command verdict caused by absence.
 scheduled_seed_commands=(
   bash dirname mkdir git jq sed awk grep tail tr head seq sleep date docker nix
 )
 
+stub_command() {
+  printf '#!/bin/sh\nexit 0\n' >"$1"
+  chmod +x "$1"
+}
+
 seed_scheduled_path() {
-  local bin_dir=$1
-  local include_rg=$2
+  local bin_dir=$1 include_rg=$2
   local command target
   mkdir -p "$bin_dir"
   for command in "${scheduled_seed_commands[@]}"; do
@@ -121,20 +114,16 @@ seed_scheduled_path() {
       [ "${target:0:1}" = / ] && [ -x "$target" ]; then
       ln -sf "$target" "$bin_dir/$command"
     else
-      printf '#!/bin/sh\nexit 0\n' >"$bin_dir/$command"
-      chmod +x "$bin_dir/$command"
+      stub_command "$bin_dir/$command"
     fi
   done
   ln -sf "$fake_gh" "$bin_dir/gh"
   if [ "$include_rg" = with-rg ]; then
-    printf '#!/bin/sh\nexit 0\n' >"$bin_dir/rg"
-    chmod +x "$bin_dir/rg"
+    stub_command "$bin_dir/rg"
   else
     rm -f "$bin_dir/rg"
   fi
-
-  # Positive control: an exclusive PATH that resolves nothing would report every
-  # command as missing and prove nothing at all.
+  # Positive control: a PATH resolving nothing would report everything missing.
   PATH="$bin_dir" command -v gh >/dev/null ||
     fail "seeded PATH cannot resolve a command that is present: $bin_dir"
   if [ "$include_rg" = without-rg ] &&
@@ -179,33 +168,40 @@ run_case() {
     "$controller" >"$case_stdout" 2>"$case_stderr" || case_rc=$?
 }
 
-run_scheduled_incident() {
-  local day=$1
-  scheduled_dir="$tmp_root/scheduled-$day"
-  scheduled_state="$scheduled_dir/state"
-  scheduled_receipt="$scheduled_dir/receipt"
-  scheduled_effects="$scheduled_dir/effects"
-  mkdir -p "$scheduled_state"
-  : >"$scheduled_effects"
-  seed_scheduled_path "$scheduled_dir/bin" without-rg
+bash_binary=$(command -v bash)
 
-  scheduled_rc=0
+# One hermetic production-transport run. `omit` is the single command removed
+# from an otherwise complete seeded PATH, or empty to seed nothing at all. An
+# absolute interpreter keeps even an empty PATH reaching the first boundary.
+run_hermetic_case() {
+  local label=$1 omit=$2 day=$3 script=${4:-$controller}
+  hermetic_dir="$tmp_root/hermetic-$label"
+  hermetic_receipt="$hermetic_dir/receipt"
+  hermetic_effects="$hermetic_dir/effects"
+  mkdir -p "$hermetic_dir/state" "$hermetic_dir/bin"
+  : >"$hermetic_effects"
+  if [ -n "$omit" ]; then
+    seed_scheduled_path "$hermetic_dir/bin" with-rg
+    rm -f "$hermetic_dir/bin/$omit"
+    if PATH="$hermetic_dir/bin" command -v "$omit" >/dev/null 2>&1; then
+      fail "hermetic omission did not apply: $omit"
+    fi
+  fi
+  hermetic_rc=0
   env \
-    PATH="$scheduled_dir/bin" \
-    DAILY_AMARU_FAKE_GH_LOG="$scheduled_effects" \
+    PATH="$hermetic_dir/bin" \
+    DAILY_AMARU_FAKE_GH_LOG="$hermetic_effects" \
     DAILY_AMARU_MODE=production \
     DAILY_AMARU_DAY="$day" \
     DAILY_AMARU_IDENTITY=seed-non-empty-identity \
-    DAILY_AMARU_STATE_DIR="$scheduled_state" \
-    DAILY_AMARU_RECEIPT="$scheduled_receipt" \
-    "$controller" \
-    >"$scheduled_dir/stdout" 2>"$scheduled_dir/stderr" || scheduled_rc=$?
+    DAILY_AMARU_STATE_DIR="$hermetic_dir/state" \
+    DAILY_AMARU_RECEIPT="$hermetic_receipt" \
+    "$bash_binary" "$script" \
+    >"$hermetic_dir/stdout" 2>"$hermetic_dir/stderr" || hermetic_rc=$?
 }
 
 run_transport_preflight() {
-  local bin_dir=$1
-  local root=$2
-  local label=$3
+  local bin_dir=$1 root=$2 label=$3
   shift 3
   preflight_rc=0
   preflight_stdout=$root/$label.stdout
@@ -219,11 +215,8 @@ run_transport_preflight() {
     >"$preflight_stdout" 2>"$preflight_stderr" || preflight_rc=$?
 }
 
-# Extract one transport `case` branch body so identity boundaries can be
-# checked per operation rather than across the whole file.
 transport_branch() {
-  local file=$1
-  local operation=$2
+  local file=$1 operation=$2
   awk -v op="$operation" '
     $0 == "  " op ")" { inside = 1; next }
     inside && $0 == "    ;;" { inside = 0 }
@@ -237,9 +230,8 @@ repository_boundary_operations=(
   require-consumer-checks await-supervised-integration real-launch receipt
 )
 
-# INV-213-03 — the minted bootstrap token must not be reachable from any
-# same-repository operation, and the bootstrap operations must not silently
-# fall back to the repository token.
+# INV-213-03: the minted token must be unreachable from every same-repository
+# operation, and bootstrap operations must not fall back to the repository one.
 identity_boundary_holds() {
   local file=$1
   local operation body
@@ -247,16 +239,12 @@ identity_boundary_holds() {
     body=$(transport_branch "$file" "$operation")
     [ -n "$body" ] || return 1
     grep -q 'bootstrap_identity' <<<"$body" || return 1
-    if grep -q 'repository_identity' <<<"$body"; then
-      return 1
-    fi
+    ! grep -q 'repository_identity' <<<"$body" || return 1
   done
   for operation in "${repository_boundary_operations[@]}"; do
     body=$(transport_branch "$file" "$operation")
     [ -n "$body" ] || return 1
-    if grep -q 'bootstrap_identity\|DAILY_AMARU_IDENTITY' <<<"$body"; then
-      return 1
-    fi
+    ! grep -q 'bootstrap_identity\|DAILY_AMARU_IDENTITY' <<<"$body" || return 1
   done
   return 0
 }
@@ -292,50 +280,42 @@ if [ ! -f "$workflow" ]; then
   fail "scheduled workflow absent: expected regular file $workflow"
 fi
 
-# --- Receipt oracle controls ----------------------------------------------
 oracle_root="$tmp_root/receipt-oracle"
 mkdir -p "$oracle_root"
 : >"$oracle_root/clean-effects"
 printf 'gh repo clone lambdasistemi/amaru-bootstrap\n' >"$oracle_root/dirty-effects"
-
 printf 'day=2026-08-02\nstage=runner-preflight\noutcome=FAILED\nerror=missing-command-rg\n' \
   >"$oracle_root/valid"
-receipt_oracle "$oracle_root/valid" 2026-08-02 runner-preflight missing-command-rg \
-  "$oracle_root/clean-effects" ||
-  fail 'receipt oracle rejected its positive control'
-
 printf 'day=2026-08-02\nstage=runner-preflight\noutcome=FAILED\n' >"$oracle_root/no-error"
-if receipt_oracle "$oracle_root/no-error" 2026-08-02 runner-preflight missing-command-rg \
-  "$oracle_root/clean-effects"; then
-  fail 'receipt oracle accepted a missing specific error'
-fi
-
 printf 'day=2026-08-02\nstage=runner-preflight\noutcome=CHANGED\nerror=missing-command-rg\n' \
   >"$oracle_root/success-like"
-if receipt_oracle "$oracle_root/success-like" 2026-08-02 runner-preflight missing-command-rg \
-  "$oracle_root/clean-effects"; then
-  fail 'receipt oracle accepted a success-like outcome'
-fi
-
-if receipt_oracle "$oracle_root/absent" 2026-08-02 runner-preflight missing-command-rg \
-  "$oracle_root/clean-effects"; then
-  fail 'receipt oracle accepted silence'
-fi
-
-if receipt_oracle "$oracle_root/valid" 2026-08-02 runner-preflight missing-command-rg \
-  "$oracle_root/dirty-effects"; then
-  fail 'receipt oracle accepted a reached business effect'
-fi
+# receipt|effects|expected|description
+for control in \
+  'valid|clean-effects|accept|its positive control' \
+  'no-error|clean-effects|reject|a missing specific error' \
+  'success-like|clean-effects|reject|a success-like outcome' \
+  'absent|clean-effects|reject|silence' \
+  'valid|dirty-effects|reject|a reached business effect'
+do
+  IFS='|' read -r control_receipt control_effects control_expect control_what \
+    <<<"$control"
+  control_rc=0
+  receipt_oracle "$oracle_root/$control_receipt" 2026-08-02 runner-preflight \
+    missing-command-rg "$oracle_root/$control_effects" || control_rc=$?
+  if [ "$control_expect" = accept ]; then
+    [ "$control_rc" -eq 0 ] || fail "receipt oracle rejected $control_what"
+  else
+    [ "$control_rc" -ne 0 ] || fail "receipt oracle accepted $control_what"
+  fi
+done
 printf 'RECEIPT-ORACLE-CONTROLS positive=1 negative=4\n'
 pass receipt-oracle-controls
 
-# --- FN-213-03 dependency preflight controls -------------------------------
 preflight_root="$tmp_root/preflight-controls"
 mkdir -p "$preflight_root/state"
 : >"$preflight_root/effects"
 seed_scheduled_path "$preflight_root/complete" with-rg
 seed_scheduled_path "$preflight_root/incomplete" without-rg
-
 run_transport_preflight "$preflight_root/complete" "$preflight_root" complete
 [ "$preflight_rc" -eq 0 ] ||
   fail "complete dependency census was rejected: $(tr '\n' ' ' <"$preflight_stderr")"
@@ -348,49 +328,91 @@ census_list=${BASH_REMATCH[2]}
   fail "declared census count $census_count differs from the named commands"
 [[ " $census_list " == *" rg "* ]] ||
   fail "dependency census omits the incident command rg: $census_list"
-
-run_transport_preflight "$preflight_root/incomplete" "$preflight_root" incomplete
-[ "$preflight_rc" -ne 0 ] || fail 'preflight accepted a runner without rg'
-grep -Fqx 'daily-amaru-github: missing command: rg' "$preflight_stderr" ||
-  fail 'preflight did not name the exact missing command on stderr'
-grep -Fqx 'MISSING-COMMAND rg' "$preflight_stdout" ||
-  fail 'preflight did not report the missing command machine-readably'
-
-# The verdict must belong to a property class, not to the single `rg` instance.
-run_transport_preflight "$preflight_root/complete" "$preflight_root" probe \
-  t213-absent-probe
-[ "$preflight_rc" -ne 0 ] ||
-  fail 'preflight accepted an explicitly required absent command'
-grep -Fqx 'daily-amaru-github: missing command: t213-absent-probe' "$preflight_stderr" ||
-  fail 'preflight did not name the absent explicit requirement'
-
-[ ! -s "$preflight_root/effects" ] ||
-  fail 'dependency preflight reached a GitHub effect'
+# Absent `rg`, then an absent explicit requirement: the verdict must belong to a
+# property class, not to the single `rg` instance.
+for absent in rg t213-absent-probe; do
+  if [ "$absent" = rg ]; then
+    run_transport_preflight "$preflight_root/incomplete" "$preflight_root" "$absent"
+    grep -Fqx 'MISSING-COMMAND rg' "$preflight_stdout" ||
+      fail 'preflight did not report the missing command machine-readably'
+  else
+    run_transport_preflight "$preflight_root/complete" "$preflight_root" "$absent" "$absent"
+  fi
+  [ "$preflight_rc" -ne 0 ] || fail "preflight accepted an absent command: $absent"
+  grep -Fqx "daily-amaru-github: missing command: $absent" "$preflight_stderr" ||
+    fail "preflight did not name the absent command: $absent"
+done
+[ -f "$preflight_root/effects" ] && [ ! -s "$preflight_root/effects" ] ||
+  fail 'dependency preflight reached a GitHub effect, or its log vanished'
 printf 'DEPENDENCY-CENSUS count=%s rg=required effects=0\n' "$census_count"
 pass scheduled-preflight-controls
 
-# --- FR-213-02 dated incident reproduction ---------------------------------
+# F1: the transport preflight cannot classify the commands needed to reach the
+# transport itself. The census is read from the controller source, so a later
+# addition to it is covered here automatically.
+mapfile -t bootstrap_census < <(
+  sed -nE 's/^bootstrap_command_census=\((.*)\)$/\1/p' "$controller" |
+    tr ' ' '\n' | sed '/^$/d'
+)
+[ "${#bootstrap_census[@]}" -ge 1 ] ||
+  fail 'controller declares no bootstrap command census'
+# With nothing reachable, anything executing before the boundary would crash
+# instead of classifying, so the first census member must be the verdict.
+run_hermetic_case empty-path '' 2026-08-02
+[ "$hermetic_rc" -ne 0 ] ||
+  fail 'controller accepted a runner with no external command at all'
+receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
+  "missing-command-${bootstrap_census[0]}" "$hermetic_effects" ||
+  fail 'empty-PATH control produced no classified durable receipt'
+[ ! -s "$hermetic_effects" ] ||
+  fail 'empty-PATH control reached a GitHub effect'
+for omitted in "${bootstrap_census[@]}"; do
+  run_hermetic_case "omit-$omitted" "$omitted" 2026-08-02
+  [ "$hermetic_rc" -ne 0 ] ||
+    fail "controller accepted a runner without $omitted"
+  grep -Fqx "daily-amaru: missing command: $omitted" "$hermetic_dir/stderr" ||
+    fail "absent $omitted was not named on stderr"
+  receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
+    "missing-command-$omitted" "$hermetic_effects" ||
+    fail "absent $omitted produced no classified durable receipt"
+  [ ! -s "$hermetic_effects" ] ||
+    fail "absent $omitted reached a GitHub effect"
+done
+# Prove the control can fail: an empty boundary crashes instead of classifying.
+bootstrap_mutant="$tmp_root/controller-unguarded.sh"
+sed -E 's/^bootstrap_command_census=\(.*\)$/bootstrap_command_census=()/' \
+  "$controller" >"$bootstrap_mutant"
+grep -Fqx 'bootstrap_command_census=()' "$bootstrap_mutant" ||
+  fail 'bootstrap-census mutation did not apply'
+run_hermetic_case unguarded-mutant '' 2026-08-02 "$bootstrap_mutant"
+if receipt_oracle "$hermetic_receipt" 2026-08-02 runner-preflight \
+  "missing-command-${bootstrap_census[0]}" "$hermetic_effects"; then
+  fail 'a controller without a bootstrap boundary still classified the failure'
+fi
+printf 'BOOTSTRAP-BOUNDARY census=%s members=%s empty_path_control=1 mutants_rejected=1\n' \
+  "${#bootstrap_census[@]}" "${bootstrap_census[*]}"
+pass bootstrap-command-boundary
+
 scheduled_effect_logs=()
 for incident_day in 2026-08-02 2026-08-03; do
-  run_scheduled_incident "$incident_day"
-  [ "$scheduled_rc" -ne 0 ] ||
+  run_hermetic_case "incident-$incident_day" rg "$incident_day"
+  [ "$hermetic_rc" -ne 0 ] ||
     fail "scenario=scheduled-$incident_day expected a non-zero scheduled exit"
-  grep -Fqx 'daily-amaru-github: missing command: rg' "$scheduled_dir/stderr" ||
+  grep -Fqx 'daily-amaru-github: missing command: rg' "$hermetic_dir/stderr" ||
     fail "scenario=scheduled-$incident_day lacks the exact incident fingerprint"
-  receipt_oracle "$scheduled_receipt" "$incident_day" runner-preflight \
-    missing-command-rg "$scheduled_effects" ||
+  receipt_oracle "$hermetic_receipt" "$incident_day" runner-preflight \
+    missing-command-rg "$hermetic_effects" ||
     fail "scenario=scheduled-$incident_day lacks a loud durable failure receipt"
   # A broken runner must not even consume the UTC day.
-  if grep -Fq "daily-amaru day=$incident_day claim" "$scheduled_effects"; then
+  if grep -Fq "daily-amaru day=$incident_day claim" "$hermetic_effects"; then
     fail "scenario=scheduled-$incident_day claimed the UTC day behind a broken runner"
   fi
-  scheduled_effect_logs+=("$scheduled_effects")
+  scheduled_effect_logs+=("$hermetic_effects")
   printf 'INCIDENT day=%s base=311dfc1 fingerprint=%s exit=%s business_effects=0\n' \
-    "$incident_day" 'daily-amaru-github: missing command: rg' "$scheduled_rc"
+    "$incident_day" 'daily-amaru-github: missing command: rg' "$hermetic_rc"
   pass "scheduled-missing-rg-$incident_day"
 done
 
-# --- Existing controller contract ------------------------------------------
 run_case changed
 require_success
 assert_file_contains "$case_receipt" 'outcome=CHANGED'
@@ -429,31 +451,24 @@ assert_file_contains "$case_receipt" 'error=missing-production-identity'
 identity_control_log=$case_log
 pass missing-identity
 
-# The controller owns the precondition order: a transport-reported missing
-# command becomes stage=runner-preflight before the day is even claimed.
-run_case missing-tool production seed-non-empty-identity
-require_failure
-assert_log_count 0 '^claim-day '
-assert_log_count 0 '^claim-sha-attempt '
-assert_no_mutation
-assert_no_launch
-assert_honest_failure_receipt runner-preflight
-assert_file_contains "$case_receipt" 'day=2026-07-31'
-assert_file_contains "$case_receipt" 'error=missing-command-rg'
-tool_control_log=$case_log
-pass missing-tool
-
-# INV-213-02 — a preflight that reports nothing, or reports an unparsable
-# success, cannot be read as a satisfied dependency contract.
-for vacuous in silent-preflight malformed-preflight; do
-  run_case "$vacuous" production seed-non-empty-identity
+# A reported missing command, silence, and an unparsable success all become
+# stage=runner-preflight before the day is claimed. INV-213-01, INV-213-02.
+for broken in missing-tool silent-preflight malformed-preflight; do
+  run_case "$broken" production seed-non-empty-identity
   require_failure
   assert_log_count 0 '^claim-day '
+  assert_log_count 0 '^claim-sha-attempt '
   assert_no_mutation
   assert_no_launch
   assert_honest_failure_receipt runner-preflight
-  assert_file_contains "$case_receipt" 'error=malformed-dependency-evidence'
-  pass "$vacuous"
+  assert_file_contains "$case_receipt" 'day=2026-07-31'
+  if [ "$broken" = missing-tool ]; then
+    assert_file_contains "$case_receipt" 'error=missing-command-rg'
+    tool_control_log=$case_log
+  else
+    assert_file_contains "$case_receipt" 'error=malformed-dependency-evidence'
+  fi
+  pass "$broken"
 done
 
 for check_case in missing-check wrong-head-check ambiguous-check pending-check failed-check; do
@@ -540,8 +555,7 @@ for observation in malformed-observation wrong-origin-observation wrong-ref-obse
   assert_honest_failure_receipt resolve-upstream
   pass "$observation"
 done
-
-# --- INV-213-06 counted effect census over both broken preconditions -------
+# INV-213-06 over both broken preconditions.
 for broken_log in "${scheduled_effect_logs[@]}"; do
   for forbidden in 'repo clone' 'pr create' 'pr merge' 'workflow run' 'run watch'; do
     if grep -Fq -- "$forbidden" "$broken_log"; then
@@ -550,13 +564,8 @@ for broken_log in "${scheduled_effect_logs[@]}"; do
   done
 done
 for broken_log in "$tool_control_log" "$identity_control_log"; do
-  for pattern in \
-    '^claim-sha-attempt ' \
-    '^mutation:' \
-    '^await-supervised-integration ' \
-    '^fake-launch ' \
-    '^real-launch '
-  do
+  for pattern in '^claim-sha-attempt ' '^mutation:' \
+    '^await-supervised-integration ' '^fake-launch ' '^real-launch '; do
     actual=$(count_matches "$broken_log" "$pattern")
     [ "$actual" -eq 0 ] ||
       fail "broken precondition reached $actual effects matching $pattern"
@@ -565,7 +574,6 @@ done
 printf 'EFFECT-CENSUS controls=2 attempts=0 mutations=0 integrations=0 fake_launches=0 real_launches=0\n'
 pass broken-preconditions-no-business-effects
 
-# --- D213-02 dedicated bootstrap App interface -----------------------------
 # The `${{ ... }}` sequences below are GitHub Actions expressions matched as
 # literal workflow text; expanding them here would defeat the assertion.
 # shellcheck disable=SC2016
@@ -586,54 +594,48 @@ done
 app_permissions=$(count_matches "$workflow" '^[[:space:]]*permission-[a-z-]+:')
 [ "$app_permissions" -eq 5 ] ||
   fail "bootstrap App permission census must be exactly five, found $app_permissions"
-
 identity_boundary_holds "$transport" ||
   fail 'the minted bootstrap identity is not confined to the bootstrap boundary'
 
-# Prove the boundary check can fail: a mutant that reaches for the bootstrap
-# identity inside a same-repository operation must be rejected, and a mutant
-# that drops it from the bootstrap boundary must be rejected too. Each mutation
-# verifies its own application so a silently unapplied edit cannot report a
-# caught defect.
-mutant_root="$tmp_root/identity-mutants"
+mutant_root="$tmp_root/mutants"
 mkdir -p "$mutant_root"
-
-# The injected text is transport source read back verbatim, not an expansion.
+# Each mutant verifies its own application; `applied` with a `!` means absence.
+reject_mutant() {
+  local label=$1 source=$2 script=$3 applied=$4 why=$5
+  shift 5
+  local mutant="$mutant_root/$label"
+  sed "$script" "$source" >"$mutant"
+  if [ "${applied:0:1}" = '!' ]; then
+    ! grep -Fq -- "${applied:1}" "$mutant" || fail "mutation did not apply: $label"
+  else
+    grep -Fq -- "$applied" "$mutant" || fail "mutation did not apply: $label"
+  fi
+  if "$@" "$mutant"; then
+    fail "check accepted $why"
+  fi
+}
 # shellcheck disable=SC2016
-sed 's#^  receipt)$#  receipt)\n    leak="$bootstrap_identity"#' "$transport" \
-  >"$mutant_root/leaked.sh"
-# shellcheck disable=SC2016
-grep -Fq 'leak="$bootstrap_identity"' "$mutant_root/leaked.sh" ||
-  fail 'identity-leak mutation did not apply'
-if identity_boundary_holds "$mutant_root/leaked.sh"; then
-  fail 'boundary check accepted a bootstrap identity inside a repository operation'
-fi
-
-sed 's#bootstrap_identity#repository_identity#g' "$transport" \
-  >"$mutant_root/downgraded.sh"
-if grep -Fq 'bootstrap_identity' "$mutant_root/downgraded.sh"; then
-  fail 'identity-downgrade mutation did not apply'
-fi
-if identity_boundary_holds "$mutant_root/downgraded.sh"; then
-  fail 'boundary check accepted a bootstrap operation without the minted identity'
-fi
+reject_mutant leaked.sh "$transport" \
+  's#^  receipt)$#  receipt)\n    leak="$bootstrap_identity"#' \
+  'leak="$bootstrap_identity"' \
+  'a bootstrap identity inside a repository operation' identity_boundary_holds
+reject_mutant downgraded.sh "$transport" 's#bootstrap_identity#repository_identity#g' \
+  '!bootstrap_identity' \
+  'a bootstrap operation without the minted identity' identity_boundary_holds
 printf 'IDENTITY-BOUNDARY bootstrap_ops=%s repository_ops=%s mutants_rejected=2\n' \
   "${#bootstrap_boundary_operations[@]}" "${#repository_boundary_operations[@]}"
 pass dedicated-app-scope
 
-# --- INV-213-05 the minted token is ephemeral ------------------------------
+# INV-213-05: bound exactly once, nowhere else, and never persisted.
 for forbidden in DAILY_AMARU_CROSS_REPO_TOKEN MOOG_GITHUB_PAT GITHUB_ENV; do
   if grep -Fq -- "$forbidden" "$workflow" "$controller" "$transport"; then
     fail "forbidden credential path remains: $forbidden"
   fi
 done
-# Literal workflow expressions again: the minted token must be bound exactly
-# once, and must appear nowhere else in the workflow.
 # shellcheck disable=SC2016
 assert_workflow_literal_once 'DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}'
 # shellcheck disable=SC2016
 assert_workflow_literal_once '${{ steps.app-token.outputs.token }}'
-
 secret_value=t213-bootstrap-secret-token-value
 run_case failed-stage production "$secret_value"
 require_failure
@@ -653,9 +655,7 @@ done < <(find "$case_dir" -type f)
   fail 'secret persistence scan inspected no artifact at all'
 [ "$leaked_artifacts" -eq 0 ] ||
   fail "minted bootstrap identity persisted into $leaked_artifacts artifact(s)"
-
-# Positive control: the same search finds the value where it is genuinely
-# present, so the zero above is absence rather than a broken instrument.
+# Positive control: the zero above must be absence, not a broken instrument.
 printf '%s\n' "$secret_value" >"$case_dir/leak-probe"
 grep -Fq -- "$secret_value" "$case_dir/leak-probe" ||
   fail 'leak search cannot detect a known-present secret'
@@ -663,9 +663,94 @@ printf 'SECRET-PERSISTENCE artifacts_scanned=%s leaks=0 probe=detected\n' \
   "$scanned_artifacts"
 pass bootstrap-token-not-persisted
 
-# --- INV-213-09 production wiring executes this proof ----------------------
-assert_workflow_literal_once 'run: tests/test-daily-amaru.sh'
-assert_workflow_literal_once 'scripts/daily-amaru.sh'
+# F2: separating the identities is not enough — the job must grant the
+# repository token what each same-repository operation declares it needs.
+job_grants() {
+  awk '
+    /^  daily-amaru-scheduled:/ { job = 1 }
+    job && /^    permissions:/ { block = 1; next }
+    block && /^      [a-z-]+:[[:space:]]*[a-z]+[[:space:]]*$/ {
+      key = $1; sub(/:$/, "", key); print key "=" $2; next
+    }
+    block && /^    [^ ]/ { exit }
+  ' "$1"
+}
+
+permission_rank() {
+  case $1 in read) printf 1 ;; write) printf 2 ;; *) printf 0 ;; esac
+}
+
+grants_satisfy_transport() {
+  local -A granted=()
+  local row
+  while IFS= read -r row; do
+    [ -z "$row" ] || granted[${row%%=*}]=${row#*=}
+  done < <(job_grants "$1")
+  [ "${#granted[@]}" -gt 0 ] || return 1
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    [ "$(permission_rank "${granted[${row%%=*}]:-none}")" -ge \
+      "$(permission_rank "${row#*=}")" ] || return 1
+  done < <(
+    sed -nE 's/^[[:space:]]*# repository-token-permissions:[[:space:]]*(.*)$/\1/p' "$2" |
+      tr ' ' '\n' | sed '/^$/d'
+  )
+  return 0
+}
+for operation in "${repository_boundary_operations[@]}"; do
+  transport_branch "$transport" "$operation" |
+    grep -q '# repository-token-permissions:' ||
+    fail "same-repository operation declares no token permission: $operation"
+done
+grants_satisfy_transport "$workflow" "$transport" ||
+  fail 'scheduled job grants do not cover the declared same-repository permissions'
+# Both directions of the seam must fail: a downgraded grant, and a newly
+# required scope nobody granted.
+grants_for_workflow() { grants_satisfy_transport "$1" "$transport"; }
+grants_for_transport() { grants_satisfy_transport "$workflow" "$1"; }
+reject_mutant downgraded-grant.yaml "$workflow" \
+  's/^      contents: write$/      contents: read/' '      contents: read' \
+  'a job that cannot perform the consumer push' grants_for_workflow
+reject_mutant ungranted-scope.sh "$transport" \
+  's/^\([[:space:]]*# repository-token-permissions:\) issues=write$/\1 issues=write packages=write/' \
+  'packages=write' 'a required scope the job never granted' grants_for_transport
+printf 'TOKEN-GRANTS scopes=%s annotated_operations=%s mutants_rejected=2\n' \
+  "$(job_grants "$workflow" | wc -l)" "${#repository_boundary_operations[@]}"
+pass repository-token-grants
+
+# F3: counting literals accepts a workflow whose callers are no-ops and whose
+# target strings survive in comments. Compare executable command words per job.
+workflow_callers() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^jobs:[[:space:]]*$/ { jobs = 1; next }
+    !jobs { next }
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { job = $1; sub(/:$/, "", job); next }
+    {
+      line = $0
+      sub(/^[[:space:]]*-[[:space:]]+/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/^run:[[:space:]]*/, "", line)
+      sub(/[[:space:]]+#.*$/, "", line)
+      gsub(/^['\''"]|['\''"]$/, "", line)
+      if (split(line, word, /[[:space:]]+/) > 0 && word[1] != "") {
+        print job "|" word[1]
+      }
+    }
+  ' "$1"
+}
+
+wiring_holds() {
+  local callers
+  callers=$(workflow_callers "$1")
+  grep -Fqx 'daily-amaru-dry-run|tests/test-daily-amaru.sh' <<<"$callers" || return 1
+  grep -Fqx 'daily-amaru-scheduled|scripts/daily-amaru.sh' <<<"$callers" || return 1
+  return 0
+}
+wiring_holds "$workflow" ||
+  fail 'the workflow does not executably call both controller entry points'
+assert_workflow_literal_once "if: github.event_name != 'schedule'"
+assert_workflow_literal_once "if: github.event_name == 'schedule'"
 assert_workflow_literal_once 'DAILY_AMARU_MODE: production'
 assert_workflow_literal_once 'uses: actions/upload-artifact@v6'
 assert_workflow_literal_once 'if: always()'
@@ -674,5 +759,15 @@ assert_workflow_literal_once 'continue-on-error: true'
   fail 'the scheduled runner does not provision the incident command'
 [ "$(count_literal "$workflow" 'setup-nix')" -ge 1 ] ||
   fail 'the scheduled runner does not provision nix for the bootstrap proposal'
-printf 'WIRING pull_request_proof=1 scheduled_controller=1 receipt_upload=1\n'
+# Orphan each caller in turn, leaving the searched literal behind in a comment.
+reject_mutant wiring-pull-request.yaml "$workflow" \
+  "s|^        run: tests/test-daily-amaru.sh\$|        # run: tests/test-daily-amaru.sh\n        run: 'true'|" \
+  "        run: 'true'" 'an orphaned pull-request proof caller' wiring_holds
+grep -Fq 'tests/test-daily-amaru.sh' "$mutant_root/wiring-pull-request.yaml" ||
+  fail 'pull-request wiring mutant lost the misleading literal'
+reject_mutant wiring-scheduled.yaml "$workflow" \
+  's|^          scripts/daily-amaru.sh$|          true # scripts/daily-amaru.sh|' \
+  '          true # scripts/daily-amaru.sh' \
+  'an orphaned scheduled controller caller' wiring_holds
+printf 'WIRING pull_request_proof=1 scheduled_controller=1 receipt_upload=1 mutants_rejected=2\n'
 pass workflow-wires-scheduled-proof

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -566,6 +566,9 @@ printf 'EFFECT-CENSUS controls=2 attempts=0 mutations=0 integrations=0 fake_laun
 pass broken-preconditions-no-business-effects
 
 # --- D213-02 dedicated bootstrap App interface -----------------------------
+# The `${{ ... }}` sequences below are GitHub Actions expressions matched as
+# literal workflow text; expanding them here would defeat the assertion.
+# shellcheck disable=SC2016
 for literal in \
   'uses: actions/create-github-app-token@v1' \
   'app-id: ${{ vars.DAILY_AMARU_APP_ID }}' \
@@ -595,8 +598,11 @@ identity_boundary_holds "$transport" ||
 mutant_root="$tmp_root/identity-mutants"
 mkdir -p "$mutant_root"
 
+# The injected text is transport source read back verbatim, not an expansion.
+# shellcheck disable=SC2016
 sed 's#^  receipt)$#  receipt)\n    leak="$bootstrap_identity"#' "$transport" \
   >"$mutant_root/leaked.sh"
+# shellcheck disable=SC2016
 grep -Fq 'leak="$bootstrap_identity"' "$mutant_root/leaked.sh" ||
   fail 'identity-leak mutation did not apply'
 if identity_boundary_holds "$mutant_root/leaked.sh"; then
@@ -621,7 +627,11 @@ for forbidden in DAILY_AMARU_CROSS_REPO_TOKEN MOOG_GITHUB_PAT GITHUB_ENV; do
     fail "forbidden credential path remains: $forbidden"
   fi
 done
+# Literal workflow expressions again: the minted token must be bound exactly
+# once, and must appear nowhere else in the workflow.
+# shellcheck disable=SC2016
 assert_workflow_literal_once 'DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}'
+# shellcheck disable=SC2016
 assert_workflow_literal_once '${{ steps.app-token.outputs.token }}'
 
 secret_value=t213-bootstrap-secret-token-value

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -1001,3 +1001,40 @@ fi
 
 printf 'IDENTITY-CREDENTIALS named=1 set_exact=1 generic_rejected=1 effects=0\n'
 pass identity-named-credentials
+
+# INV-213-B01: scheduled controller environment bindings
+scheduled_bindings_hold() {
+  local step
+  step=$(workflow_step "$1" 'Run the once-daily state machine')
+  grep -Eq '^[[:space:]]*DAILY_AMARU_APP_ID:[[:space:]]*\$\{\{[[:space:]]*vars\.DAILY_AMARU_APP_ID[[:space:]]*\}\}' <<<"$step" || return 1
+  grep -Eq '^[[:space:]]*DAILY_AMARU_APP_PRIVATE_KEY:[[:space:]]*\$\{\{[[:space:]]*secrets\.DAILY_AMARU_APP_PRIVATE_KEY[[:space:]]*\}\}' <<<"$step" || return 1
+}
+scheduled_bindings_hold "$workflow" ||
+  fail 'scheduled controller missing required credential env bindings'
+reject_mutant drop-app-id.yaml "$workflow" \
+  '/^[[:space:]]*DAILY_AMARU_APP_ID:/d' '!DAILY_AMARU_APP_ID:' \
+  'missing App ID binding' scheduled_bindings_hold
+reject_mutant drop-app-key.yaml "$workflow" \
+  '/^[[:space:]]*DAILY_AMARU_APP_PRIVATE_KEY:/d' '!DAILY_AMARU_APP_PRIVATE_KEY:' \
+  'missing App key binding' scheduled_bindings_hold
+
+# INV-213-P01: fully provisioned production path with 3 distinct nonempty sentinels
+prod_id=sentinel-prod-token
+prod_app=sentinel-prod-app-id
+prod_key=sentinel-prod-key
+[ "$prod_id" != "$prod_app" ] && [ "$prod_id" != "$prod_key" ] && [ "$prod_app" != "$prod_key" ] ||
+  fail 'sentinels must be distinct'
+run_case changed production "$prod_id" "$prod_app" "$prod_key"
+require_success
+assert_file_contains "$case_receipt" 'stage=complete'
+assert_file_contains "$case_receipt" 'outcome=CHANGED'
+assert_log_count 1 '^real-launch '
+! grep -rq "$prod_key" "$case_dir" || fail 'private key sentinel leaked to disk or log'
+
+# INV-213-B02: docs must describe named credentials and not promise generic missing-production-identity
+assert_file_lacks "$repo_root/docs/daily-amaru.md" 'error=missing-production-identity'
+grep -Fq 'error=missing-credentials-' "$repo_root/docs/daily-amaru.md" ||
+  fail 'docs must describe named-credential error'
+
+printf 'CREDENTIAL-BINDING workflow=1 tuple=1 docs=1\n'
+pass credential-binding-contract


### PR DESCRIPTION
## Outcome

Make the Daily Amaru scheduled controller enter an explicit dependency and short-lived identity contract, and make broken runner/identity preconditions exit red with a durable stage-specific receipt instead of disappearing before the state machine.

## What changed

- provision and preflight every scheduled transport dependency before claiming the UTC day;
- wire a dedicated, least-scope GitHub App interface for `lambdasistemi/amaru-bootstrap`, while keeping its token separate from the repository token;
- report absent App inputs as an exact machine-readable `missing-credentials-<name>` identity failure with nonzero exit and zero mutation or launch effects;
- preserve the fully provisioned production path and prove it with distinct identity/App-ID/private-key sentinels without printing or persisting the key;
- make receipt publication, exact PR-head checks, effect-stream observation, and zero-real-launch controls executable and mutation-sensitive.

No App, secret, PAT, or other credential is added by this PR. Until the later operator-owned App setup is performed, scheduled production fails closed at the named credential boundary by design.

## Verification

- accepted head: `6735541bb61076de81bab3e1676f8f2eb4017229`
- accepted tree: `d294717c3d626d3c8a2bb3fbaabba935631cbe6c`
- independent audit: PASS, report SHA-256 `32bdf2adb25366a0e03ad0bc80e2de4da8c566dbdf14ad4ce44dc60e3c438937`
- final ticket-owner verification: all five frozen local commands passed
- required hosted contexts at the accepted head: `Build`, `Run unit Tests`, `Check code quality`, `Compose smoke test`, `publish-images`, and `build-docs` all passed

Closes #213
