### PR TITLE
ci: restore Daily Amaru workflow evaluation and gate expression contexts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,13 @@
+# Baselines for `scripts/check-github-actions.sh`.
+#
+# Every entry is path-specific and quotes the exact diagnostic it accepts. This
+# file must never disable a diagnostic class repository-wide: the incident it
+# exists beside is a `runner` lookup in a job-level mapping (issue #219), and
+# `tests/test-workflow-validation.sh` restores that exact defect with this
+# baseline in place to prove it still goes red.
+paths:
+  .github/workflows/publish-images.yaml:
+    ignore:
+      # Pre-existing workflow_dispatch compatibility lookups that GitHub
+      # accepts; guarded by the `|| ''` fallback beside each of them.
+      - 'property "ref_name" is not defined in object type \{\}'

--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -38,11 +38,12 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    # `runner` values exist only once a runner has been allocated. A job-level
+    # mapping is evaluated before that, so runner-local paths are bound one
+    # level deeper, on the steps that actually use them.
     env:
       GH_TOKEN: ${{ github.token }}
       DAILY_AMARU_MODE: production
-      DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru
-      DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt
     steps:
       - name: Check out exact main
         uses: actions/checkout@v6
@@ -83,6 +84,8 @@ jobs:
           DAILY_AMARU_IDENTITY: ${{ steps.app-token.outputs.token }}
           DAILY_AMARU_APP_ID: ${{ vars.DAILY_AMARU_APP_ID }}
           DAILY_AMARU_APP_PRIVATE_KEY: ${{ secrets.DAILY_AMARU_APP_PRIVATE_KEY }}
+          DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru
+          DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt
         run: |
           set -euo pipefail
           scripts/daily-amaru.sh

--- a/.github/workflows/tracer-sidecar-CI.yaml
+++ b/.github/workflows/tracer-sidecar-CI.yaml
@@ -71,6 +71,11 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      # Runs from the repository root, before the component checks: a workflow
+      # GitHub cannot evaluate creates zero jobs, so this required context is
+      # the only place the whole census is observed.
+      - name: Validate GitHub Actions workflows
+        run: nix develop --quiet -c just check-workflows
       - name: Check Formatting
         working-directory: ./components/tracer-sidecar
         run: nix develop .#quality -c just format

--- a/docs/daily-amaru.md
+++ b/docs/daily-amaru.md
@@ -19,6 +19,20 @@ success is `error=malformed-dependency-evidence`. Each transport operation
 declares only the commands it uses, so publishing a failure receipt never
 depends on the command whose absence it reports.
 
+## Runner allocation boundary
+
+`runner` values exist only after GitHub has allocated a runner for a job.
+GitHub evaluates a job's own `env:` mapping *before* that allocation, so
+`${{ runner.temp }}` written there is not merely empty — it is rejected, and
+the whole workflow file produces zero jobs. Nothing else in CI observes that:
+a run with no jobs has no failing job to report, so every other required
+context stays green while the schedule silently never ran.
+
+The scheduled job therefore binds `DAILY_AMARU_STATE_DIR` and
+`DAILY_AMARU_RECEIPT` on the step that uses them, not on the job. The values
+are unchanged — `$RUNNER_TEMP/daily-amaru` and its `receipt` child — and the
+receipt upload keeps its own step-scoped `${{ runner.temp }}` lookup.
+
 ## Bootstrap App identity
 
 Production mints a short-lived token from a dedicated GitHub App, named by
@@ -110,3 +124,25 @@ non-persistence, and the token grant/use seam, counts the effects both broken
 preconditions reach, and checks that CI executably calls this suite while the
 schedule calls the controller. Every instrument carries controls proving it can
 fail.
+
+Validate every tracked workflow in the repository, which is the same command
+the merge-required `Check code quality` context runs:
+
+```console
+nix develop --quiet -c just check-workflows
+```
+
+It enumerates every tracked `.github/workflows/*.yaml` and `*.yml` file, prints
+the census and its count, refuses an empty census, and validates the expression
+contexts with the `flake.lock`-pinned actionlint. Baselines in
+`.github/actionlint.yaml` are path-specific and quote the exact pre-existing
+diagnostic they accept; none of them can suppress the `runner`-at-job-level
+class.
+
+Run the complete local gate — workflow validation, shell analysis, formatting,
+and both focused proofs, none of which need Docker, network, or credentials —
+with:
+
+```console
+nix develop --quiet -c just ci
+```

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,9 @@
                 pkgs.just
                 pkgs.nixfmt-classic
                 pkgs.shellcheck
+                # Pinned by flake.lock, so `just check-workflows` validates
+                # with the same validator locally and in required CI.
+                pkgs.actionlint
                 pkgs.mkdocs
                 mkdocs-pkgs.mkdocs-packages
                 mkdocs-pkgs.mkdocs-asciinema-player

--- a/justfile
+++ b/justfile
@@ -79,3 +79,41 @@ format:
     #!/usr/bin/env bash
     set -euo pipefail
     nixfmt *.nix
