### PR TITLE
fix: propagate the derived UTC day to Daily Amaru transports

### DIFF
--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -146,6 +146,9 @@ receipt[day]=$day
 [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] ||
   die "invalid UTC day: $day"
 
+# Publish the validated day before any transport child is forked.
+export DAILY_AMARU_DAY=$day
+
 [ -x "$transport" ] || die "transport is not executable: $transport"
 mkdir -p "$state_dir"
 

--- a/specs/221-daily-amaru-day-propagation/data-model.md
+++ b/specs/221-daily-amaru-day-propagation/data-model.md
@@ -1,0 +1,37 @@
+# Data model — Issue 221
+
+Artifact ceiling: 2,500 bytes and 60 lines.
+
+## D221-01 — `DAILY_AMARU_DAY` (process-environment field)
+
+- **Owner:** M221-01 (controller).
+- **Consumers:** every transport child forked by the controller; today
+  `propose-bootstrap` and `prepare-consumer-repin` bind it as required.
+- **Type:** string matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}$`.
+- **Source:** the caller-supplied value when present, otherwise the
+  controller's own UTC derivation.
+- **Validation:** the existing day regex, applied before publication. An
+  invalid day still aborts the run before anything is published.
+- **Channel:** process environment only. Never a command-line argument, never a
+  file, never a persisted artifact.
+
+### State invariants
+
+- **D221-01-I1.** Publication happens after validation and before the first
+  transport child is forked; no transport child may observe an unvalidated or
+  absent day.
+- **D221-01-I2.** The published value equals the value the controller recorded
+  in `receipt[day]`, so the durable receipt and every transport child agree on
+  one day for the whole run.
+- **D221-01-I3.** Publication is idempotent with respect to a caller-supplied
+  day: when the environment already carried a valid day, the published value is
+  that same day.
+
+## D221-02 — Effect-log day observation (fixture-owned record)
+
+- **Owner:** M221-03.
+- **Content:** the day value observed inside the transport child, recorded
+  alongside the existing per-operation effect record.
+- **Constraint:** it records the observed environment value only. It must not
+  synthesize, default, or repair a missing day, or the mutant becomes
+  unkillable.

--- a/specs/221-daily-amaru-day-propagation/modules-model.md
+++ b/specs/221-daily-amaru-day-propagation/modules-model.md
@@ -1,0 +1,47 @@
+# Modules model — Issue 221
+
+Artifact ceiling: 2,500 bytes and 60 lines.
+
+Only changed responsibilities are listed. Dependency direction is unchanged:
+the controller depends on the transport contract; the transport never depends
+on the controller.
+
+## M221-01 — `scripts/daily-amaru.sh` (Daily Amaru controller)
+
+Changed responsibility: the controller is the sole deriver **and the sole
+publisher** of the validated UTC day to its transport children. Owning the
+value without publishing it was the defect; publication is part of the
+derivation responsibility, not of the transport's.
+
+The publication channel is the process environment, matching the existing
+`DAILY_AMARU_STATE_DIR`, `DAILY_AMARU_RECEIPT`, and `DAILY_AMARU_IDENTITY`
+promotions already performed by this component. No new component, no new
+channel, and no promotion to a shared upstream owner: exactly one consumer
+family exists and it is the transport this controller already owns.
+
+Unchanged: derivation source, validation, stage sequencing, receipt
+composition and ordering, identity handling, and launch selection.
+
+## M221-02 — `scripts/daily-amaru-github.sh` (production transport)
+
+Unchanged and read-only in this ticket. It remains the authority on which
+operations require the day. Its source is the declared side of the
+reconciliation in M221-03.
+
+## M221-03 — `tests/fixtures/daily-amaru/fake-transport.sh` (fixture transport)
+
+Changed responsibility: the deterministic transport gains the ability to
+observe the day seam. It binds the day with the same expansion the production
+transport uses, in exactly the operation set derived from M221-02, and records
+the observed value in the effect log it already owns.
+
+This fixture holds no contract authority of its own. Its agreement with M221-02
+is asserted mechanically by M221-04; without that assertion the fixture would
+be a check that can stop being able to fail.
+
+## M221-04 — `tests/test-daily-amaru.sh` (focused controller proof)
+
+Changed responsibility: the focused proof additionally owns the workflow-shaped
+omitted-day class — derived-day propagation, the killing mutant, receipt
+survival through a downstream failure, and the declared-versus-observed
+reconciliation between M221-02 and M221-03.

--- a/specs/221-daily-amaru-day-propagation/plan.md
+++ b/specs/221-daily-amaru-day-propagation/plan.md
@@ -1,0 +1,102 @@
+# Plan — Issue 221 Daily Amaru derived-day propagation
+
+Artifact ceiling: 6,000 bytes and 150 lines.
+
+## Technical context
+
+Frozen base `7ac049e748ff83ab12dee2864343510d6fb9541e`; refreshed
+`origin/main` and the GitHub API head both resolve to it. Lane worktree
+`/code/cardano-node-antithesis-issue-221`, branch
+`fix/221-daily-amaru-day-propagation`.
+
+Baseline `nix develop --quiet -c just ci` at that base exits 0 in 17.4 s
+(evidence `evidence/baseline-ci.log` under the ticket runtime root), so the
+starting tree is green and any red is caused by this ticket.
+
+`scripts/daily-amaru-github.sh` and `.github/workflows/daily-amaru.yaml` are
+read-only contract surfaces. The workflow supplying no day is correct by #213:
+no external `date` may stand before the controller's first receipt boundary.
+The defect is entirely on the controller side of the process boundary.
+
+## Architecture decisions
+
+- The controller keeps deriving and validating the day exactly as today and
+  additionally promotes that validated value into the process environment,
+  before the first `transport_call`. Nothing else about derivation, validation,
+  ordering, staging, receipts, identity, or launch changes.
+- The transport contract is unchanged: the day continues to travel in the
+  process environment, never as a command-line argument, and never through a
+  file. See `modules-model.md` and `data-model.md`.
+- The deterministic fixture transport becomes able to observe the seam. It
+  binds the day with the identical expansion the production transport uses, in
+  exactly the operations production binds it in, and records the observed value
+  in the existing effect log. The operation set is derived mechanically from
+  the production transport source rather than restated by hand, so the fixture
+  cannot drift into being unable to fail.
+- No function signature is created or changed, so no `functions-model.md` is
+  introduced. `modules-model.md` and `data-model.md` carry the only changed
+  rows.
+
+## Proof strategy
+
+One bisect-safe slice. The commit owner writes the complete RED proof first and
+watches it fail for the stated reason before any production edit.
+
+The permanent regression exercises the production shape the suite never had:
+
+1. **Success path, day omitted.** A deterministic fake `date` is prepended to
+   `PATH`; `DAILY_AMARU_DAY` is absent from the controller environment. The
+   controller must run to completion through the fixture transport, and both
+   `propose-bootstrap` and `prepare-consumer-repin` must report the exact
+   derived day. The fake day is a fixed past date, distinct from the real
+   system UTC day and from every day literal already used by the suite, so an
+   observed match cannot come from an injected constant or from the real clock.
+2. **Failure path, day omitted.** The same shape with a forced downstream
+   transport failure at the bootstrap proposal. The #210 day claim must carry
+   the derived day, the ordered stage receipts must still be published, the
+   durable receipt must satisfy the existing receipt oracle as an honest
+   failure, and no launcher may be reached.
+3. **Killing mutant.** A copy of the controller with only the propagation
+   removed, proved applied, must fail case 1 with stderr fingerprint
+   `DAILY_AMARU_DAY: DAILY_AMARU_DAY is required` and the production receipt
+   triple `stage=bootstrap-proposal` / `outcome=FAILED` /
+   `error=proposal-failed` — the exact shape of run `32215848871`.
+4. **Fixture reconciliation.** The set of transport operations that bind
+   `DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required` in the production transport
+   is computed from source and must equal the set that binds it in the fixture,
+   and must be non-empty. This is the permanent guard against the fixture
+   quietly losing the ability to observe the defect.
+
+Each case prints a machine-readable census line so a pass carries evidence and
+selection is provable. The frozen slice gate greps those census lines, checks
+that the export exists exactly once and lexically precedes the first
+`transport_call`, enforces the changed-path fence, and runs the focused suite
+plus complete local CI.
+
+## Slice
+
+- **S221-01 — Export the derived day and permanently prove the omitted-day
+  path.** Proof, production, and fixture-observability change land in one
+  bisect-safe commit; splitting them would leave a committed proof that cannot
+  run or a production change with no proof.
+
+## Constraints and risks
+
+- The fixture is test infrastructure, not the production transport: its
+  authority over the contract comes only from the reconciliation in step 4.
+  Without that reconciliation the mutant could stop being killable without
+  anything going red.
+- Prepending a fake `date` must not disturb the rest of the seeded command
+  surface; only the controller's own `date -u +%F` derivation is redirected.
+- The new cases must not alter existing log-count assertions. Existing
+  `mutation:` patterns are unanchored at their right edge, so appended fields
+  are compatible; the commit owner must verify that rather than assume it.
+- Schedule pressure toward `2026-08-20T04:17Z` does not weaken RED/GREEN,
+  audit, exact-head CI, or guarded merge. The controller must not be fired
+  after merge.
+
+## Status
+
+- **Completed:** lane, green baseline, ticket contract, frozen falsified gate.
+- **Current:** commit-owner campaign for S221-01.
+- **Blockers:** none.

--- a/specs/221-daily-amaru-day-propagation/spec.md
+++ b/specs/221-daily-amaru-day-propagation/spec.md
@@ -1,0 +1,121 @@
+# Issue 221 — Daily Amaru derived-day propagation
+
+Artifact ceiling: 7,000 bytes and 160 lines.
+
+## Priority story
+
+As the Daily Amaru operator, I let the scheduled controller derive its own UTC
+day and observe that every transport child receives exactly that validated day,
+while the durable issue #210 day claim and stage receipts survive a downstream
+transport failure.
+
+## Root cause and incident
+
+Scheduled run `32215848871` on head `7ac049e748ff83ab12dee2864343510d6fb9541e`
+recorded stage `bootstrap-proposal`, `outcome=FAILED`, `error=proposal-failed`.
+The underlying child error was
+`scripts/daily-amaru-github.sh:185: DAILY_AMARU_DAY is required`.
+
+`scripts/daily-amaru.sh` assigns `day=${DAILY_AMARU_DAY:-$(date -u +%F)}` as a
+plain shell variable. `transport_call` forks a child process, which cannot see a
+non-exported variable. The transport operations `propose-bootstrap` and
+`prepare-consumer-repin` bind `${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}`
+and therefore abort whenever the workflow does not supply the day itself.
+
+The scheduled workflow deliberately supplies no day: #213 made the controller
+the sole deriver so no external `date` stands before the first receipt
+boundary. Every existing controller case in `tests/test-daily-amaru.sh` injects
+`DAILY_AMARU_DAY`, so the complete suite was green while the only production
+shape — an omitted day — was never exercised.
+
+## Functional requirements
+
+- **FR-221-01 — Exported derived day.** After `scripts/daily-amaru.sh` derives
+  and validates its UTC day, it exports exactly that value as
+  `DAILY_AMARU_DAY` before the first transport child is forked.
+- **FR-221-02 — Workflow-shaped proof.** A permanent regression omits
+  `DAILY_AMARU_DAY` from the controller environment, supplies a deterministic
+  fake `date`, and proves the derived day is the exact value observed by both
+  the `propose-bootstrap` and `prepare-consumer-repin` transport paths.
+- **FR-221-03 — Killing mutant.** Removing only the propagation, and nothing
+  else, makes that regression fail with the production fingerprint
+  `DAILY_AMARU_DAY: DAILY_AMARU_DAY is required` and the production receipt
+  triple `stage=bootstrap-proposal`, `outcome=FAILED`, `error=proposal-failed`.
+  The mutation proves it applied before its red is believed; the repaired path
+  rejects it.
+- **FR-221-04 — Receipts survive failure.** The same omitted-day regression
+  proves that, through a forced downstream transport failure, the issue #210
+  day claim carries the derived day and the ordered stage receipts are still
+  published. No receipt behavior, marker vocabulary, or ordering is weakened,
+  bypassed, or replaced.
+- **FR-221-05 — Non-drifting seam.** The deterministic transport fixture
+  requires the day in exactly the operations the production transport requires
+  it in, reconciled mechanically from the production transport source, so the
+  fixture cannot silently stop being able to observe the defect.
+- **FR-221-06 — Preserved guards.** Existing no-effect, no-real-launch,
+  duplicate-day, attempted-SHA, credential, receipt, and failure guards remain
+  green and unweakened.
+- **FR-221-07 — Fenced effect surface.** The new proof reaches no real
+  launcher, no GitHub dispatch, no external repository mutation, and no
+  credential material.
+- **FR-221-08 — Green gates.** The focused controller suite and complete local
+  CI are freshly green, the frozen slice gate and ticket gate are freshly
+  green, the finalization audit passes, and all six required GitHub contexts
+  are green on the exact pushed head.
+
+## Invariant mandate
+
+All four rows are operational process-boundary, evidence, receipt-continuity,
+and effect-fence truths. They do not constrain chain state, money, or a
+signature, so under the loaded severity law they are classified `ADVISORY`.
+
+**Ticket-specific acceptance floor.** Advisory severity does not lower this
+ticket's bar. Every one of the four rows requires a permanent executing proof
+and a demonstrated killing mutant before acceptance. No row may become an
+accepted residual on the ground that its severity is advisory.
+
+- **INV-221-DERIVED-DAY-CROSSES-PROCESS** (ADVISORY). With `DAILY_AMARU_DAY`
+  absent from the controller environment, the validated controller-derived day
+  is the exact value observed inside every named transport child.
+  *Fails as:* a transport child observes an absent, empty, or different day.
+  *Succeeds as:* both named operations report the exact derived day in the
+  effect log, and the derived day equals the deterministic fake date.
+- **INV-221-PROPAGATION-PROOF-NONVACUOUS** (ADVISORY). The fake date is
+  distinguishable from the real system UTC day and from every day literal
+  already used by the suite; the remove-propagation mutant is proved applied
+  and recreates the exact production failure; the fixture's day requirement is
+  reconciled against the production transport's.
+  *Fails as:* the proof passes against the mutant, the mutation silently does
+  not apply, the observed day could have come from an injected constant, or the
+  fixture requires the day in a different operation set than production.
+  *Succeeds as:* a printed census naming the derived day, its source, the
+  matched operation set, and the rejected mutant.
+- **INV-221-RECEIPTS-SURVIVE-FAILURE** (ADVISORY). Under an omitted day and a
+  forced downstream transport failure, the #210 day claim carries the derived
+  day, the stage receipts are published in their existing order, and the final
+  receipt is an honest failure receipt.
+  *Fails as:* a missing or mis-dated day claim, a dropped or reordered stage
+  receipt, or a success-like outcome on a failed run.
+  *Succeeds as:* the receipt oracle accepting the durable receipt plus a
+  printed ordered stage-receipt census.
+- **INV-221-SCOPE-AND-EFFECT-FENCE** (ADVISORY). The candidate touches only the
+  declared paths and reaches no real launch, dispatch, external repository
+  mutation, or credential material.
+  *Fails as:* any changed path outside the fence, or any real-launch, clone,
+  PR-create, merge, or workflow-run effect in the new cases.
+  *Succeeds as:* a mechanical path census and a zero-effect census.
+
+## Rejection behavior
+
+The controller must still reject an invalid supplied day before exporting
+anything, must still classify a missing first-boundary command as
+`runner-preflight` without claiming the day, and must still fail the run when a
+transport child fails. Exporting the day changes no stage, marker, or exit
+semantics.
+
+## Non-goals
+
+No workflow edit, receipt-schema change, controller or transport redesign, real
+launch, dispatch, MOOG or Antithesis submission, same-day rerun, issue #210
+marker removal, or work on `lambdasistemi/amaru-bootstrap`, t75, cadence, #212,
+#208, #207, or #206.

--- a/specs/221-daily-amaru-day-propagation/tasks.md
+++ b/specs/221-daily-amaru-day-propagation/tasks.md
@@ -4,25 +4,31 @@ Artifact ceiling: 3,000 bytes and 70 lines.
 
 ## Slice S221-01 — Export the derived day and prove the omitted-day path
 
-- [ ] **T2211** Commit an executable RED proof that, with `DAILY_AMARU_DAY`
+- [x] **T2211** Commit an executable RED proof that, with `DAILY_AMARU_DAY`
   absent and a deterministic fake `date` supplying the day, the controller
   fails with the production fingerprint
   `DAILY_AMARU_DAY: DAILY_AMARU_DAY is required` at
   `stage=bootstrap-proposal` / `outcome=FAILED` / `error=proposal-failed`.
-- [ ] **T2212** Make the deterministic fixture transport observe the day seam
+- [x] **T2212** Make the deterministic fixture transport observe the day seam
   with the production expansion, and permanently reconcile the operation set
   that requires the day against `scripts/daily-amaru-github.sh`.
-- [ ] **T2213** Export the validated derived day from `scripts/daily-amaru.sh`
+- [x] **T2213** Export the validated derived day from `scripts/daily-amaru.sh`
   before the first transport child, changing no other controller semantics.
-- [ ] **T2214** Prove permanently that both `propose-bootstrap` and
+- [x] **T2214** Prove permanently that both `propose-bootstrap` and
   `prepare-consumer-repin` observe the derived day, that the remove-propagation
   mutant is applied and rejected, and that the issue #210 day claim and ordered
   stage receipts survive a forced downstream failure with no launcher reached.
-- [ ] **T2215** Keep every existing guard green and pass the frozen slice gate,
+- [x] **T2215** Keep every existing guard green and pass the frozen slice gate,
   the ticket gate, complete local CI, a fresh independent audit, the final
   tree/diff checks, and all six required contexts on the exact pushed head
   without dispatch, launch, spend, merge, or same-day rerun.
 
 The ticket owner checks these entries only after an exact candidate receives a
-fresh `AUDIT-PASS`. The parked commit owner then includes the task stamp in the
-single final squashed behavior commit.
+fresh audit verdict and an acceptance decision. The parked commit owner then
+includes the task stamp in the single final squashed behavior commit.
+
+T2214 ships with one accepted residual, `CNA205-DAY-SOURCE-NONCE-01`: the
+regression cannot distinguish an implementation that invokes and discards the
+declared date source and then recomputes an equivalent day. Owner: the #205
+epic invariant ledger. The green that ships beside it proves the day crosses
+the process boundary, not that it was consumed from the declared source.

--- a/specs/221-daily-amaru-day-propagation/tasks.md
+++ b/specs/221-daily-amaru-day-propagation/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — Issue 221 Daily Amaru derived-day propagation
+
+Artifact ceiling: 3,000 bytes and 70 lines.
+
+## Slice S221-01 — Export the derived day and prove the omitted-day path
+
+- [ ] **T2211** Commit an executable RED proof that, with `DAILY_AMARU_DAY`
+  absent and a deterministic fake `date` supplying the day, the controller
+  fails with the production fingerprint
+  `DAILY_AMARU_DAY: DAILY_AMARU_DAY is required` at
+  `stage=bootstrap-proposal` / `outcome=FAILED` / `error=proposal-failed`.
+- [ ] **T2212** Make the deterministic fixture transport observe the day seam
+  with the production expansion, and permanently reconcile the operation set
+  that requires the day against `scripts/daily-amaru-github.sh`.
+- [ ] **T2213** Export the validated derived day from `scripts/daily-amaru.sh`
+  before the first transport child, changing no other controller semantics.
+- [ ] **T2214** Prove permanently that both `propose-bootstrap` and
+  `prepare-consumer-repin` observe the derived day, that the remove-propagation
+  mutant is applied and rejected, and that the issue #210 day claim and ordered
+  stage receipts survive a forced downstream failure with no launcher reached.
+- [ ] **T2215** Keep every existing guard green and pass the frozen slice gate,
+  the ticket gate, complete local CI, a fresh independent audit, the final
+  tree/diff checks, and all six required contexts on the exact pushed head
+  without dispatch, launch, spend, merge, or same-day rerun.
+
+The ticket owner checks these entries only after an exact candidate receives a
+fresh `AUDIT-PASS`. The parked commit owner then includes the task stamp in the
+single final squashed behavior commit.

--- a/tests/fixtures/daily-amaru/fake-transport.sh
+++ b/tests/fixtures/daily-amaru/fake-transport.sh
@@ -118,9 +118,12 @@ case "$operation" in
 
   propose-bootstrap)
     sha=${1:?upstream SHA is required}
+    # Same expansion as production: observe the day, never synthesize one.
+    day=${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}
     # The minted bootstrap identity travels in the process environment only, so
     # the log records its presence and never its value.
     log mutation:bootstrap "$sha" "$(identity_marker)"
+    log observed-day propose-bootstrap "$day"
     if [ "$scenario" = failed-stage ]; then
       printf 'bootstrap proposal failed\n' >&2
       exit 1
@@ -142,7 +145,10 @@ case "$operation" in
 
   prepare-consumer-repin)
     image=${1:?image is required}
+    # Same expansion as production: observe the day, never synthesize one.
+    day=${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}
     log mutation:repin "$image"
+    log observed-day prepare-consumer-repin "$day"
     printf '%s\n' "$consumer_sha"
     ;;
 

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -1038,3 +1038,312 @@ grep -Fq 'error=missing-credentials-' "$repo_root/docs/daily-amaru.md" ||
 
 printf 'CREDENTIAL-BINDING workflow=1 tuple=1 docs=1\n'
 pass credential-binding-contract
+
+# INV-221: the scheduled shape never injects a day. Existing cases all set
+# DAILY_AMARU_DAY, so they cannot see a child that does not inherit $day.
+#
+# The expected day is assembled at runtime from components so it is not a
+# YYYY-MM-DD literal in this file or in the controller. A controller that
+# hardcodes a harness-known constant therefore cannot match it.
+real_utc_day=$(date -u +%F)
+omitted_day_y=1999
+omitted_day_m=6
+omitted_day_d=12
+omitted_day_fake=
+while [ -z "$omitted_day_fake" ]; do
+  trial=$(printf '%04d-%02d-%02d' "$omitted_day_y" "$omitted_day_m" "$omitted_day_d")
+  if [ "$trial" != "$real_utc_day" ] &&
+    ! grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+      "$controller" \
+      "$repo_root/tests/test-daily-amaru.sh" \
+      "$repo_root/tests/fixtures/daily-amaru/fake-transport.sh" |
+      grep -qxF "$trial"; then
+    omitted_day_fake=$trial
+  else
+    omitted_day_d=$((omitted_day_d + 1))
+    [ "$omitted_day_d" -le 28 ] ||
+      fail 'could not assemble a derived-day nonce absent from the suite'
+  fi
+done
+
+fake_date_bin="$tmp_root/fake-date-bin"
+fake_date_log="$tmp_root/fake-date-invocations"
+mkdir -p "$fake_date_bin"
+: >"$fake_date_log"
+real_date=$(command -v date)
+[ -x "$real_date" ] || fail 'cannot resolve the real date binary'
+# shellcheck disable=SC2016
+cat >"$fake_date_bin/date" <<EOF
+#!/bin/sh
+if [ "\$#" -eq 2 ] && [ "\$1" = -u ] && [ "\$2" = +%F ]; then
+  printf 'date -u +%%F -> %s\n' '$omitted_day_fake' >>'$fake_date_log'
+  printf '%s\n' '$omitted_day_fake'
+  exit 0
+fi
+exec '$real_date' "\$@"
+EOF
+chmod +x "$fake_date_bin/date"
+fake_date_out=$(PATH="$fake_date_bin:$PATH" date -u +%F)
+[ "$fake_date_out" = "$omitted_day_fake" ] ||
+  fail "fake date returned $fake_date_out, not $omitted_day_fake"
+[ "$(date -u +%F)" = "$real_utc_day" ] ||
+  fail 'real date is no longer the system UTC day'
+# The probe above proves the binary works. It does not prove the controller
+# invoked it; that is observed per run from fake_date_log.
+
+# The production expansion is compared as a literal, not expanded here.
+# shellcheck disable=SC2016
+day_bind='${DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required}'
+operations_requiring_day() {
+  local file=$1 operation body
+  while IFS= read -r operation; do
+    [ -n "$operation" ] || continue
+    body=$(transport_branch "$file" "$operation")
+    [ -n "$body" ] || continue
+    if grep -Fq -- "$day_bind" <<<"$body"; then
+      printf '%s\n' "$operation"
+    fi
+  done < <(grep -E '^  [a-z0-9-]+\)$' "$file" | sed 's/^  //; s/)$//')
+}
+
+mapfile -t prod_day_ops < <(operations_requiring_day "$transport" | sort -u)
+mapfile -t fix_day_ops < <(operations_requiring_day "$fake_transport" | sort -u)
+required_ops=${#prod_day_ops[@]}
+matched=0
+if [ "$required_ops" -ge 2 ] &&
+  [ "${#fix_day_ops[@]}" -eq "$required_ops" ] &&
+  [ "${prod_day_ops[*]}" = "${fix_day_ops[*]}" ]; then
+  matched=1
+fi
+printf 'DAY-FIXTURE-RECONCILIATION required_ops=%s matched=%s\n' \
+  "$required_ops" "$matched"
+# Negative control: dropping the production expansion must unmatch.
+fixture_day_mutant="$tmp_root/fake-transport-no-day.sh"
+# Delete only the production expansion; leave every other arm intact.
+sed '/DAILY_AMARU_DAY:?DAILY_AMARU_DAY is required/d' \
+  "$fake_transport" >"$fixture_day_mutant"
+grep -Fq -- "$day_bind" "$fake_transport" ||
+  fail 'fixture does not contain the production day expansion'
+! grep -Fq -- "$day_bind" "$fixture_day_mutant" ||
+  fail 'fixture day-bind mutation did not apply'
+mapfile -t fix_mut_ops < <(operations_requiring_day "$fixture_day_mutant" | sort -u)
+[ "${prod_day_ops[*]}" != "${fix_mut_ops[*]}" ] ||
+  fail 'reconciliation cannot detect a fixture that dropped the day bind'
+[ "$required_ops" -ge 2 ] && [ "$matched" -eq 1 ] ||
+  fail "fixture day requirement does not match production: prod=[${prod_day_ops[*]}] fixture=[${fix_day_ops[*]}]"
+pass day-fixture-reconciliation
+
+run_omitted_day_case() {
+  local label=$1 scenario=$2 script=${3:-$controller}
+  case_name=$label
+  case_number=$((case_number + 1))
+  case_dir="$tmp_root/$case_number-$case_name"
+  case_state="$case_dir/state"
+  case_log="$case_dir/transport.log"
+  case_receipt="$case_dir/receipt"
+  case_stdout="$case_dir/stdout"
+  case_stderr="$case_dir/stderr"
+  case_effects="$case_dir/effects"
+  mkdir -p "$case_state"
+  : >"$case_log"
+  : >"$case_effects"
+  : >"$fake_date_log"
+  case_rc=0
+  env -u DAILY_AMARU_DAY \
+    PATH="$fake_date_bin:$PATH" \
+    FAKE_SCENARIO="$scenario" \
+    FAKE_LOG="$case_log" \
+    DAILY_AMARU_TRANSPORT="$fake_transport" \
+    DAILY_AMARU_MODE=test \
+    DAILY_AMARU_IDENTITY=test-identity \
+    DAILY_AMARU_STATE_DIR="$case_state" \
+    DAILY_AMARU_RECEIPT="$case_receipt" \
+    DAILY_AMARU_ALLOW_REAL=1 \
+    "$bash_binary" "$script" \
+    >"$case_stdout" 2>"$case_stderr" || case_rc=$?
+}
+
+receipt_day() {
+  if [ -f "$case_receipt" ]; then
+    sed -nE 's/^day=([0-9]{4}-[0-9]{2}-[0-9]{2})$/\1/p' "$case_receipt" |
+      head -1
+  fi
+}
+
+observed_day_for() {
+  sed -n "s/^observed-day $1 //p" "$case_log" | tail -n 1
+}
+
+fake_date_invocations() {
+  if [ -f "$fake_date_log" ]; then
+    grep -c 'date -u +%F' "$fake_date_log" || true
+  else
+    printf '0\n'
+  fi
+}
+
+observed_date_source() {
+  if [ "$(fake_date_invocations)" -ge 1 ]; then
+    printf 'fake-date\n'
+  else
+    printf 'uninvoked\n'
+  fi
+}
+
+# True only when the last omitted-day run used the fake date's output as
+# the derived day and the script under test does not contain that day as
+# a literal. A hardcoded default, a printf constant, or invoke-and-discard
+# cannot satisfy this.
+controller_used_fake_date() {
+  local script=$1
+  local day
+  day=$(receipt_day)
+  [ "$(fake_date_invocations)" -ge 1 ] || return 1
+  [ "$day" = "$omitted_day_fake" ] || return 1
+  ! grep -Fq -- "$omitted_day_fake" "$script" || return 1
+  return 0
+}
+
+# Family of hardcoded/default substitutions. Closing only
+# day=${DAILY_AMARU_DAY:-<known-literal>} is not enough.
+source_mutant_root="$tmp_root/source-mutants"
+mkdir -p "$source_mutant_root"
+rejected_source_mutants=0
+reject_source_mutant() {
+  local label=$1 script=$2 applied=$3 why=$4
+  local mutant="$source_mutant_root/$label"
+  sed "$script" "$controller" >"$mutant"
+  if [ "${applied:0:1}" = '!' ]; then
+    ! grep -Fq -- "${applied:1}" "$mutant" ||
+      fail "mutation did not apply: $label"
+  else
+    grep -Fq -- "$applied" "$mutant" || fail "mutation did not apply: $label"
+  fi
+  chmod +x "$mutant"
+  run_omitted_day_case "source-$label" changed "$mutant"
+  [ -n "$(receipt_day)" ] ||
+    fail "source mutant $label never produced a derived day"
+  if controller_used_fake_date "$mutant"; then
+    fail "source-use check accepted $why"
+  fi
+  rejected_source_mutants=$((rejected_source_mutants + 1))
+}
+
+# shellcheck disable=SC2016
+reject_source_mutant hardcoded-default \
+  's|^day=${DAILY_AMARU_DAY:-$(date -u +%F)}$|day=${DAILY_AMARU_DAY:-2024-11-05}|' \
+  'day=${DAILY_AMARU_DAY:-2024-11-05}' \
+  'a controller that defaults to a hardcoded day instead of date'
+# shellcheck disable=SC2016
+reject_source_mutant printf-default \
+  's|$(date -u +%F)|$(printf %s 2023-01-01)|' \
+  '$(printf %s 2023-01-01)' \
+  'a controller that substitutes a printf constant for date'
+# shellcheck disable=SC2016
+reject_source_mutant invoke-and-discard \
+  's|^day=${DAILY_AMARU_DAY:-$(date -u +%F)}$|day=${DAILY_AMARU_DAY:-$(date -u +%F >/dev/null; printf %s 2024-11-05)}|' \
+  'date -u +%F >/dev/null; printf %s 2024-11-05' \
+  'a controller that invokes date and then ignores its output'
+[ "$rejected_source_mutants" -eq 3 ] ||
+  fail "source-use family rejected $rejected_source_mutants mutants, expected 3"
+printf 'DAY-SOURCE-MUTANTS rejected=%s\n' "$rejected_source_mutants"
+pass omitted-day-source-use-family
+
+run_omitted_day_case omitted-day-success changed
+derived_day=$(receipt_day)
+propose_day=$(observed_day_for propose-bootstrap)
+repin_day=$(observed_day_for prepare-consumer-repin)
+injected_day=absent
+observed_source=$(observed_date_source)
+printf 'DAY-PROPAGATION derived_day=%s source=%s injected_day=%s propose-bootstrap=%s prepare-consumer-repin=%s\n' \
+  "${derived_day:-missing}" "$observed_source" "$injected_day" \
+  "${propose_day:-missing}" "${repin_day:-missing}"
+[ "$case_rc" -eq 0 ] ||
+  fail "omitted-day success failed: exit=$case_rc: $(tr '\n' ' ' <"$case_stderr")"
+controller_used_fake_date "$controller" ||
+  fail 'fake date was not used by the controller'
+[ "$observed_source" = fake-date ] ||
+  fail "fake date was not used by the controller (source=$observed_source)"
+[ "$derived_day" = "$omitted_day_fake" ] ||
+  fail "derived day ${derived_day:-missing} is not the fake date $omitted_day_fake"
+[ "$propose_day" = "$derived_day" ] ||
+  fail "propose-bootstrap observed ${propose_day:-missing}, not $derived_day"
+[ "$repin_day" = "$derived_day" ] ||
+  fail "prepare-consumer-repin observed ${repin_day:-missing}, not $derived_day"
+assert_log_count 1 '^mutation:bootstrap '
+assert_log_count 1 '^mutation:repin '
+assert_log_count 0 '^real-launch '
+pass omitted-day-propagation
+
+prop_mutant="$tmp_root/controller-no-day-export.sh"
+sed '/^export DAILY_AMARU_DAY=/d' "$controller" >"$prop_mutant"
+applied=0
+if grep -Eq '^export DAILY_AMARU_DAY=' "$controller" &&
+  ! grep -Eq '^export DAILY_AMARU_DAY=' "$prop_mutant"; then
+  applied=1
+fi
+run_omitted_day_case omitted-day-mutant changed "$prop_mutant"
+mutant_rejected=0
+fingerprint=absent
+mutant_stage=missing
+mutant_error=missing
+[ "$case_rc" -ne 0 ] && mutant_rejected=1
+if grep -Fq 'DAILY_AMARU_DAY: DAILY_AMARU_DAY is required' "$case_stderr"; then
+  fingerprint=matched
+fi
+if [ -f "$case_receipt" ]; then
+  mutant_stage=$(sed -nE 's/^stage=(.*)$/\1/p' "$case_receipt" | head -1)
+  mutant_error=$(sed -nE 's/^error=(.*)$/\1/p' "$case_receipt" | head -1)
+fi
+printf 'DAY-PROPAGATION-MUTANT applied=%s rejected=%s fingerprint=%s stage=%s error=%s\n' \
+  "$applied" "$mutant_rejected" "$fingerprint" "$mutant_stage" "$mutant_error"
+[ "$applied" -eq 1 ] && [ "$mutant_rejected" -eq 1 ] &&
+  [ "$fingerprint" = matched ] &&
+  [ "$mutant_stage" = bootstrap-proposal ] &&
+  [ "$mutant_error" = proposal-failed ] ||
+  fail 'remove-propagation mutant was not applied and rejected as production'
+pass omitted-day-propagation-mutant
+
+run_omitted_day_case omitted-day-failed-stage failed-stage
+derived_day=$(receipt_day)
+day_claim=0
+if [ -n "$derived_day" ] && [ -f "$case_state/day-claim" ] &&
+  grep -Fqx "$derived_day" "$case_state/day-claim"; then
+  day_claim=1
+fi
+mapfile -t receipt_stages < <(
+  sed -nE 's/^receipt .* stage=([^ ]+).*/\1/p' "$case_log"
+)
+stage_receipts=${#receipt_stages[@]}
+expected_stages=(day-claim resolve-upstream launch-attempt bootstrap-proposal)
+ordered=0
+if [ "$stage_receipts" -eq "${#expected_stages[@]}" ]; then
+  ordered=1
+  for i in "${!expected_stages[@]}"; do
+    [ "${receipt_stages[$i]}" = "${expected_stages[$i]}" ] || ordered=0
+  done
+fi
+real_launches=$(count_matches "$case_log" '^real-launch ')
+fake_launches=$(count_matches "$case_log" '^fake-launch ')
+printf 'DAY-RECEIPTS derived_day=%s day_claim=%s stage_receipts=%s ordered=%s real_launches=%s fake_launches=%s\n' \
+  "${derived_day:-missing}" "$day_claim" "$stage_receipts" "$ordered" \
+  "$real_launches" "$fake_launches"
+[ "$case_rc" -ne 0 ] || fail 'omitted-day failed-stage unexpectedly succeeded'
+[ "$derived_day" = "$omitted_day_fake" ] ||
+  fail "failure-path derived day ${derived_day:-missing} is not $omitted_day_fake"
+[ "$day_claim" -eq 1 ] ||
+  fail "issue #210 day claim is missing or not $derived_day"
+[ "$stage_receipts" -ge 1 ] || fail 'no stage receipts were published'
+[ "$ordered" -eq 1 ] ||
+  fail "stage receipts were dropped or reordered: ${receipt_stages[*]}"
+[ "$real_launches" -eq 0 ] && [ "$fake_launches" -eq 0 ] ||
+  fail "failure path reached a launcher: real=$real_launches fake=$fake_launches"
+receipt_oracle "$case_receipt" "$derived_day" bootstrap-proposal \
+  proposal-failed "$case_effects" ||
+  fail 'omitted-day failure receipt was not an honest failure'
+for forbidden in 'repo clone' 'pr create' 'pr merge' 'workflow run' 'run watch'; do
+  if grep -Fq -- "$forbidden" "$case_log" "$case_effects"; then
+    fail "omitted-day failure path reached a business effect: $forbidden"
+  fi
+done
+pass omitted-day-receipts-survive-failure


### PR DESCRIPTION
Fixes #221

## Why

Scheduled run `32215848871` on head `7ac049e748ff83ab12dee2864343510d6fb9541e`
failed at `stage=bootstrap-proposal` with `outcome=FAILED`,
`error=proposal-failed`. The underlying child error was
`scripts/daily-amaru-github.sh:185: DAILY_AMARU_DAY is required`.

`scripts/daily-amaru.sh` derived and validated the UTC day into a plain shell
variable. `transport_call` forks a child process, which cannot see a
non-exported variable, so `propose-bootstrap` and `prepare-consumer-repin`
aborted whenever the workflow did not supply the day itself — which is exactly
the scheduled shape, since #213 deliberately made the controller the sole
deriver so no external `date` stands before the first receipt boundary.

Every existing controller case in `tests/test-daily-amaru.sh` injected
`DAILY_AMARU_DAY`. The suite was green while the only production shape was
never exercised.

## What changed

Three lines of production code and the proof that makes them permanent.

**`scripts/daily-amaru.sh`** publishes the validated day into the process
environment, after validation and before the first transport child. Derivation,
validation, stage sequencing, receipt composition and ordering, identity
handling, and launch selection are unchanged.

**`tests/test-daily-amaru.sh`** gains the workflow-shaped omitted-day class:

- `DAILY_AMARU_DAY` absent from the controller environment, with a
  deterministic fake `date` supplying the day, and both named transport paths
  required to observe exactly that derived day;
- a remove-propagation mutant, proved applied, that recreates the exact
  production failure — stderr fingerprint
  `DAILY_AMARU_DAY: DAILY_AMARU_DAY is required` plus the receipt triple
  `stage=bootstrap-proposal` / `outcome=FAILED` / `error=proposal-failed`;
- three further source-substitution mutants (hardcoded default, printf default,
  invoke-and-discard), each proved applied and rejected;
- the issue #210 day claim and the ordered stage receipts published through a
  forced downstream failure, with the existing receipt oracle accepting the
  durable failure receipt and zero launchers reached;
- a reconciliation that derives from `scripts/daily-amaru-github.sh` the set of
  transport operations requiring the day and demands the fixture match exactly
  that set, so the fixture cannot drift into being unable to observe the defect.

**`tests/fixtures/daily-amaru/fake-transport.sh`** binds the day with the same
expansion production uses, in exactly that reconciled operation set, and records
the observed value in the effect log it already owns. It never synthesizes,
defaults, or repairs a missing day.

Each case prints a machine-readable census line, so a pass carries evidence and
selection is provable rather than assumed. The suite goes from 42 to 47 `PASS`
lines; no existing assertion was loosened.

## Accepted residual

`CNA205-DAY-SOURCE-NONCE-01` (ADVISORY, owner: the #205 epic invariant ledger).

An implementation could invoke and discard the declared fake `date` output and
then reconstruct the predictable fixed-component day, and this regression would
not distinguish it from the correct one. **Honest limit:** the green here proves
the validated derived day is exported before the first transport child, that
both named transport children observe it, that removing propagation reproduces
the exact production fingerprint, and that the #210 claim and stage receipts
survive a downstream failure with zero launches. It does **not** prove that
every future implementation consumed the declared date source rather than
predictably recomputing an equivalent day. Closing that needs a per-run value
the implementation cannot compute or read, which is filed for the epic ledger
rather than smuggled into this fix.

Found by an independent audit; the shipped code and its proof are unaffected by
it.

## Out of scope

No workflow edit, receipt-schema change, transport redesign, docs change (the
operator-visible contract is unchanged — the controller was always the day's
publisher), dispatch, launch, rerun, or issue #210 marker removal.

## Record

`specs/221-daily-amaru-day-propagation/` carries the spec, plan, modules and
data models, and tasks. No `functions-model.md`: this slice creates and changes
no function signature.