+
+# check nix formatting without rewriting sources
+format-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    nixfmt --check *.nix
+
+### Verification Commands ###
+
+# validate the Actions expression contexts of every tracked workflow
+check-workflows:
+    ./scripts/check-github-actions.sh
+
+# shellcheck the maintained shell surface
+check-shell:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # `old-broken/` and `tools/` carry pre-existing diagnostics and are not
+    # part of this surface; the census is printed so it cannot shrink unnoticed.
+    mapfile -t sources < <(git ls-files 'scripts/*.sh' 'tests/*.sh' | sort -u)
+    if [ "${#sources[@]}" -eq 0 ]; then
+        echo 'SHELL-ANALYSIS-ERROR empty shell census' >&2
+        exit 1
+    fi
+    printf 'shell-census %s\n' "${sources[@]}"
+    shellcheck -x "${sources[@]}"
+    printf 'SHELL-ANALYSIS count=%d status=pass\n' "${#sources[@]}"
+
+# focused proof for the repository-wide workflow validation
+test-workflow-validation:
+    ./tests/test-workflow-validation.sh
+
+# focused proof for the Daily Amaru controller
+test-daily-amaru:
+    ./tests/test-daily-amaru.sh
+
+# complete local CI: no Docker, no network, no credentials
+ci: check-workflows check-shell format-check test-workflow-validation test-daily-amaru

--- a/scripts/check-github-actions.sh
+++ b/scripts/check-github-actions.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Validate the Actions expression contexts of every workflow GitHub will
+# evaluate in this repository.
+#
+# GitHub rejects a workflow whose expressions reference a context that is not
+# available where they are written, and it does so before creating any job. The
+# run then reports no failing job at all, so nothing else in CI can observe it.
+# This command is the observation: it enumerates the complete tracked census,
+# proves that census is not empty, and validates every file in it exactly once.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+config=.github/actionlint.yaml
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  printf 'WORKFLOW-VALIDATION-ERROR actionlint is not on PATH; run through nix develop\n' >&2
+  exit 1
+fi
+
+mapfile -t workflows < <(
+  git ls-files '.github/workflows/*.yaml' '.github/workflows/*.yml' | sort -u
+)
+
+# A census that silently became empty would pass every remaining check while
+# validating nothing, which is exactly the shape of failure this command exists
+# to make impossible.
+if [ "${#workflows[@]}" -eq 0 ]; then
+  printf 'WORKFLOW-VALIDATION-ERROR empty workflow census under .github/workflows\n' >&2
+  exit 1
+fi
+
+for workflow in "${workflows[@]}"; do
+  printf 'workflow-census %s\n' "$workflow"
+done
+
+# actionlint's embedded shellcheck and pyflakes integrations are switched off
+# so this command owns exactly the Actions expression-context class and its
+# result does not depend on which linters happen to be on PATH. Shell analysis
+# is a separate, explicitly scoped step of the local gate (`just check-shell`).
+actionlint \
+  -shellcheck= \
+  -pyflakes= \
+  -config-file "$config" \
+  "${workflows[@]}"
+
+printf 'WORKFLOW-VALIDATION count=%d validator=actionlint config=%s status=pass\n' \
+  "${#workflows[@]}" "$config"

--- a/specs/219-daily-amaru-workflow-validation/plan.md
+++ b/specs/219-daily-amaru-workflow-validation/plan.md
@@ -1,0 +1,105 @@
+# Plan — Issue 219 Daily Amaru workflow validation
+
+Artifact ceiling: 7,000 bytes and 170 lines.
+
+## Technical context
+
+The frozen base is `5641da000f3b5fecfae9eaa2df42e67cd293f3b0`; refreshed
+`origin/main` still resolves to that commit. The issue worktree is clean and
+the branch is `fix/219-daily-amaru-workflow-validation`.
+
+GitHub rejected runs `31791847532` and `31793226810` before job creation with
+`Unrecognized named-value: 'runner'` at Daily Amaru workflow lines 44–45.
+Actionlint 1.7.10 independently reports the same two context errors. A complete
+base census also reports one unrelated shellcheck diagnostic in
+`cardano-node.yaml` and two pre-existing typed-event diagnostics in
+`publish-images.yaml`; they must receive only narrow path-specific baselines,
+not unrelated behavior changes or a global expression suppression.
+
+The nominal baseline command `nix develop --quiet -c just ci` exits 1 because
+the base Justfile has no `ci` recipe. That is recorded as a pre-existing local
+gate gap and is part of FR-219-09, not evidence that the frozen base is green.
+
+## Architecture decisions
+
+- `.github/workflows/daily-amaru.yaml` retains runner-local state and receipt
+  values but initializes them only after runner allocation. The controller,
+  transport, schedule, permissions, identity, receipt, and launch contracts do
+  not change.
+- A repository-local command owns workflow discovery, positive census output,
+  the empty-census guard, and invocation of the pinned Actions validator. It
+  validates both `.yaml` and `.yml` files and does not silently omit tracked
+  workflows.
+- Root Nix/Just plumbing makes that command identical locally and in CI. The
+  required `Check code quality` job invokes it before its existing component
+  quality work, so the required context cannot be green when validation is
+  red.
+- Focused proof owns the exact merged mutant, empty-census mutant, complete
+  passing census, and required-job reachability. Existing
+  `tests/test-daily-amaru.sh` remains the controller and credential oracle.
+- `docs/daily-amaru.md` explains the allocation boundary and local command.
+
+No module, data, or function interface changes are planned, so the parent
+brief's authorized planning record is exactly `spec.md`, `plan.md`, and
+`tasks.md`; no empty model artifacts are introduced.
+
+## Proof strategy
+
+The ticket owner freezes one executable gate outside Git before implementation.
+Its first check runs a pinned Actions validator over the complete base census,
+with only the named pre-existing path baselines, and must fail on the two exact
+`runner` job-env diagnostics. The gate then requires:
+
+- the permanent workflow-validation controls, including exact mutant and empty
+  census rejection;
+- the permanent local CI command and required-job reachability;
+- the complete existing Daily Amaru controller suite;
+- shell analysis, formatting checks, and `git diff --check`;
+- meaningful workflow and credential-control evidence in passing output.
+
+After GREEN, the commit owner independently restores the broken form or exact
+fixture, records RED, restores the candidate, and records GREEN. The fresh
+auditor repeats the invariant matrix in a clean detached worktree.
+
+## Slice S219-01 — Evaluation repair and permanent workflow guard
+
+Topology is `OWNER`: the slice changes workflow evaluation and a merge-required
+CI boundary, and hosted GitHub evaluation remains outside a complete local
+mechanical signal.
+
+- Ticket owner: Codex `gpt-5.6-sol`, effort `xhigh`, pane `%6710`.
+- Commit owner: fresh Claude Code `claude-opus-5[1m]`, effort `high`.
+- Draft tool: `NONE`; qwen, grok, and agy are not authorized.
+- Fresh auditor: Codex `gpt-5.6-sol`, effort `xhigh`, in a clean detached
+  worktree at each submitted candidate.
+- Audited submissions: maximum two, with at most one findings-driven repair.
+- Commit owner and auditor have no push, publication, live dispatch, secret,
+  App, spend, merge, or history-rewrite authority.
+
+Predetermined final commit:
+
+`fix(ci): validate GitHub Actions expression contexts`
+
+The body explains runner-allocation timing, complete workflow census, required
+CI reachability, and both-way controls. The trailer is:
+
+`Tasks: T2191, T2192, T2193, T2194, T2195, T2196`
+
+## Publication and hosted acceptance
+
+Commit and push this planning record and open a draft PR before behavior work.
+The planning head is expected to preserve the meaningful zero-job red; it must
+not be rerun to hide that evidence. Implementation is pushed only after the
+frozen gate, fresh audit, final tree proof, and complete local gate are green.
+
+Normal pull-request evaluation—not `workflow_dispatch`—must then prove on the
+exact accepted head:
+
+- Daily Amaru workflow job census greater than zero;
+- `Daily Amaru contract dry run` completed successfully;
+- all six ruleset contexts (`Build`, `Run unit Tests`, `Check code quality`,
+  `Compose smoke test`, `publish-images`, `build-docs`) green.
+
+No scheduled or manual production run is part of acceptance. Dedicated App
+inputs remain deliberately absent, so production continues to fail closed at
+the named credential boundary with zero spend.

--- a/specs/219-daily-amaru-workflow-validation/spec.md
+++ b/specs/219-daily-amaru-workflow-validation/spec.md
@@ -1,0 +1,103 @@
+# Issue 219 — Daily Amaru workflow validation
+
+Artifact ceiling: 7,000 bytes and 160 lines.
+
+## Priority story
+
+As the Daily Amaru operator, I need GitHub to allocate and run the pull-request
+dry-run job and I need required CI to reject invalid Actions expression
+contexts across the repository, so a workflow cannot merge while creating zero
+jobs.
+
+## Root cause and incident
+
+At accepted head `6735541bb61076de81bab3e1676f8f2eb4017229` and merged
+head `5641da000f3b5fecfae9eaa2df42e67cd293f3b0`, the Daily Amaru
+workflow bound `${{ runner.temp }}` in scheduled-job `env`. GitHub evaluates
+that mapping before allocating a runner, where `runner` is unavailable, and
+rejected the whole workflow with zero jobs. Runs `31791847532` and
+`31793226810` record the failure.
+
+The six required contexts on PR #218 were green because none evaluated all
+repository workflows with GitHub Actions expression-context rules.
+
+## Functional requirements
+
+- **FR-219-01 — Runner-scoped initialization.** Daily Amaru state and receipt
+  paths resolve to runner-local temporary storage only in a context where a
+  runner has already been allocated. The resolved paths remain
+  `$RUNNER_TEMP/daily-amaru` and `$RUNNER_TEMP/daily-amaru/receipt`.
+- **FR-219-02 — Repository-wide census.** One permanent local command
+  enumerates every tracked `.yaml` and `.yml` workflow under
+  `.github/workflows`, reports a positive file count, and exits non-zero when
+  that census is empty.
+- **FR-219-03 — Expression validation.** The command validates the census with
+  a pinned Actions-aware validator and exits non-zero for invalid expression
+  contexts. Any baseline suppression is path-specific, documented, and cannot
+  suppress the `runner`-at-job-env class.
+- **FR-219-04 — Required-CI reachability.** The validator command executes in
+  the repository-required `Check code quality` context. A validator failure
+  therefore makes one of the six merge-required contexts red.
+- **FR-219-05 — Both-way proof.** Permanent controls reject the exact merged
+  `${{ runner.temp }}` scheduled-job-env defect and an empty workflow census,
+  then emit meaningful positive evidence for the repaired complete census.
+- **FR-219-06 — Hosted dry-run proof.** On the exact accepted PR head, the
+  `Daily Amaru contract dry run` is a real GitHub-hosted job, the Daily Amaru
+  workflow job census is non-zero, and all six required contexts are green.
+- **FR-219-07 — Controller preservation.** Existing Daily Amaru controller
+  tests remain green, including absent named-credential and distinct-present
+  credential controls. Once-per-day, identity, receipt, and launch semantics
+  do not change.
+- **FR-219-08 — Operator explanation.** User-facing documentation explains
+  that `runner` values exist only after allocation and identifies the local
+  repository-wide validation command.
+- **FR-219-09 — Local gate.** The repository exposes a complete local CI
+  command covering workflow validation, focused Daily Amaru proof, shell
+  analysis, and formatting checks that are available without Docker or live
+  services.
+
+## Invariant mandate
+
+- **INV-219-01 — No pre-allocation runner lookup.** No job-level mapping
+  references `runner`; runner-local Daily Amaru paths retain their exact values
+  after allocation.
+- **INV-219-02 — Census cannot pass vacuously.** Every tracked repository
+  workflow is validated exactly once, the passing output names a positive
+  count, and zero workflows is red.
+- **INV-219-03 — The validator can catch the incident class.** Restoring the
+  exact two merged job-env bindings makes the permanent validator exit
+  non-zero with a `runner` context diagnostic.
+- **INV-219-04 — The guard is merge-reachable.** The exact validator command is
+  called by `Check code quality`; an orphaned command or test is red.
+- **INV-219-05 — Fail-closed identity survives.** Missing App configuration
+  still yields the exact named missing-credential receipt and zero business
+  effects; three distinct present sentinels still exercise the positive
+  production control without leaking.
+- **INV-219-06 — Hosted evidence binds the candidate.** The Daily Amaru
+  pull-request job and all six required contexts report the exact accepted PR
+  SHA, not a prior head or rerun substitute.
+- **INV-219-07 — No live effects.** Local and hosted dry-run proof performs no
+  App or secret provisioning, workflow dispatch, MOOG/Antithesis submission,
+  production schedule execution, spend, or merge.
+
+## Rejection behavior
+
+CI rejects an unreadable workflow, invalid Actions expression context,
+incomplete workflow census, empty census, a validator no longer called from a
+required context, or a restoration of either broken `runner.temp` job-env
+binding. A zero-job GitHub evaluation is a failure even when every other
+required context is green.
+
+## Scope
+
+Owned implementation is limited to `.github/workflows/daily-amaru.yaml`, the
+required `Check code quality` workflow path, the repository-local workflow
+validation command and focused tests/fixtures, strictly necessary Nix/Just
+tool plumbing, and Daily Amaru documentation. Narrow path-specific validator
+baselines may describe pre-existing diagnostics but may not alter unrelated
+workflow behavior.
+
+App/secret/variable provisioning, credential values, Daily Amaru policy,
+MOOG/Antithesis submission, manual workflow dispatch, production schedule
+execution, compose/image changes, and implementation of #75/#212/#208/#207/
+#206 are excluded.

--- a/specs/219-daily-amaru-workflow-validation/tasks.md
+++ b/specs/219-daily-amaru-workflow-validation/tasks.md
@@ -4,20 +4,20 @@ Artifact ceiling: 3,500 bytes and 90 lines.
 
 ## Slice S219-01 — Evaluation repair and permanent workflow guard
 
-- [ ] **T2191** Commit and preserve an executable RED proof that actionlint
+- [x] **T2191** Commit and preserve an executable RED proof that actionlint
   rejects both exact merged `${{ runner.temp }}` scheduled-job-env bindings.
-- [ ] **T2192** Initialize Daily Amaru state and receipt paths only after runner
+- [x] **T2192** Initialize Daily Amaru state and receipt paths only after runner
   allocation while preserving their values and all controller semantics.
-- [ ] **T2193** Add the pinned repository-wide Actions validator with complete
+- [x] **T2193** Add the pinned repository-wide Actions validator with complete
   `.yaml`/`.yml` enumeration, positive census evidence, narrow documented
   legacy baselines, and a non-zero empty-census result.
-- [ ] **T2194** Wire the validator into the required `Check code quality`
+- [x] **T2194** Wire the validator into the required `Check code quality`
   context and the complete local CI command; prove the exact defect, empty
   census, and orphaned required-job caller are red.
-- [ ] **T2195** Keep the full Daily Amaru controller and named-credential
+- [x] **T2195** Keep the full Daily Amaru controller and named-credential
   controls green and document why runner-scoped paths are initialized only
   after allocation.
-- [ ] **T2196** Pass the frozen gate, complete local gate, fresh independent
+- [x] **T2196** Pass the frozen gate, complete local gate, fresh independent
   audit, final tree/diff checks, exact-head hosted Daily Amaru job census, and
   all six required contexts without App/secret setup, live dispatch, spend,
   merge, or production execution.

--- a/specs/219-daily-amaru-workflow-validation/tasks.md
+++ b/specs/219-daily-amaru-workflow-validation/tasks.md
@@ -1,0 +1,27 @@
+# Tasks — Issue 219 Daily Amaru workflow validation
+
+Artifact ceiling: 3,500 bytes and 90 lines.
+
+## Slice S219-01 — Evaluation repair and permanent workflow guard
+
+- [ ] **T2191** Commit and preserve an executable RED proof that actionlint
+  rejects both exact merged `${{ runner.temp }}` scheduled-job-env bindings.
+- [ ] **T2192** Initialize Daily Amaru state and receipt paths only after runner
+  allocation while preserving their values and all controller semantics.
+- [ ] **T2193** Add the pinned repository-wide Actions validator with complete
+  `.yaml`/`.yml` enumeration, positive census evidence, narrow documented
+  legacy baselines, and a non-zero empty-census result.
+- [ ] **T2194** Wire the validator into the required `Check code quality`
+  context and the complete local CI command; prove the exact defect, empty
+  census, and orphaned required-job caller are red.
+- [ ] **T2195** Keep the full Daily Amaru controller and named-credential
+  controls green and document why runner-scoped paths are initialized only
+  after allocation.
+- [ ] **T2196** Pass the frozen gate, complete local gate, fresh independent
+  audit, final tree/diff checks, exact-head hosted Daily Amaru job census, and
+  all six required contexts without App/secret setup, live dispatch, spend,
+  merge, or production execution.
+
+The ticket owner checks these entries only after an exact candidate receives a
+fresh `AUDIT-PASS`. The parked commit owner then includes the task stamp in the
+single final squashed behavior commit.

--- a/tests/test-workflow-validation.sh
+++ b/tests/test-workflow-validation.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Focused proof for issue #219.
+#
+# GitHub evaluates a workflow's job-level mappings before it allocates a runner.
+# A `runner` lookup there is rejected outright and the workflow creates zero
+# jobs, so every other required context can be green while nothing ran. This
+# proof owns three things: the repaired allocation boundary, a repository-wide
+# expression-context census that cannot pass vacuously, and the fact that a
+# merge-required context still calls that census.
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+command_path=scripts/check-github-actions.sh
+daily_amaru=.github/workflows/daily-amaru.yaml
+quality_workflow=.github/workflows/tracer-sidecar-CI.yaml
+actionlint_config=.github/actionlint.yaml
+justfile_path=justfile
+validator_command='nix develop --quiet -c just check-workflows'
+
+fail() {
+  printf 'FAIL %s\n' "$*" >&2
+  exit 1
+}
+
+pass() {
+  printf 'PASS %s\n' "$1"
+}
+
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
+mutant_root="$tmp_root/mutants"
+mkdir -p "$mutant_root"
+
+# Every mutant verifies its own application. A silently unapplied edit would
+# otherwise report "the check caught it" while nothing was ever mutated.
+# A leading `!` means the mutation is proved by the absence of a line.
+reject_mutant() {
+  local label=$1 source=$2 script=$3 applied=$4 why=$5
+  shift 5
+  local mutant="$mutant_root/$label"
+  sed "$script" "$source" >"$mutant"
+  if [ "${applied:0:1}" = '!' ]; then
+    ! grep -Fqx -- "${applied:1}" "$mutant" || fail "mutation did not apply: $label"
+  else
+    grep -Fqx -- "$applied" "$mutant" || fail "mutation did not apply: $label"
+  fi
+  if "$@" "$mutant"; then
+    fail "check accepted $why"
+  fi
+}
+
+# A named step's own lines, so a binding belonging to a neighbouring step can
+# never be read as this one's.
+workflow_step() {
+  awk -v header="      - name: $2" '
+    $0 == header { inside = 1 }
+    inside && $0 != header && /^      - (name|uses):/ { exit }
+    inside { print }
+  ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# INV-219-01 — runner-scoped paths are bound only after allocation.
+#
+# Job-level mapping entries sit at exactly six columns; step-level ones sit at
+# ten. Matching the column is what separates the incident from the legitimate
+# step-scoped lookups the same workflow still makes.
+# ---------------------------------------------------------------------------
+
+job_level_runner_refs() {
+  grep -cE '^ {6}[A-Za-z_][A-Za-z0-9_-]*:.*\$\{\{[^}]*runner\.' "$1" || true
+}
+
+allocation_boundary_holds() {
+  local step
+  [ "$(job_level_runner_refs "$1")" -eq 0 ] || return 1
+  step=$(workflow_step "$1" 'Run the once-daily state machine')
+  # shellcheck disable=SC2016
+  grep -Fqx '          DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru' \
+    <<<"$step" || return 1
+  # shellcheck disable=SC2016
+  grep -Fqx '          DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt' \
+    <<<"$step" || return 1
+}
+
+allocation_boundary_holds "$daily_amaru" ||
+  fail "runner-local paths are not bound after allocation in $daily_amaru:" \
+    "$(job_level_runner_refs "$daily_amaru") job-level runner reference(s)"
+
+# Restoring the exact two merged bindings, at the exact merged location.
+# shellcheck disable=SC2016
+merged_runner_regression='/^      DAILY_AMARU_MODE: production$/a\
+      DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru\
+      DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt'
+
+# shellcheck disable=SC2016
+reject_mutant merged-runner-job-env.yaml "$daily_amaru" "$merged_runner_regression" \
+  '      DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru' \
+  'the exact merged job-level runner bindings' allocation_boundary_holds
+# shellcheck disable=SC2016
+reject_mutant dropped-state-dir.yaml "$daily_amaru" \
+  '/^          DAILY_AMARU_STATE_DIR: [$][{][{] runner[.]temp [}][}]\/daily-amaru$/d' \
+  '!          DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru' \
+  'a controller that lost its runner-local state directory' \
+  allocation_boundary_holds
+# shellcheck disable=SC2016
+reject_mutant relocated-receipt.yaml "$daily_amaru" \
+  's|^          DAILY_AMARU_RECEIPT: [$][{][{] runner[.]temp [}][}]/daily-amaru/receipt$|          DAILY_AMARU_RECEIPT: /tmp/daily-amaru/receipt|' \
+  '          DAILY_AMARU_RECEIPT: /tmp/daily-amaru/receipt' \
+  'a receipt moved off runner-local storage' allocation_boundary_holds
+
+printf 'ALLOCATION-BOUNDARY job_env_runner_refs=0 state_dir=1 receipt=1 mutants_rejected=3\n'
+pass runner-paths-bound-after-allocation
+
+# ---------------------------------------------------------------------------
+# INV-219-02 / INV-219-03 — a complete census that cannot pass vacuously, and a
+# validator that catches the incident class.
+# ---------------------------------------------------------------------------
+
+[ -x "$command_path" ] ||
+  fail "the repository-wide validator is missing or not executable: $command_path"
+[ -f "$actionlint_config" ] ||
+  fail "the validator baseline is missing: $actionlint_config"
+command -v actionlint >/dev/null 2>&1 ||
+  fail 'actionlint is not on PATH; run this through just test-workflow-validation'
+
+census=$(git ls-files '.github/workflows/*.yaml' '.github/workflows/*.yml' | sort -u)
+expected_count=$(printf '%s\n' "$census" | grep -c . || true)
+[ "$expected_count" -gt 0 ] ||
+  fail 'the repository tracks no workflows, so a passing census would prove nothing'
+
+validation_output="$tmp_root/validation.out"
+if ! "$command_path" >"$validation_output" 2>&1; then
+  cat "$validation_output" >&2
+  fail 'repository-wide workflow validation failed on the tracked census'
+fi
+
+reported_count=$(sed -n 's/^WORKFLOW-VALIDATION count=\([0-9][0-9]*\) .*$/\1/p' \
+  "$validation_output")
+[ -n "$reported_count" ] ||
+  fail 'passing validation output does not report a workflow count'
+[ "$reported_count" -gt 0 ] ||
+  fail 'validation reported a zero workflow count as a pass'
+[ "$reported_count" -eq "$expected_count" ] ||
+  fail "validated $reported_count workflows while the repository tracks $expected_count"
+
+listed=$(grep -c '^workflow-census ' "$validation_output" || true)
+[ "$listed" -eq "$expected_count" ] ||
+  fail "the census listed $listed paths for $expected_count tracked workflows"
+while IFS= read -r workflow; do
+  seen=$(grep -Fxc "workflow-census $workflow" "$validation_output" || true)
+  [ "$seen" -eq 1 ] ||
+    fail "workflow validated $seen times instead of exactly once: $workflow"
+done <<<"$census"
+
+# A scratch repository runs the production command, unmodified, over a tracked
+# file set this proof controls. Its own positive control has to go green first,
+# so a red from a seeded defect is the defect and not the harness.
+scratch_repo() {
+  local root=$1
+  mkdir -p "$root/.github/workflows" "$root/scripts"
+  install -m 0755 "$command_path" "$root/scripts/check-github-actions.sh"
+  cp "$actionlint_config" "$root/.github/actionlint.yaml"
+  git -C "$root" init --quiet
+  git -C "$root" config user.email 'issue-219-proof@invalid'
+  git -C "$root" config user.name 'issue-219 proof'
+}
+
+scratch_validate() {
+  local root=$1
+  git -C "$root" add -A
+  (cd "$root" && ./scripts/check-github-actions.sh) >"$root/out" 2>&1
+}
+
+harness_root="$tmp_root/harness-positive"
+scratch_repo "$harness_root"
+cp "$daily_amaru" "$harness_root/.github/workflows/daily-amaru.yaml"
+scratch_validate "$harness_root" ||
+  fail "the scratch harness cannot go green on the repaired workflow: $(cat "$harness_root/out")"
+grep -q '^WORKFLOW-VALIDATION count=1 ' "$harness_root/out" ||
+  fail 'the scratch harness did not report its single-workflow census'
+
+empty_root="$tmp_root/empty-census"
+scratch_repo "$empty_root"
+if scratch_validate "$empty_root"; then
+  fail 'an empty workflow census passed validation'
+fi
+grep -Fq 'empty workflow census' "$empty_root/out" ||
+  fail "an empty census failed for the wrong reason: $(cat "$empty_root/out")"
+
+# The baseline config is present in this scratch repository on purpose: a
+# path-specific baseline must not be able to suppress the incident class.
+regression_root="$tmp_root/merged-runner"
+scratch_repo "$regression_root"
+regression_workflow="$regression_root/.github/workflows/daily-amaru.yaml"
+sed "$merged_runner_regression" "$daily_amaru" >"$regression_workflow"
+# shellcheck disable=SC2016
+grep -Fqx '      DAILY_AMARU_STATE_DIR: ${{ runner.temp }}/daily-amaru' \
+  "$regression_workflow" ||
+  fail 'mutation did not apply: merged job-level state directory binding'
+# shellcheck disable=SC2016
+grep -Fqx '      DAILY_AMARU_RECEIPT: ${{ runner.temp }}/daily-amaru/receipt' \
+  "$regression_workflow" ||
+  fail 'mutation did not apply: merged job-level receipt binding'
+if scratch_validate "$regression_root"; then
+  fail 'the validator accepted the exact merged runner-at-job-env defect'
+fi
+runner_diagnostics=$(grep -c 'context "runner" is not allowed here' \
+  "$regression_root/out" || true)
+[ "$runner_diagnostics" -eq 2 ] ||
+  fail "expected both merged bindings diagnosed, got $runner_diagnostics"
+
+printf 'WORKFLOW-CENSUS count=%d duplicates=0 validator=actionlint baseline=%s\n' \
+  "$reported_count" "$actionlint_config"
+printf 'WORKFLOW-MUTANTS exact_runner_job_env=reject empty_census=reject harness_positive=pass\n'
+pass repository-wide-expression-census
+
+# ---------------------------------------------------------------------------
+# INV-219-04 — the guard is only worth its cost while a merge-required context
+# still calls it. An orphaned command is red.
+# ---------------------------------------------------------------------------
+
+quality_job() {
+  awk '
+    $0 == "  code-quality:" { inside = 1; print; next }
+    inside && /^  [A-Za-z0-9_-]+:/ { exit }
+    inside { print }
+  ' "$1"
+}
+
+required_caller_holds() {
+  local job
+  job=$(quality_job "$1")
+  grep -Fqx '    name: Check code quality' <<<"$job" || return 1
+  grep -Fqx "        run: $validator_command" <<<"$job" || return 1
+}
+
+required_caller_holds "$quality_workflow" ||
+  fail "the required 'Check code quality' context does not run: $validator_command"
+
+reject_mutant caller-commented.yaml "$quality_workflow" \
+  "s|^        run: $validator_command\$|        # run: $validator_command|" \
+  "        # run: $validator_command" \
+  'a commented-out validator call' required_caller_holds
+reject_mutant caller-removed.yaml "$quality_workflow" \
+  "/^        run: $validator_command\$/d" \
+  "!        run: $validator_command" \
+  'a required context that no longer calls the validator' required_caller_holds
+reject_mutant caller-renamed-context.yaml "$quality_workflow" \
+  's/^    name: Check code quality$/    name: Check code quality (advisory)/' \
+  '    name: Check code quality (advisory)' \
+  'a validator call moved out of the merge-required context name' \
+  required_caller_holds
+reject_mutant caller-orphaned-job.yaml "$quality_workflow" \
+  's/^  code-quality:$/  code-quality-disabled:/' \
+  '  code-quality-disabled:' \
+  'a validator call left in a disabled job' required_caller_holds
+
+printf "REQUIRED-CALLER context='Check code quality' command=1 mutants_rejected=4\n"
+pass validator-reachable-from-required-context
+
+# ---------------------------------------------------------------------------
+# FR-219-09 — the same command is reachable from the complete local gate, so
+# the hosted context is not the only place the guard ever runs.
+# ---------------------------------------------------------------------------
+
+recipe_body() {
+  awk -v name="$2" '
+    $0 ~ "^" name ":" { inside = 1; next }
+    inside && /^[^ \t]/ { exit }
+    inside { print }
+  ' "$1"
+}
+
+ci_line() {
+  grep -E '^ci:' "$1" || true
+}
+
+local_ci_holds() {
+  local line
+  line=$(ci_line "$1")
+  [ -n "$line" ] || return 1
+  local dependency
+  for dependency in check-workflows check-shell format-check \
+    test-workflow-validation test-daily-amaru; do
+    grep -Fq -- "$dependency" <<<"$line" || return 1
+  done
+}
+
+# The exact recipe line, so a commented-out or shadowed invocation is not read
+# as a call.
+check_workflows_calls_validator() {
+  recipe_body "$1" check-workflows | grep -Fqx "    ./$command_path"
+}
+
+local_ci_holds "$justfile_path" ||
+  fail 'the local CI recipe does not cover the complete slice gate'
+check_workflows_calls_validator "$justfile_path" ||
+  fail "the check-workflows recipe does not run ./$command_path"
+
+ci_without_validator="$mutant_root/justfile-ci-without-validator"
+sed 's/^ci: .*$/ci: check-shell format-check test-workflow-validation test-daily-amaru/' \
+  "$justfile_path" >"$ci_without_validator"
+grep -Fqx 'ci: check-shell format-check test-workflow-validation test-daily-amaru' \
+  "$ci_without_validator" ||
+  fail 'mutation did not apply: local CI recipe without the validator'
+if local_ci_holds "$ci_without_validator"; then
+  fail 'the local gate check accepted a CI recipe that never validates workflows'
+fi
+
+reject_mutant justfile-check-workflows-noop "$justfile_path" \
+  "s|^    ./$command_path\$|    true # ./$command_path|" \
+  "    true # ./$command_path" \
+  'a check-workflows recipe that runs nothing' check_workflows_calls_validator
+
+printf 'LOCAL-CI ci_dependencies=5 validator_called=1 mutants_rejected=2\n'
+pass validator-reachable-from-local-gate
+
+printf 'WORKFLOW-VALIDATION-PROOF workflows=%d controls=4 mutants_rejected=9\n' \
+  "$reported_count"


### PR DESCRIPTION
Closes #219.

## Outcome

Restore GitHub evaluation of Daily Amaru and make invalid GitHub Actions
expression contexts a permanent merge-blocking failure.

## Change

- move the existing Daily Amaru runner-temporary state and receipt bindings
  from scheduled-job `env` to the controller step, after runner allocation;
- add a pinned actionlint command over the complete tracked workflow census,
  with positive count and empty-census rejection;
- execute that command from the ruleset-required `Check code quality` job and
  from `nix develop --quiet -c just ci`;
- ship permanent exact-runner, empty-census, required-caller, and allocation
  controls while preserving the full Daily Amaru controller/credential suite;
- document the runner allocation boundary and local validation commands.

## Evidence

- Planning head `2704058` intentionally reproduced the GitHub zero-job red:
  https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/32149823599
  (`total_count=0`).
- Frozen ticket gate SHA256:
  `d419f77ab4426fdd611db80faaa6f7d3d38a84d1a6dc3b791280d34a1f0907cf`.
  Its base RED receipt SHA256 is
  `e49f0f0dd3647b72e79c494fd1e5920d4ebb87e44a29f8ea177b3cf7ab6149ed`
  and contains exactly the two merged `runner` context errors.
- Local RED proof commit: `ac633a53c4961541e86056c99a1e04456d3b3a1c`.
  Audited GREEN candidate: `de9314a6b62872fa707104df2599e1e502523c86`.
- Fresh independent audit: PASS, 15/15 rows terminal, zero blocking/open;
  report SHA256
  `910aba24fa8fedf41ada6a473bb40d5ed303cb00b7cccbed43b37d3aa7df59d6`.
- Accepted final commit/tree:
  `4052f9c1feb0bbade4155a68003314cfca4603ef` /
  `09add124a296e947b2178fa722737d7f2c840988`.
- Ticket-owner final receipts: commit gate exit 0
  (`6a5494764a7218cd1aee4163a7745e183cef6c445e3e7b6017103e1d58259d93`),
  `just ci` exit 0
  (`ff46386690a82b948d00c5c7afd18fac9fb0be8cd8d706f8cef42ce4c351035a`),
  frozen gate exit 0
  (`13c1c76910c4c09781b4da24576c147085e4575d809c51799c7b5fa91a3b9c41`),
  and both diff checks exit 0.
- Finalization audit exit 0, SHA256
  `a67e77a07335c094a6b3a060aa4444032928844dee7c3aa088873bdfb2bda71f`.

## Hosted acceptance

- Exact-head Daily Amaru run:
  https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/32154486684
  has two hosted jobs. `Daily Amaru contract dry run` succeeded and scheduled
  production was correctly skipped.
- All six repository-required contexts are green on exact head `4052f9c`:
  `Build`, `Run unit Tests`, `Check code quality`, `Compose smoke test`,
  `publish-images`, and `build-docs`. Exact-head check-census evidence SHA256:
  `911dc4d5e8add0313eb0162c0ce415674035d665960fdeda9a8ae1c71fa3b1be`.
- The first Compose attempt remains preserved as a meaningful cna#212-class
  live-boundary red:
  https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/32154486746/job/95768518698.
  It reached healthy nodes, bootstrap, relays, seeding, and a non-restarting
  consumer, then timed out at consumer convergence. Under the parent-approved
  one-unchanged-retry exception, attempt 2 at the same head/tree succeeded:
  https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/32154486746/job/95777311397.
  No Compose, image, testnet, or smoke source was changed.

## Named residual limits

- The current 8-file census is complete and every file is passed to actionlint,
  but the permanent proof does not kill a hypothetical validate-first-only
  implementation or exercise `.yml` discovery while the repository contains
  no tracked `.yml` workflow (`RES-219-CENSUS-01/02`).
- Current CI shellchecks all 13 maintained `scripts/*.sh`/`tests/*.sh` files,
  but its proof does not prevent future census shrinkage
  (`RES-219-SHELL-01`).
- Local proof cannot establish GitHub evaluator equivalence, external ruleset
  membership, or hosted default working-directory semantics; the exact-head
  hosted evidence above closes those acceptance boundaries
  (`T2196/R02/R03/R08`).
- The shared handoff helper's textual equality rejects valid new-file patches;
  independent materialization proved all candidate paths/blobs/modes. This is
  recorded outside the ticket as `CNA205-PROVENANCE-NEWFILE-01`.

## Safety

No App, secret, variable, or credential was provisioned or disclosed; no
production workflow was manually dispatched; no production schedule,
Daily Amaru/MOOG/Antithesis submission, spend, merge, or history rewrite
occurred. One unchanged failed Compose job retry was performed under the
recorded parent exception, with both attempts retained. Missing dedicated App
inputs retain the exact named fail-closed receipt and zero-effect contract.
