### PR TITLE
ci: add manual production trigger with a code-enforced daily launch cap

### DIFF
--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -4,19 +4,25 @@ on:
   schedule:
     - cron: '17 4 * * *'
   workflow_dispatch:
+    inputs:
+      production:
+        description: Run the guarded production path
+        required: false
+        type: boolean
+        default: false
   pull_request:
 
 permissions:
   contents: read
 
 concurrency:
-  group: daily-amaru-${{ github.event_name }}-${{ github.ref }}
+  group: daily-amaru-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   daily-amaru-dry-run:
     name: Daily Amaru contract dry run
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.production)
     runs-on: ubuntu-latest
     steps:
       - name: Check out the exact candidate
@@ -27,8 +33,8 @@ jobs:
         run: tests/test-daily-amaru.sh
 
   daily-amaru-scheduled:
-    name: Daily Amaru scheduled production
-    if: github.event_name == 'schedule'
+    name: Daily Amaru production run
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.production)
     runs-on: ubuntu-latest
     timeout-minutes: 180
     # Exactly what the transport's same-repository operations declare they need.

--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -66,6 +66,68 @@ comment_issue() {
   gh issue comment "$receipt_issue" -R "$repository" --body "$1" >/dev/null
 }
 
+marker_census() {
+  issue_bodies
+}
+
+validate_head() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]] || die "invalid workflow head: $1"
+}
+
+# Claim an append-only pre-launch marker. A successful census is captured
+# before it is searched, so a failed `gh` cannot masquerade as no match.
+claim_prelaunch_marker() {
+  local kind=$1 value=$2 head=$3 census line marker legacy_marker
+  local current_prefix previous_head='' recorded_head='' found=0
+
+  if ! census=$(marker_census); then # census-fails-closed
+    printf 'BLOCKED census-unreadable\n'
+    return 1
+  fi
+
+  if [ "$kind" = day ]; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$value"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
+        printf 'BLOCKED launch-consumed\n'
+        return 1 # launch-consumed-final
+      fi
+    done <<<"$census"
+    legacy_marker="<!-- daily-amaru day=$value claim -->"
+    current_prefix="<!-- daily-amaru day=$value claim head="
+    marker="<!-- daily-amaru day=$value claim head=$head -->"
+  else
+    legacy_marker="<!-- daily-amaru attempted-sha=$value -->"
+    current_prefix="<!-- daily-amaru attempted-sha=$value head="
+    marker="<!-- daily-amaru attempted-sha=$value head=$head -->"
+  fi
+
+  while IFS= read -r line; do
+    if [ "$line" = "$legacy_marker" ]; then
+      found=1
+      previous_head=legacy
+      continue
+    fi
+    if [[ "$line" == "$current_prefix"*' -->' ]]; then
+      recorded_head=${line#"$current_prefix"}
+      recorded_head=${recorded_head%' -->'}
+      [[ "$recorded_head" =~ ^[0-9a-f]{40}$ ]] || continue
+      found=1
+      previous_head=$recorded_head
+      if [ "$recorded_head" = "$head" ]; then # unchanged-head-guard
+        printf 'BLOCKED unchanged-head\n'
+        return 1
+      fi
+    fi
+  done <<<"$census"
+
+  comment_issue "$marker"
+  if [ "$found" -eq 0 ]; then
+    printf 'CLAIMED\n'
+  else
+    printf 'SUPERSEDED previous-head=%s\n' "$previous_head"
+  fi
+}
+
 with_identity() {
   local identity=$1
   shift
@@ -143,11 +205,10 @@ case "$operation" in
     # repository-token-permissions: issues=write
     require_commands gh grep
     day=${1:?day is required}
-    marker="<!-- daily-amaru day=$day claim -->"
-    if issue_bodies | grep -Fqx -- "$marker"; then
-      die "UTC day already claimed: $day"
-    fi
-    comment_issue "$marker"
+    head=${2:?head is required}
+    [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || die "invalid UTC day: $day"
+    validate_head "$head"
+    claim_prelaunch_marker day "$day" "$head"
     ;;
 
   resolve-upstream)
@@ -172,11 +233,31 @@ case "$operation" in
     # repository-token-permissions: issues=write
     require_commands gh grep
     sha=${1:?upstream SHA is required}
-    marker="<!-- daily-amaru attempted-sha=$sha -->"
-    if issue_bodies | grep -Fqx -- "$marker"; then
-      die "upstream SHA already attempted: $sha"
+    head=${2:?head is required}
+    [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || die "invalid upstream SHA: $sha"
+    validate_head "$head"
+    claim_prelaunch_marker sha "$sha" "$head"
+    ;;
+
+  claim-launch)
+    # repository-token-permissions: issues=write
+    require_commands gh grep
+    day=${1:?day is required}
+    head=${2:?head is required}
+    [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || die "invalid UTC day: $day"
+    validate_head "$head"
+    if ! census=$(marker_census); then # census-fails-closed
+      printf 'BLOCKED census-unreadable\n'
+      exit 1
     fi
-    comment_issue "$marker"
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$day"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
+        printf 'BLOCKED launch-consumed\n'
+        exit 1 # launch-consumed-final
+      fi
+    done <<<"$census"
+    comment_issue "<!-- daily-amaru day=$day launch-consumed head=$head -->"
+    printf 'CLAIMED\n'
     ;;
 
   propose-bootstrap)

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -34,6 +34,12 @@ utc_day() {
   printf '%s' "$day"
 }
 
+# Builtin-only workflow head: resolve and validate it before the first
+# transport child so every later operation inherits one immutable value.
+workflow_head() {
+  printf '%s' "${DAILY_AMARU_HEAD:-${GITHUB_SHA:-}}"
+}
+
 case "$mode" in
   production | manual | pull_request | test) ;;
   *) die "unsupported mode: $mode" ;;
@@ -52,6 +58,7 @@ receipt[upstream_ref]=$ref
 
 receipt_keys=(
   day stage outcome error
+  workflow_head claim_supersedes launch_claim
   dependency_census
   upstream_origin upstream_ref upstream_sha
   bootstrap_candidate_sha image_ref
@@ -149,8 +156,43 @@ receipt[day]=$day
 # Publish the validated day before any transport child is forked.
 export DAILY_AMARU_DAY=$day
 
+head=$(workflow_head)
+if [ -z "$head" ]; then
+  fail_stage head-resolution unresolvable-head
+fi
+[[ "$head" =~ ^[0-9a-f]{40}$ ]] || fail_stage head-resolution malformed-head
+receipt[workflow_head]=$head
+export DAILY_AMARU_HEAD=$head
+
 [ -x "$transport" ] || die "transport is not executable: $transport"
 mkdir -p "$state_dir"
+
+claim_operation() {
+  local stage=$1 operation=$2 record_supersede=$3
+  local verdict reason previous_head
+  shift 3
+
+  verdict=''
+  if ! verdict=$(transport_call "$operation" "$@"); then
+    if [[ "$verdict" =~ ^BLOCKED\ ([a-z-]+)$ ]]; then
+      reason=${BASH_REMATCH[1]}
+    else
+      reason=malformed-claim-verdict
+    fi
+    fail_stage "$stage" "$reason"
+  fi
+
+  case "$verdict" in
+    CLAIMED) ;;
+    'SUPERSEDED previous-head='*)
+      previous_head=${verdict#SUPERSEDED previous-head=}
+      if [ "$record_supersede" = yes ]; then
+        receipt[claim_supersedes]=$previous_head
+      fi
+      ;;
+    *) fail_stage "$stage" malformed-claim-verdict ;;
+  esac
+}
 
 # The full census is checked before the UTC day is claimed, so a runner missing
 # a required command costs neither the day nor a business effect.
@@ -169,9 +211,7 @@ fi
   fail_stage runner-preflight malformed-dependency-evidence
 receipt[dependency_census]=$preflight_output
 
-if ! transport_call claim-day "$day"; then
-  fail_stage day-claim duplicate-day
-fi
+claim_operation day-claim claim-day yes "$day" "$head"
 write_receipt day-claim CLAIMED
 
 observation_output=''
@@ -228,9 +268,7 @@ fi
 # Process environment only: never a command-line argument any process can read.
 export DAILY_AMARU_IDENTITY=$identity
 
-if ! transport_call claim-sha-attempt "$observed_sha"; then
-  fail_stage launch-attempt sha-already-attempted
-fi
+claim_operation launch-attempt claim-sha-attempt no "$observed_sha" "$head"
 write_receipt launch-attempt CLAIMED
 
 bootstrap_sha=''
@@ -334,6 +372,9 @@ write_receipt supervised-integration VERIFIED
 
 launch_operation=fake-launch
 if [ "$mode" = production ]; then
+  claim_operation launch-cap claim-launch no "$day" "$head"
+  receipt[launch_claim]=consumed
+  write_receipt launch-cap CLAIMED
   launch_operation=real-launch
 fi
 

--- a/specs/223-manual-production-trigger/data-model.md
+++ b/specs/223-manual-production-trigger/data-model.md
@@ -1,0 +1,66 @@
+# Data model — Issue 223
+
+Artifact ceiling: 4,000 bytes and 90 lines.
+
+## Marker vocabulary on issue #210 (append-only)
+
+Every marker is one exact line inside an issue comment. Nothing is ever
+deleted or rewritten; a later marker supersedes an earlier one by existing.
+
+| Marker | Form | State it records |
+|---|---|---|
+| day claim (legacy) | `<!-- daily-amaru day=<day> claim -->` | day claimed, claiming head unknown |
+| day claim | `<!-- daily-amaru day=<day> claim head=<sha40> -->` | day claimed by that workflow head |
+| launch claim | `<!-- daily-amaru day=<day> launch-consumed head=<sha40> -->` | the day's one real launch is spent |
+| attempted SHA (legacy) | `<!-- daily-amaru attempted-sha=<sha40> -->` | upstream SHA attempted, claiming head unknown |
+| attempted SHA | `<!-- daily-amaru attempted-sha=<sha40> head=<sha40> -->` | attempted by that workflow head |
+| last success | `<!-- daily-amaru last-success sha=<sha40> -->` | unchanged |
+| receipt | `<!-- daily-amaru receipt -->` + `- key=value` | unchanged |
+
+`<day>` is `YYYY-MM-DD`; `<sha40>` is exactly 40 lowercase hex characters.
+Legacy forms are recognised forever: they are the durable record of every run
+before this change, including the 2026-08-19 claim this ticket unblocks.
+
+## Claim verdict
+
+Produced by the transport, consumed by the controller. The controller never
+parses a marker.
+
+| Verdict | Stdout | Exit | Meaning |
+|---|---|---|---|
+| claimed | `CLAIMED` | 0 | no prior marker; a new one was appended |
+| superseded | `SUPERSEDED previous-head=<sha40\|legacy>` | 0 | prior pre-launch claim, head differs; a superseding marker was appended |
+| blocked | `BLOCKED <reason>` | non-zero | refused, nothing appended |
+
+Blocked reasons, each a distinct named receipt error:
+
+- `launch-consumed` — the day already holds a launch claim (final, whatever the head)
+- `unchanged-head` — a prior pre-launch claim recorded this exact head
+- `census-unreadable` — the marker census could not be read
+
+## Head state
+
+| Value | Source | Rule |
+|---|---|---|
+| current head | `DAILY_AMARU_HEAD`, else `GITHUB_SHA` | must match `^[0-9a-f]{40}$`; unresolvable or malformed refuses the run at stage `head-resolution` before any claim |
+| recorded head | the marker's `head=` field | absent (legacy) counts as *differs from current* |
+
+## Receipt fields added
+
+Appended to `receipt_keys` after the existing `day` group; every existing key,
+value, and order is unchanged.
+
+| Key | Value | Written at |
+|---|---|---|
+| `workflow_head` | current head, 40 hex | first receipt of the run |
+| `claim_supersedes` | previous head or `legacy` | day-claim stage, only on a supersede |
+| `launch_claim` | `consumed` | launch-cap stage, before the launcher |
+
+## State invariants
+
+- For one `<day>`, at most one launch claim is ever admitted.
+- A day holding a launch claim admits no further claim that day.
+- A day holding only pre-launch claims admits a new claim iff the current head
+  differs from every recorded head on those claims.
+- A refused claim appends nothing.
+- Marker count over issue #210 is monotonically non-decreasing.

--- a/specs/223-manual-production-trigger/functions-model.md
+++ b/specs/223-manual-production-trigger/functions-model.md
@@ -1,0 +1,47 @@
+# Functions model — Issue 223
+
+Artifact ceiling: 3,500 bytes and 70 lines.
+
+Only new or changed signatures. Local helpers are the implementer's choice.
+
+## `scripts/daily-amaru-github.sh` — transport operations
+
+| Operation | Arguments | Result |
+|---|---|---|
+| `claim-day` | `day` (`YYYY-MM-DD`), `head` (sha40) | claim verdict on stdout; exit 0 claimed/superseded, non-zero blocked |
+| `claim-sha-attempt` | `sha` (sha40), `head` (sha40) | claim verdict; same vocabulary |
+| `claim-launch` | `day` (`YYYY-MM-DD`), `head` (sha40) | `CLAIMED` on stdout, exit 0; `BLOCKED <reason>` and non-zero otherwise |
+
+`claim-day` and `claim-sha-attempt` change arity: both gain the required
+trailing `head`. A call missing it is a hard error, never a silent legacy path.
+
+Internal, transport-private:
+
+| Function | Arguments | Result |
+|---|---|---|
+| `marker_census` | none | every issue-comment body on stdout; non-zero when the census could not be read, with no partial body treated as complete |
+
+## `scripts/daily-amaru.sh` — controller
+
+| Function | Arguments | Result |
+|---|---|---|
+| `workflow_head` | none | the current head string; builtin-only, no external command |
+
+Changed call sites, in existing stage order:
+
+| Stage | Change |
+|---|---|
+| `head-resolution` (new, before `day-claim`) | derives, validates, and exports the head; refuses the run on an unresolvable or malformed head |
+| `day-claim` | passes `head`; maps `BLOCKED <reason>` to `fail_stage day-claim <reason>` and records `claim_supersedes` on a supersede |
+| `launch-attempt` | passes `head`; same verdict mapping under `fail_stage launch-attempt <reason>` |
+| `launch-cap` (new, after `supervised-integration`, before the launcher, production mode only) | calls `claim-launch`; on refusal `fail_stage launch-cap <reason>` with zero launcher invocations |
+
+`transport_call`'s signature is unchanged. No existing stage name, receipt key,
+exit code, or marker is renamed or removed.
+
+## `tests/fixtures/daily-amaru/fake-transport.sh`
+
+Implements `claim-day`, `claim-sha-attempt`, and `claim-launch` with the exact
+arity above, logging the head it observed so the propagation census can read
+it. Its claim-operation set is reconciled mechanically against the production
+transport.

--- a/specs/223-manual-production-trigger/modules-model.md
+++ b/specs/223-manual-production-trigger/modules-model.md
@@ -1,0 +1,49 @@
+# Modules model — Issue 223
+
+Artifact ceiling: 3,500 bytes and 70 lines.
+
+Dependency direction is unchanged: workflow → controller → transport → GitHub.
+No new module and no new dependency edge. Two existing modules gain one
+responsibility each; one gains none and is only re-routed.
+
+## `.github/workflows/daily-amaru.yaml` — trigger surface
+
+Gains a typed `workflow_dispatch` input and a routing rule. Owns no spend
+decision: it selects which of the two existing jobs runs and nothing more. The
+production job it selects for a dispatch is the identical job the schedule
+selects — a single definition, never a copy.
+
+## `scripts/daily-amaru.sh` — controller
+
+Gains the workflow-head derivation, validation, and export, mirroring the day
+boundary repaired by #221, and gains one ordering duty: the launch claim is a
+stage of its own, immediately before the launcher. Owns the mapping from a
+refused claim to a named stage and error in the durable receipt. Owns no
+knowledge of how a marker is stored.
+
+## `scripts/daily-amaru-github.sh` — transport
+
+Owns the durable marker vocabulary on issue #210 and every claim decision made
+from it: one census reader that fails closed, and three claim operations that
+share it. Owns the supersede rule. The controller learns a verdict, never a
+marker string.
+
+## `tests/fixtures/daily-amaru/fake-transport.sh` — deterministic fixture
+
+Must implement exactly the claim-operation set the production transport
+implements, reconciled mechanically as `tests/test-daily-amaru.sh` already
+reconciles the day-requiring operation set (#221 FR-05). A fixture free to
+accept an operation production rejects cannot observe the defect it exists for.
+
+## `tests/test-daily-amaru.sh` — the proof
+
+The single home for every #223 proof, because it is the only proof this
+repository runs in hosted CI. Owns the routing census, the cap and supersede
+scenarios, the fail-closed census case, the head-propagation census, and the
+mutants. Consumes the workflow file, the controller, the production transport,
+and both fixtures.
+
+## Promotion
+
+None. Every new responsibility lands on the module that already owns its
+neighbours; no shared abstraction is justified by two call sites.

--- a/specs/223-manual-production-trigger/plan.md
+++ b/specs/223-manual-production-trigger/plan.md
@@ -1,0 +1,89 @@
+# Plan — Issue 223 manual production trigger and daily launch cap
+
+Artifact ceiling: 6,000 bytes and 130 lines.
+
+## Strategy
+
+Two absences in the current marker vocabulary cause the whole ticket: a marker
+cannot say *this day already spent its launch*, and a marker cannot say *which
+workflow head claimed it*. Add exactly those two facts, then let the existing
+claim boundary — which already runs before every effect — carry the cap.
+
+The trigger surface stays dumb. `production=true` selects the existing
+production job and nothing else; every spend decision is made by
+`scripts/daily-amaru.sh` and `scripts/daily-amaru-github.sh`, so the guarantee
+is identical for a schedule and a dispatch by construction rather than by two
+matching conditions.
+
+## Ordering constraint that makes the cap fail closed
+
+The launch claim is published BEFORE the launcher runs. An attempt that dies
+between claiming and launching has consumed the day. This deliberately
+over-counts rather than under-counts: an unspent day costs one day of latency,
+a double launch costs real money.
+
+Symmetrically, an unresolvable current head refuses the claim. Only a *recorded*
+head may be absent (legacy markers); the *current* head never may.
+
+## Live boundary
+
+GitHub's expression evaluator is not executable here. The proof extracts the
+exact `if:` condition strings from the workflow and evaluates them with a small
+pure truth table, so a wrong condition in the file is caught, while the
+evaluator itself is the residual. The first real `production=true` dispatch —
+fired by the epic owner after merge, never by this ticket — is that boundary's
+smoke. Keep both conditions simple enough to read as a truth table.
+
+`inputs.production` is the boolean-typed dispatch input. `github.event.inputs.production`
+is the string form and must not be used: it is `'false'`, which is truthy.
+
+## Slice S223-01 (single, bisect-safe)
+
+Trigger input, routing, head derivation, the three claim operations, the
+fixture, and the proofs land together. Splitting them would ship a trigger
+without its cap or a cap without its trigger; neither half is safe to merge
+alone, and NOTE-029 wants the smallest honest whole thing today.
+
+Order inside the slice:
+
+1. RED: the complete executable proof of every invariant row, red for the
+   right reason against the unchanged base.
+2. GREEN: workflow input and routing; controller head derivation, export, and
+   claim-gate ordering; transport census and the three claim operations;
+   fixture parity.
+3. Mutants: each protection shown able to fail, each mutation proved applied.
+
+## Constraints
+
+- `tests/test-daily-amaru.sh` is the home for every new proof: it is the only
+  proof this repository executes in hosted CI (the `Daily Amaru contract dry
+  run` job), and it already owns both controller cases and workflow-file
+  assertions. `tests/test-workflow-validation.sh` runs only in local CI; do not
+  put a spend protection where hosted CI cannot see it.
+- Reuse the existing harness vocabulary — `run_case`, `run_hermetic_case`,
+  `assert_no_launch`, `assert_no_mutation`, the receipt oracle, the
+  applied-then-rejected mutant pattern. Do not build a second framework.
+- The production transport is exercised with the deterministic fake `gh`
+  fixture, never a real one.
+- Keep the production job's job id `daily-amaru-scheduled` stable. Its `name:`
+  may become `Daily Amaru production run`; that context is not merge-required
+  (the six required contexts are fixed and unrelated).
+- `concurrency.group` drops `github.event_name` so a dispatch and a schedule on
+  the same ref serialize instead of racing the check-then-write claim. A queued
+  dry run behind a production run is accepted cost.
+- `DAILY_AMARU_ALLOW_REAL` is set by the existing suite and read by nothing.
+  It is a dead variable, not a protection; do not build on it and do not change
+  it here. Reported to the epic invariant ledger as an observation.
+
+## Risks
+
+- **Same-day attempted-SHA block.** Requirement 3 is unsatisfiable in practice
+  unless the attempted-SHA marker supersedes under the same rule: after the
+  2026-08-19 pre-launch death, upstream may not have moved, so a re-attempt
+  would die at `launch-attempt` even with the day superseded. The supersede
+  rule therefore governs every pre-launch gate marker — day claim and
+  attempted-SHA claim alike. Ticket-owner ruling, reported upward, not a scope
+  change: without it the issue's own acceptance bullet cannot be met.
+- **Check-then-write race.** Two runners can both read an unclaimed day. The
+  concurrency group removes the realistic case; the pre-launcher claim narrows
+  the remainder. Residual, named, not eliminated.

--- a/specs/223-manual-production-trigger/spec.md
+++ b/specs/223-manual-production-trigger/spec.md
@@ -1,0 +1,172 @@
+# Issue 223 — Manual production trigger with a code-enforced daily launch cap
+
+Artifact ceiling: 11,000 bytes and 190 lines.
+
+## Priority story
+
+As the Daily Amaru operator, I can fire the production path on demand from
+`workflow_dispatch` with `production=true`, through the exact code path the
+04:17Z schedule uses, while the controller itself — not the trigger surface —
+guarantees at most one real Antithesis launch per UTC day.
+
+## Why now
+
+Desk ruling NOTE-029 (2026-08-19) partially reverses the schedule-only rule:
+the schedule remains the routine driver, a manual test path is added, and the
+spend cap moves out of "only the schedule can fire" and into code.
+
+The first production fire (run `32215848871`, 2026-08-19) died at
+`bootstrap-proposal` before any launch. Issue #210 therefore carries a claim
+for 2026-08-19 whose real-run allowance is unconsumed, and the current
+`claim-day` refuses the day outright. Under this contract that exact state —
+a pre-launch death whose workflow head has since moved — becomes re-attemptable.
+
+## Current mechanics (discovered, not assumed)
+
+`scripts/daily-amaru.sh` claims the UTC day at its `day-claim` stage, long
+before the launcher at its `launch` stage. `scripts/daily-amaru-github.sh`
+implements every claim as an exact-line marker comment on issue #210:
+
+- day claim: `<!-- daily-amaru day=<day> claim -->`
+- attempted upstream SHA: `<!-- daily-amaru attempted-sha=<sha> -->`
+- last success: `<!-- daily-amaru last-success sha=<sha> -->`
+- receipts: `<!-- daily-amaru receipt -->` plus `- key=value` lines
+
+No marker distinguishes *claimed* from *launched*, and no marker records the
+workflow head that claimed it. Those two absences are what this ticket adds.
+
+## Functional requirements
+
+- **FR-223-01 — Manual production trigger.** `.github/workflows/daily-amaru.yaml`
+  declares a `workflow_dispatch` boolean input `production` defaulting to
+  `false`. `production=true` runs the existing production job — the same job,
+  steps, environment, and `scripts/daily-amaru.sh` invocation the schedule
+  uses. No second production job, no duplicated steps, no parallel path.
+- **FR-223-02 — Unchanged dry-run default.** With `production=false`, and for
+  every `pull_request` event, exactly the existing dry-run job runs and its
+  step body is byte-unchanged. The production job does not run.
+- **FR-223-03 — Trigger-independent cap.** At most ONE real Antithesis launch
+  per UTC day, enforced in the controller's claim/marker code and identical for
+  `schedule` and `workflow_dispatch`. A second same-day attempt that would
+  launch fails closed, before reaching the launcher, with a named stage and
+  error in the durable receipt.
+- **FR-223-04 — Pre-launch-death supersede.** A day whose claim came from an
+  attempt that died BEFORE the launcher is re-attemptable if and only if the
+  workflow head differs from the head recorded on that claim. The re-attempt
+  appends a superseding claim naming the previous head; a claim carrying no
+  recorded head (every marker written before this change, including
+  2026-08-19) counts as a differing head. Nothing on issue #210 is deleted or
+  rewritten: both attempts' markers and receipts survive.
+- **FR-223-05 — Post-launch finality.** Once a real launch is claimed for a UTC
+  day, that day is never superseded again that day, whatever the workflow head
+  is. The launch claim is written and durably published BEFORE the launcher is
+  invoked, so an attempt that dies at or after the launch consumes the day.
+- **FR-223-06 — Fail-closed census.** A marker census that cannot be read
+  refuses the claim. An unreadable, failed, or empty-on-error census is never
+  read as "no marker present".
+- **FR-223-07 — Head crosses the process boundary.** The controller derives the
+  workflow head once, validates it as 40 lowercase hex, exports it before the
+  first transport child is forked, and fails closed with a named stage when it
+  cannot be resolved. This is the #221 defect class; it must not be recreated.
+- **FR-223-08 — Preserved semantics.** Receipt vocabulary, marker vocabulary,
+  stage order, exit semantics, and every existing guard — no-effect,
+  no-real-launch, duplicate-day, attempted-SHA, credential, preflight, day
+  propagation — remain green and unweakened. The only receipt-schema change is
+  the supersede/launch-claim addition.
+- **FR-223-09 — Fenced proofs.** No test reaches a real Antithesis launch, a
+  real GitHub dispatch, an external repository mutation, or credential
+  material.
+- **FR-223-10 — Green gates.** The focused controller suite and complete local
+  CI are freshly green, the frozen slice gate and ticket gate are freshly
+  green, the finalization audit passes, and all six required GitHub contexts
+  (`Build`, `Run unit Tests`, `Check code quality`, `Compose smoke test`,
+  `publish-images`, `build-docs`) are green on the exact pushed head.
+
+## Invariant mandate
+
+Rows 1–6 govern real-money spend on Antithesis compute; under the loaded
+severity law they are `CRITICAL`, and the desk's proportionality steer
+(NOTE-028) explicitly exempts spend protection from ceremony reduction. Every
+row requires a permanent executing proof AND a demonstrated killing mutant
+before it is trusted. No row may ship as an accepted residual.
+
+- **INV-223-DISPATCH-ROUTING** (CRITICAL). The workflow's job selection is
+  exactly: `schedule` → production only; `workflow_dispatch` with
+  `production=true` → production only; `workflow_dispatch` with
+  `production=false` → dry-run only; `pull_request` → dry-run only.
+  *Fails as:* a trigger selecting both jobs, neither job, or the wrong one;
+  a production job reachable from a `pull_request`; a dispatch default that is
+  not `false`; a second production job or duplicated production steps.
+  *Succeeds as:* a printed four-row routing census over the exact condition
+  strings extracted from the workflow file, plus a proof that exactly one job
+  invokes `scripts/daily-amaru.sh`.
+- **INV-223-DRY-RUN-BYTE-UNCHANGED** (CRITICAL). The dry-run job's step body is
+  byte-identical to its pre-change content.
+  *Fails as:* any byte of the dry-run job's steps differing from the frozen
+  base content.
+  *Succeeds as:* a printed hash comparison against the base-commit extraction.
+- **INV-223-ONE-LAUNCH-PER-DAY** (CRITICAL). At most one real launch is reached
+  per UTC day across both triggers. A day carrying a launch claim refuses every
+  further same-day claim regardless of workflow head, and the refusal is a
+  named stage/error in the durable receipt with zero launcher invocations.
+  *Fails as:* two real-launch effects for one day in any trigger combination; a
+  post-launch day accepting a new claim because the head moved; a refusal that
+  reaches the launcher, exits zero, or lands an unnamed/success-like receipt.
+  *Succeeds as:* a per-scenario census printing trigger, day, head, launcher
+  invocation count (`0` or `1`), and the exact refusal stage and error.
+- **INV-223-PRELAUNCH-SUPERSEDE** (CRITICAL). A pre-launch-death claim with an
+  unchanged head stays blocked; with a changed head — including a claim with no
+  recorded head — the re-attempt is admitted, appends a superseding claim naming
+  the previous head, and every prior marker and receipt still exists afterwards.
+  *Fails as:* an unchanged head being admitted; a changed head being refused; a
+  supersede that deletes, rewrites, or fails to name the superseded claim; a
+  prior receipt absent after the re-attempt; a legacy headless claim treated as
+  unchanged.
+  *Succeeds as:* a census printing recorded head, current head, verdict,
+  superseded head, and a before/after marker count that only grows.
+- **INV-223-MARKER-CENSUS-FAILS-CLOSED** (CRITICAL). When the marker census
+  command fails, the claim is refused.
+  *Fails as:* a failing census being read as "no marker present" and the claim
+  succeeding; a pipeline whose reader status masks the census status.
+  *Succeeds as:* a forced-census-failure case refusing the claim with a named
+  error, proved against a positive control where the same census succeeds.
+- **INV-223-HEAD-CROSSES-PROCESS** (CRITICAL). With no head injected into the
+  controller environment, the derived head is validated, is the exact value
+  every claim operation observes in its own child process, and an unresolvable
+  head fails closed at a named stage without claiming the day.
+  *Fails as:* a transport child observing an absent, empty, or different head;
+  an unresolvable head being treated as "changed" and admitting a re-attempt.
+  *Succeeds as:* an effect-log census naming the head each claim child observed,
+  plus a refused unresolvable-head case with zero markers written.
+- **INV-223-PROOFS-NONVACUOUS** (CRITICAL). Every protection above has a mutant
+  that is proved to have applied and is then rejected by the proof; the
+  deterministic fixture requires the same claim-operation set the production
+  transport implements.
+  *Fails as:* a mutation that silently does not apply; a proof green against its
+  own mutant; a fixture accepting a claim operation production does not
+  implement, or vice versa.
+  *Succeeds as:* a printed `mutants_rejected=<n>` census with `n` covering every
+  row, plus a mechanical fixture/production operation-set reconciliation.
+- **INV-223-SCOPE-AND-EFFECT-FENCE** (ADVISORY). The candidate touches only the
+  declared paths and reaches no real launch, dispatch, external repository
+  mutation, or credential material.
+  *Fails as:* a changed path outside the fence, or any real-launch, clone,
+  PR-create, merge, or workflow-run effect in the new cases.
+  *Succeeds as:* a mechanical path census and a zero-effect census.
+
+## Rejection behavior
+
+A refused claim exits non-zero, publishes an honest `outcome=FAILED` receipt
+naming its stage and error, and reaches no launcher and no mutation. An invalid
+day, an invalid head, a missing first-boundary command, and a failed transport
+child keep their existing stages and exit semantics. Superseding never removes
+a marker: issue #210 is append-only.
+
+## Non-goals
+
+No real Antithesis launch or rerun from any test; no edit to
+`lambdasistemi/amaru-bootstrap` or compose image refs; no receipt-schema change
+beyond the supersede and launch-claim additions; no weakening of #219
+evaluability or #221 propagation; no credential change; no issue #210 marker
+removal; no work on t75, #212, #208, #207, or #206; no merge and no dispatch by
+this ticket — the epic owner fires `production=true` after merge.

--- a/specs/223-manual-production-trigger/tasks.md
+++ b/specs/223-manual-production-trigger/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — Issue 223 manual production trigger and daily launch cap
+
+Artifact ceiling: 3,000 bytes and 70 lines.
+
+## Slice S223-01 — Manual production trigger with a code-enforced daily cap
+
+- [ ] **T2231** Commit an executable RED proof of every invariant row against
+  the unchanged base: routing census, dry-run byte-identity, cap under both
+  triggers, supersede in all four states (unchanged head, changed head, legacy
+  headless claim, post-launch day), fail-closed census, and head propagation.
+- [ ] **T2232** Add the typed `workflow_dispatch` boolean input `production`
+  (default `false`) and route `production=true` to the existing production job,
+  leaving the dry-run job's step body byte-unchanged and serialising the
+  concurrency group per the plan.
+- [ ] **T2233** Derive, validate, and export the workflow head in
+  `scripts/daily-amaru.sh` before the first transport child, refusing an
+  unresolvable or malformed head at its own named stage with nothing claimed.
+- [ ] **T2234** Implement the fail-closed marker census and the three claim
+  operations with the supersede rule in `scripts/daily-amaru-github.sh`, and
+  order the launch claim before the launcher in the controller.
+- [ ] **T2235** Bring the deterministic fixture to the production claim-operation
+  set, reconciled mechanically, and prove every protection able to fail with an
+  applied-then-rejected mutant.
+- [ ] **T2236** Keep every existing guard green and pass the frozen slice gate,
+  the ticket gate, complete local CI, a fresh independent audit, the final
+  tree/diff checks, and all six required contexts on the exact pushed head
+  without dispatch, launch, spend, merge, or same-day rerun.
+
+The ticket owner checks these entries only after an exact candidate receives a
+fresh audit verdict and an acceptance decision. The parked commit owner then
+includes the task stamp in the single final squashed behavior commit.

--- a/specs/223-manual-production-trigger/tasks.md
+++ b/specs/223-manual-production-trigger/tasks.md
@@ -4,24 +4,24 @@ Artifact ceiling: 3,000 bytes and 70 lines.
 
 ## Slice S223-01 — Manual production trigger with a code-enforced daily cap
 
-- [ ] **T2231** Commit an executable RED proof of every invariant row against
+- [x] **T2231** Commit an executable RED proof of every invariant row against
   the unchanged base: routing census, dry-run byte-identity, cap under both
   triggers, supersede in all four states (unchanged head, changed head, legacy
   headless claim, post-launch day), fail-closed census, and head propagation.
-- [ ] **T2232** Add the typed `workflow_dispatch` boolean input `production`
+- [x] **T2232** Add the typed `workflow_dispatch` boolean input `production`
   (default `false`) and route `production=true` to the existing production job,
   leaving the dry-run job's step body byte-unchanged and serialising the
   concurrency group per the plan.
-- [ ] **T2233** Derive, validate, and export the workflow head in
+- [x] **T2233** Derive, validate, and export the workflow head in
   `scripts/daily-amaru.sh` before the first transport child, refusing an
   unresolvable or malformed head at its own named stage with nothing claimed.
-- [ ] **T2234** Implement the fail-closed marker census and the three claim
+- [x] **T2234** Implement the fail-closed marker census and the three claim
   operations with the supersede rule in `scripts/daily-amaru-github.sh`, and
   order the launch claim before the launcher in the controller.
-- [ ] **T2235** Bring the deterministic fixture to the production claim-operation
+- [x] **T2235** Bring the deterministic fixture to the production claim-operation
   set, reconciled mechanically, and prove every protection able to fail with an
   applied-then-rejected mutant.
-- [ ] **T2236** Keep every existing guard green and pass the frozen slice gate,
+- [x] **T2236** Keep every existing guard green and pass the frozen slice gate,
   the ticket gate, complete local CI, a fresh independent audit, the final
   tree/diff checks, and all six required contexts on the exact pushed head
   without dispatch, launch, spend, merge, or same-day rerun.
@@ -29,3 +29,17 @@ Artifact ceiling: 3,000 bytes and 70 lines.
 The ticket owner checks these entries only after an exact candidate receives a
 fresh audit verdict and an acceptance decision. The parked commit owner then
 includes the task stamp in the single final squashed behavior commit.
+
+S223-01 ships with one accepted residual, `FU-223-EFFECT-CENSUS-CONTROL`
+(`INV-223-SCOPE-AND-EFFECT-FENCE`, ADVISORY): the whole-suite effect census
+discovers its own subject with `find` and never requires the discovered set to
+be non-empty, so a pattern matching nothing would print `effect_artifacts=0
+forbidden_effects=0` — absence of evidence rendered as evidence of absence.
+Owner: the #205 epic invariant ledger. Property class: a census that discovers
+its own subject must assert the subject set is non-empty and be shown able to
+detect a positive. The green that ships establishes that 117 effect artifacts
+were inspected and none carried a forbidden effect or credential sentinel, and
+that the path half of the fence rejects an injected out-of-fence path; it does
+not establish that this census would notice a forbidden effect. The underlying
+no-effect property remains independently protected by the pre-existing per-case
+business-effect guards, proved to fire.

--- a/tests/fixtures/daily-amaru/fake-gh.sh
+++ b/tests/fixtures/daily-amaru/fake-gh.sh
@@ -12,3 +12,39 @@ log_file=${DAILY_AMARU_FAKE_GH_LOG:?DAILY_AMARU_FAKE_GH_LOG is required}
   fi
   printf '\n'
 } >>"$log_file"
+
+comments_file=${DAILY_AMARU_FAKE_GH_COMMENTS:-}
+
+if [ "${1:-}" = api ]; then
+  for argument in "$@"; do
+    if [[ "$argument" == repos/*/issues/*/comments* ]]; then
+      if [ "${DAILY_AMARU_FAKE_GH_CENSUS_FAIL:-0}" = 1 ]; then
+        printf 'fake-gh: forced comment census failure\n' >&2
+        exit 70
+      fi
+      [ -z "$comments_file" ] || cat "$comments_file"
+      exit 0
+    fi
+  done
+fi
+
+if [ "${1:-}" = issue ] && [ "${2:-}" = comment ]; then
+  [ -n "$comments_file" ] || {
+    printf 'fake-gh: comment store is required\n' >&2
+    exit 64
+  }
+  body=''
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = --body ]; then
+      body=${2:?--body value is required}
+      break
+    fi
+    shift
+  done
+  [ -n "$body" ] || {
+    printf 'fake-gh: comment body is required\n' >&2
+    exit 64
+  }
+  printf '%s\n' "$body" >>"$comments_file"
+fi

--- a/tests/fixtures/daily-amaru/fake-transport.sh
+++ b/tests/fixtures/daily-amaru/fake-transport.sh
@@ -13,6 +13,9 @@ integrated_sha=4444444444444444444444444444444444444444
 image_ref="ghcr.io/lambdasistemi/amaru-bootstrap-producer:${bootstrap_sha}@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 mkdir -p "$state_dir"
+markers_file=$state_dir/markers
+receipt_history=$state_dir/receipt-history
+touch "$markers_file" "$receipt_history"
 
 log() {
   printf '%s' "$1" >>"$log_file"
@@ -37,6 +40,67 @@ identity_marker() {
     printf 'identity-present'
   else
     printf 'identity-absent'
+  fi
+}
+
+validate_head() {
+  [[ "$1" =~ ^[0-9a-f]{40}$ ]] || {
+    printf 'invalid workflow head: %s\n' "$1" >&2
+    return 1
+  }
+}
+
+claim_prelaunch_marker() {
+  local kind=$1 value=$2 head=$3 line marker legacy_marker current_prefix
+  local previous_head='' recorded_head='' found=0
+
+  if [ "$scenario" = census-failure ]; then
+    printf 'BLOCKED census-unreadable\n'
+    return 1
+  fi
+  if [ "$kind" = day ]; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$value"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
+        printf 'BLOCKED launch-consumed\n'
+        return 1
+      fi
+    done <"$markers_file"
+    legacy_marker="<!-- daily-amaru day=$value claim -->"
+    current_prefix="<!-- daily-amaru day=$value claim head="
+    marker="<!-- daily-amaru day=$value claim head=$head -->"
+  else
+    legacy_marker="<!-- daily-amaru attempted-sha=$value -->"
+    current_prefix="<!-- daily-amaru attempted-sha=$value head="
+    marker="<!-- daily-amaru attempted-sha=$value head=$head -->"
+  fi
+  while IFS= read -r line; do
+    if [ "$line" = "$legacy_marker" ]; then
+      found=1
+      previous_head=legacy
+      continue
+    fi
+    if [[ "$line" == "$current_prefix"*' -->' ]]; then
+      recorded_head=${line#"$current_prefix"}
+      recorded_head=${recorded_head%' -->'}
+      [[ "$recorded_head" =~ ^[0-9a-f]{40}$ ]] || continue
+      found=1
+      previous_head=$recorded_head
+      if [ "$recorded_head" = "$head" ]; then
+        printf 'BLOCKED unchanged-head\n'
+        return 1
+      fi
+    fi
+  done <"$markers_file"
+  printf '%s\n' "$marker" >>"$markers_file"
+  if [ "$kind" = day ]; then
+    printf '%s\n' "$value" >"$state_dir/day-claim"
+  else
+    printf '%s\n' "$value" >"$state_dir/attempted-sha"
+  fi
+  if [ "$found" -eq 0 ]; then
+    printf 'CLAIMED\n'
+  else
+    printf 'SUPERSEDED previous-head=%s\n' "$previous_head"
   fi
 }
 
@@ -66,12 +130,10 @@ case "$operation" in
 
   claim-day)
     day=${1:?day is required}
-    log claim-day "$day"
-    if [ -e "$state_dir/day-claim" ]; then
-      printf 'day already claimed\n' >&2
-      exit 1
-    fi
-    printf '%s\n' "$day" >"$state_dir/day-claim"
+    head=${2:?head is required}
+    validate_head "$head"
+    log claim-day "$day" "$head"
+    claim_prelaunch_marker day "$day" "$head"
     ;;
 
   resolve-upstream)
@@ -108,12 +170,26 @@ case "$operation" in
 
   claim-sha-attempt)
     sha=${1:?upstream SHA is required}
-    log claim-sha-attempt "$sha"
-    if [ -e "$state_dir/attempted-sha" ]; then
-      printf 'SHA already attempted\n' >&2
-      exit 1
-    fi
-    printf '%s\n' "$sha" >"$state_dir/attempted-sha"
+    head=${2:?head is required}
+    validate_head "$head"
+    log claim-sha-attempt "$sha" "$head"
+    claim_prelaunch_marker sha "$sha" "$head"
+    ;;
+
+  claim-launch)
+    day=${1:?day is required}
+    head=${2:?head is required}
+    validate_head "$head"
+    log claim-launch "$day" "$head"
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$day"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
+        printf 'BLOCKED launch-consumed\n'
+        exit 1
+      fi
+    done <"$markers_file"
+    printf '<!-- daily-amaru day=%s launch-consumed head=%s -->\n' \
+      "$day" "$head" >>"$markers_file"
+    printf 'CLAIMED\n'
     ;;
 
   propose-bootstrap)
@@ -221,6 +297,8 @@ case "$operation" in
     log receipt "$@"
     : >"$receipt_file"
     printf '%s\n' "$@" >>"$receipt_file"
+    printf '%s\n' '--- receipt ---' >>"$receipt_history"
+    printf '%s\n' "$@" >>"$receipt_history"
     ;;
 
   *)

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -7,12 +7,32 @@ transport="$repo_root/scripts/daily-amaru-github.sh"
 workflow="$repo_root/.github/workflows/daily-amaru.yaml"
 fake_transport="$repo_root/tests/fixtures/daily-amaru/fake-transport.sh"
 fake_gh="$repo_root/tests/fixtures/daily-amaru/fake-gh.sh"
+pre_slice_base=cd8144bdd7d3996ccc63e159227a6376e822df2c
+default_workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
+}
+
+ensure_history_commit() {
+  local repository=$1 commit=$2
+  if git -C "$repository" cat-file -e "$commit^{commit}" 2>/dev/null; then
+    return 0
+  fi
+  if ! git -C "$repository" fetch --no-tags --depth=1 origin "$commit" \
+    >/dev/null 2>&1; then
+    printf 'HISTORY-BASE-UNAVAILABLE repository=%s commit=%s fetch=failed\n' \
+      "$repository" "$commit" >&2
+    return 1
+  fi
+  if ! git -C "$repository" cat-file -e "$commit^{commit}" 2>/dev/null; then
+    printf 'HISTORY-BASE-UNAVAILABLE repository=%s commit=%s fetch=incomplete\n' \
+      "$repository" "$commit" >&2
+    return 1
+  fi
 }
 
 pass() {
@@ -139,25 +159,38 @@ run_case() {
   local identity=${3-test-identity}
   local app_id=${4-}
   local app_key=${5-}
+  local head_source=${6:-daily:$default_workflow_head}
+  local shared_state=${7:-}
+  local controller_under_test=${8:-$controller}
+  local head_env=()
   case_number=$((case_number + 1))
   case_dir="$tmp_root/$case_number-$case_name"
-  case_state="$case_dir/state"
+  case_state=${shared_state:-$case_dir/state}
   case_log="$case_dir/transport.log"
   case_receipt="$case_dir/receipt"
   case_stdout="$case_dir/stdout"
   case_stderr="$case_dir/stderr"
-  mkdir -p "$case_state"
+  mkdir -p "$case_state" "$case_dir"
   : >"$case_log"
 
   if [ "$case_name" = duplicate-same-day ]; then
-    printf '2026-07-31-existing-claim\n' >"$case_state/day-claim"
+    printf '<!-- daily-amaru day=2026-07-31 claim head=%s -->\n' \
+      "$default_workflow_head" >"$case_state/markers"
   fi
   if [ "$case_name" = same-sha-retry ]; then
-    printf '1111111111111111111111111111111111111111\n' >"$case_state/attempted-sha"
+    printf '<!-- daily-amaru attempted-sha=1111111111111111111111111111111111111111 head=%s -->\n' \
+      "$default_workflow_head" >"$case_state/markers"
   fi
 
+  case "$head_source" in
+    daily:*) head_env=(DAILY_AMARU_HEAD="${head_source#daily:}") ;;
+    github:*) head_env=(GITHUB_SHA="${head_source#github:}") ;;
+    absent) head_env=() ;;
+    *) fail "unknown head source: $head_source" ;;
+  esac
+
   case_rc=0
-  env \
+  env -u DAILY_AMARU_HEAD -u GITHUB_SHA \
     FAKE_SCENARIO="$case_name" \
     FAKE_LOG="$case_log" \
     DAILY_AMARU_TRANSPORT="$fake_transport" \
@@ -169,7 +202,8 @@ run_case() {
     DAILY_AMARU_STATE_DIR="$case_state" \
     DAILY_AMARU_RECEIPT="$case_receipt" \
     DAILY_AMARU_ALLOW_REAL=1 \
-    "$controller" >"$case_stdout" 2>"$case_stderr" || case_rc=$?
+    "${head_env[@]}" \
+    "$controller_under_test" >"$case_stdout" 2>"$case_stderr" || case_rc=$?
 }
 
 bash_binary=$(command -v bash)
@@ -208,6 +242,7 @@ run_hermetic_case() {
     DAILY_AMARU_FAKE_GH_LOG="$hermetic_effects" \
     DAILY_AMARU_EFFECT_LOG="$hermetic_effects" \
     DAILY_AMARU_MODE=production \
+    GITHUB_SHA="$default_workflow_head" \
     "${day_env[@]}" \
     DAILY_AMARU_IDENTITY=seed-non-empty-identity \
     DAILY_AMARU_STATE_DIR="$hermetic_state" \
@@ -256,7 +291,7 @@ transport_branch() {
 
 bootstrap_boundary_operations=(propose-bootstrap require-bootstrap-checks)
 repository_boundary_operations=(
-  claim-day last-success-sha claim-sha-attempt prepare-consumer-repin
+  claim-day last-success-sha claim-sha-attempt claim-launch prepare-consumer-repin
   require-consumer-checks await-supervised-integration real-launch receipt
 )
 
@@ -288,6 +323,56 @@ require_failure() {
   [ "$case_rc" -ne 0 ] || fail "scenario=$case_name expected failure"
 }
 
+job_condition() {
+  awk -v job="  $2:" '
+    $0 == job { inside = 1; next }
+    inside && /^  [A-Za-z0-9_-]+:/ { exit }
+    inside && /^    if: / { sub(/^    if: /, ""); print; exit }
+  ' "$1"
+}
+
+workflow_job_steps() {
+  awk -v job="  $2:" '
+    $0 == job { inside = 1; next }
+    inside && /^  [A-Za-z0-9_-]+:/ { exit }
+    inside && $0 == "    steps:" { steps = 1 }
+    inside && steps { print }
+  ' "$1"
+}
+
+routing_holds() {
+  local file=$1 dispatch production dry
+  dispatch=$(awk '
+    /^  workflow_dispatch:$/ { inside = 1 }
+    inside && /^  pull_request:/ { exit }
+    inside { print }
+  ' "$file")
+  grep -Fqx '  workflow_dispatch:' <<<"$dispatch" || return 1
+  grep -Fqx '      production:' <<<"$dispatch" || return 1
+  grep -Fqx '        type: boolean' <<<"$dispatch" || return 1
+  grep -Fqx '        default: false' <<<"$dispatch" || return 1
+  production=$(job_condition "$file" daily-amaru-scheduled)
+  dry=$(job_condition "$file" daily-amaru-dry-run)
+  [ "$production" = "github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.production)" ] || return 1
+  [ "$dry" = "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.production)" ] || return 1
+  [ "$(grep -Ec '^  daily-amaru-scheduled:$' "$file" || true)" -eq 1 ] || return 1
+  [ "$(grep -Ec '^[[:space:]]+scripts/daily-amaru[.]sh$' "$file" || true)" -eq 1 ] || return 1
+  # shellcheck disable=SC2016
+  grep -Fqx '  group: daily-amaru-${{ github.ref }}' "$file" || return 1
+  grep -Fqx '  cancel-in-progress: false' "$file" || return 1
+}
+
+dry_run_steps_identical() {
+  local file=$1 repository=${2:-$repo_root}
+  local base_commit=${3:-$pre_slice_base}
+  local base_workflow=$tmp_root/pre-slice-workflow.yaml
+  git -C "$repository" show \
+    "$base_commit:.github/workflows/daily-amaru.yaml" >"$base_workflow" || return 1
+  cmp -s \
+    <(workflow_job_steps "$file" daily-amaru-dry-run) \
+    <(workflow_job_steps "$base_workflow" daily-amaru-dry-run)
+}
+
 if [ ! -x "$fake_transport" ]; then
   fail "fake transport is absent or not executable: $fake_transport"
 fi
@@ -309,6 +394,13 @@ fi
 if [ ! -f "$workflow" ]; then
   fail "scheduled workflow absent: expected regular file $workflow"
 fi
+
+ensure_history_commit "$repo_root" "$pre_slice_base" ||
+  fail "history baseline unavailable: $pre_slice_base"
+
+# Complete #223 proof bundle is intentionally RED on the unchanged base.
+routing_holds "$workflow" ||
+  fail 'INV-223-DISPATCH-ROUTING: typed manual production routing is absent'
 
 oracle_root="$tmp_root/receipt-oracle"
 mkdir -p "$oracle_root"
@@ -580,19 +672,23 @@ pass '#202-zero'
 
 run_case duplicate-same-day
 require_failure
-assert_file_contains "$case_state/day-claim" '2026-07-31-existing-claim'
+assert_file_contains "$case_state/markers" \
+  "<!-- daily-amaru day=2026-07-31 claim head=$default_workflow_head -->"
 assert_log_count 0 '^resolve-upstream '
 assert_no_mutation
 assert_no_launch
 assert_honest_failure_receipt day-claim
+assert_file_contains "$case_receipt" 'error=unchanged-head'
 pass duplicate-same-day
 
 run_case same-sha-retry
 require_failure
-assert_file_contains "$case_state/attempted-sha" '1111111111111111111111111111111111111111'
+assert_file_contains "$case_state/markers" \
+  "<!-- daily-amaru attempted-sha=1111111111111111111111111111111111111111 head=$default_workflow_head -->"
 assert_no_mutation
 assert_no_launch
 assert_honest_failure_receipt launch-attempt
+assert_file_contains "$case_receipt" 'error=unchanged-head'
 pass same-sha-retry
 
 run_case failed-stage
@@ -833,8 +929,10 @@ wiring_holds() {
 }
 wiring_holds "$workflow" ||
   fail 'the workflow does not executably call both controller entry points'
-assert_workflow_literal_once "if: github.event_name != 'schedule'"
-assert_workflow_literal_once "if: github.event_name == 'schedule'"
+assert_workflow_literal_once \
+  "if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.production)"
+assert_workflow_literal_once \
+  "if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.production)"
 assert_workflow_literal_once 'DAILY_AMARU_MODE: production'
 assert_workflow_literal_once 'uses: actions/upload-artifact@v6'
 [ "$(count_literal "$workflow" 'if: always()')" -eq 2 ] ||
@@ -989,6 +1087,7 @@ env \
   FAKE_LOG="$generic_id_dir/transport.log" \
   DAILY_AMARU_TRANSPORT="$fake_transport" \
   DAILY_AMARU_MODE=production \
+  GITHUB_SHA="$default_workflow_head" \
   DAILY_AMARU_DAY=2026-07-31 \
   DAILY_AMARU_IDENTITY="" \
   DAILY_AMARU_STATE_DIR="$generic_id_dir/state" \
@@ -1155,6 +1254,7 @@ run_omitted_day_case() {
     FAKE_LOG="$case_log" \
     DAILY_AMARU_TRANSPORT="$fake_transport" \
     DAILY_AMARU_MODE=test \
+    GITHUB_SHA="$default_workflow_head" \
     DAILY_AMARU_IDENTITY=test-identity \
     DAILY_AMARU_STATE_DIR="$case_state" \
     DAILY_AMARU_RECEIPT="$case_receipt" \
@@ -1347,3 +1447,841 @@ for forbidden in 'repo clone' 'pr create' 'pr merge' 'workflow run' 'run watch';
   fi
 done
 pass omitted-day-receipts-survive-failure
+
+# ---------------------------------------------------------------------------
+# Issue #223 — manual production routing and controller-owned daily launch cap.
+# ---------------------------------------------------------------------------
+
+claim_call() {
+  local root=$1 script=$2 census_failure=$3 operation=$4
+  shift 4
+  mkdir -p "$root/bin"
+  ln -sf "$fake_gh" "$root/bin/gh"
+  [ "$(PATH="$root/bin:$PATH" command -v gh)" = "$root/bin/gh" ] ||
+    fail 'claim harness did not resolve the deterministic gh fixture'
+  claim_stdout=$root/stdout
+  claim_stderr=$root/stderr
+  claim_rc=0
+  env \
+    PATH="$root/bin:$PATH" \
+    GH_TOKEN=fake-repository-token \
+    DAILY_AMARU_FAKE_GH_LOG="$root/gh.log" \
+    DAILY_AMARU_FAKE_GH_COMMENTS="$root/comments" \
+    DAILY_AMARU_FAKE_GH_CENSUS_FAIL="$census_failure" \
+    DAILY_AMARU_STATE_DIR="$root/state" \
+    DAILY_AMARU_RECEIPT="$root/receipt" \
+    bash "$script" "$operation" "$@" \
+    >"$claim_stdout" 2>"$claim_stderr" || claim_rc=$?
+  claim_output=$(cat "$claim_stdout")
+}
+
+launch_cap_holds() {
+  local script=$1 root
+  root=$(mktemp -d "$tmp_root/launch-cap.XXXXXX")
+  mkdir -p "$root/state"
+  : >"$root/comments"
+  : >"$root/gh.log"
+  claim_call "$root" "$script" 0 claim-day 2026-08-19 \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  [ "$claim_rc" -eq 0 ] && [ "$claim_output" = CLAIMED ] || return 1
+  claim_call "$root" "$script" 0 claim-launch 2026-08-19 \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  [ "$claim_rc" -eq 0 ] && [ "$claim_output" = CLAIMED ] || return 1
+  claim_call "$root" "$script" 0 claim-day 2026-08-19 \
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  [ "$claim_rc" -ne 0 ] && [ "$claim_output" = 'BLOCKED launch-consumed' ] || return 1
+  [ "$(grep -c 'launch-consumed' "$root/comments" || true)" -eq 1 ]
+}
+
+supersede_holds() {
+  local script=$1 root before after
+  root=$(mktemp -d "$tmp_root/supersede.XXXXXX")
+  mkdir -p "$root/state"
+  printf '<!-- daily-amaru day=2026-08-19 claim head=%s -->\n' \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa >"$root/comments"
+  : >"$root/gh.log"
+  before=$(wc -l <"$root/comments")
+  claim_call "$root" "$script" 0 claim-day 2026-08-19 \
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  [ "$claim_rc" -ne 0 ] && [ "$claim_output" = 'BLOCKED unchanged-head' ] || return 1
+  claim_call "$root" "$script" 0 claim-day 2026-08-19 \
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  [ "$claim_rc" -eq 0 ] &&
+    [ "$claim_output" = 'SUPERSEDED previous-head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ] || return 1
+  after=$(wc -l <"$root/comments")
+  [ "$after" -eq $((before + 1)) ] || return 1
+  grep -Fqx '<!-- daily-amaru day=2026-08-19 claim head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->' \
+    "$root/comments"
+}
+
+census_failure_holds() {
+  local script=$1 operation positive_root failure_root before after
+  local -a arguments
+  census_positive_controls=0
+  census_forced_failures=0
+  census_unchanged_stores=0
+  for operation in claim-day claim-sha-attempt claim-launch; do
+    case "$operation" in
+      claim-sha-attempt)
+        arguments=(1111111111111111111111111111111111111111 \
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+        ;;
+      *)
+        arguments=(2026-08-20 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+        ;;
+    esac
+    positive_root=$(mktemp -d "$tmp_root/census-positive.XXXXXX")
+    failure_root=$(mktemp -d "$tmp_root/census-failure.XXXXXX")
+    mkdir -p "$positive_root/state" "$failure_root/state"
+    : >"$positive_root/comments"
+    : >"$positive_root/gh.log"
+    : >"$failure_root/comments"
+    : >"$failure_root/gh.log"
+    claim_call "$positive_root" "$script" 0 "$operation" "${arguments[@]}"
+    [ "$claim_rc" -eq 0 ] && [ "$claim_output" = CLAIMED ] || return 1
+    census_positive_controls=$((census_positive_controls + 1))
+    before=$(sha256sum "$failure_root/comments" | awk '{print $1}')
+    claim_call "$failure_root" "$script" 1 "$operation" "${arguments[@]}"
+    after=$(sha256sum "$failure_root/comments" | awk '{print $1}')
+    [ "$claim_rc" -ne 0 ] && [ "$claim_output" = 'BLOCKED census-unreadable' ] &&
+      [ "$before" = "$after" ] || return 1
+    census_forced_failures=$((census_forced_failures + 1))
+    census_unchanged_stores=$((census_unchanged_stores + 1))
+  done
+}
+
+claim_operations() {
+  grep -E '^  claim-(day|sha-attempt|launch)\)$' "$1" |
+    sed 's/^  //; s/)$//' | sort -u
+}
+
+claim_operation_sets_match() {
+  local production=$1 fixture=$2
+  [ "$(claim_operations "$production")" = "$(claim_operations "$fixture")" ] &&
+    [ "$(claim_operations "$production" | grep -c . || true)" -eq 3 ]
+}
+
+declare -A issue_223_mutant_invariant=()
+issue_223_declared_invariants=(
+  INV-223-DISPATCH-ROUTING
+  INV-223-DRY-RUN-BYTE-UNCHANGED
+  INV-223-ONE-LAUNCH-PER-DAY
+  INV-223-PRELAUNCH-SUPERSEDE
+  INV-223-MARKER-CENSUS-FAILS-CLOSED
+  INV-223-HEAD-CROSSES-PROCESS
+  INV-223-PROOFS-NONVACUOUS
+  INV-223-SCOPE-AND-EFFECT-FENCE
+)
+issue_223_declared_mutants=(
+  routing-string-input
+  dry-run-byte
+  launch-cap-exit-open
+  supersede-inverted
+  census-open
+  head-export-removed
+  fixture-claim-launch-removed
+  claim-after-launch
+  legacy-marker-ignored
+  legacy-verdict-corrupted
+  sha-prefix-blinded
+  launch-marker-blinded
+  receipt-workflow-head-removed
+  receipt-supersedes-removed
+  receipt-launch-claim-removed
+  receipt-launch-cap-write-removed
+  scope-path-outside-fence
+  history-base-unavailable
+)
+issue_223_allowed_paths=(
+  .github/workflows/daily-amaru.yaml
+  scripts/daily-amaru.sh
+  scripts/daily-amaru-github.sh
+  tests/test-daily-amaru.sh
+  tests/test-workflow-validation.sh
+  tests/fixtures/daily-amaru/fake-transport.sh
+  tests/fixtures/daily-amaru/fake-gh.sh
+  specs/223-manual-production-trigger/tasks.md
+)
+
+register_223_mutant() {
+  local invariant=$1 label=$2
+  [ -z "${issue_223_mutant_invariant[$label]:-}" ] ||
+    fail "duplicate #223 mutant registration: $label"
+  issue_223_mutant_invariant[$label]=$invariant
+}
+
+reject_223_mutant() {
+  local invariant=$1 label=$2
+  shift 2
+  reject_mutant "$@"
+  register_223_mutant "$invariant" "$label"
+}
+
+evaluate_job_condition() {
+  local condition=$1 event=$2 input=$3
+  case "$condition" in
+    "github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.production)")
+      [ "$event" = schedule ] ||
+        { [ "$event" = workflow_dispatch ] && [ "$input" = true ]; }
+      ;;
+    "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.production)")
+      [ "$event" = pull_request ] ||
+        { [ "$event" = workflow_dispatch ] && [ "$input" = false ]; }
+      ;;
+    *) return 2 ;;
+  esac
+}
+
+routing_truth_table_holds() {
+  local file=$1 production dry row event input expected_production expected_dry
+  local actual_production actual_dry
+  production=$(job_condition "$file" daily-amaru-scheduled)
+  dry=$(job_condition "$file" daily-amaru-dry-run)
+  routing_census_rows=()
+  routing_cases=(
+    'schedule|false|1|0'
+    'workflow_dispatch|true|1|0'
+    'workflow_dispatch|false|0|1'
+    'pull_request|false|0|1'
+  )
+  for row in "${routing_cases[@]}"; do
+    IFS='|' read -r event input expected_production expected_dry <<<"$row"
+    actual_production=0
+    evaluate_job_condition "$production" "$event" "$input" && actual_production=1
+    actual_dry=0
+    evaluate_job_condition "$dry" "$event" "$input" && actual_dry=1
+    [ "$actual_production" -eq "$expected_production" ] &&
+      [ "$actual_dry" -eq "$expected_dry" ] || return 1
+    routing_census_rows+=("event=$event production_input=$input production=$actual_production dry_run=$actual_dry")
+  done
+}
+
+claim_backend_call() {
+  local backend=$1 root=$2 script=$3 operation=$4
+  shift 4
+  if [ "$backend" = production ]; then
+    claim_call "$root" "$script" 0 "$operation" "$@"
+    return
+  fi
+  mkdir -p "$root/state"
+  : >"$root/fixture.log"
+  claim_stdout=$root/stdout
+  claim_stderr=$root/stderr
+  claim_rc=0
+  env \
+    FAKE_SCENARIO=changed \
+    FAKE_LOG="$root/fixture.log" \
+    DAILY_AMARU_STATE_DIR="$root/state" \
+    DAILY_AMARU_RECEIPT="$root/receipt" \
+    bash "$script" "$operation" "$@" \
+    >"$claim_stdout" 2>"$claim_stderr" || claim_rc=$?
+  claim_output=$(cat "$claim_stdout")
+}
+
+claim_verdict_table_holds() {
+  local script=$1 backend=$2 row kind prior expected_output expected_rc
+  local root store operation value marker before after appended
+  local old_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  local new_head=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  claim_verdict_rows=(
+    'day|none|CLAIMED|0'
+    'day|legacy|SUPERSEDED previous-head=legacy|0'
+    'day|same|BLOCKED unchanged-head|1'
+    'day|changed|SUPERSEDED previous-head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0'
+    'day|launched|BLOCKED launch-consumed|1'
+    'sha|none|CLAIMED|0'
+    'sha|legacy|SUPERSEDED previous-head=legacy|0'
+    'sha|same|BLOCKED unchanged-head|1'
+    'sha|changed|SUPERSEDED previous-head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|0'
+    'launch|none|CLAIMED|0'
+    'launch|launched|BLOCKED launch-consumed|1'
+  )
+  # Operation names ending in "-day" are strings, not arithmetic updates.
+  # shellcheck disable=SC2100
+  for row in "${claim_verdict_rows[@]}"; do
+    IFS='|' read -r kind prior expected_output expected_rc <<<"$row"
+    root=$(mktemp -d "$tmp_root/verdict-$backend.XXXXXX")
+    mkdir -p "$root/state"
+    if [ "$backend" = production ]; then
+      store=$root/comments
+      : >"$root/gh.log"
+    else
+      store=$root/state/markers
+    fi
+    : >"$store"
+    case "$kind" in
+      day)
+        operation=claim-day
+        value=2026-08-21
+        marker="<!-- daily-amaru day=$value claim head=$new_head -->"
+        ;;
+      sha)
+        operation=claim-sha-attempt
+        value=1111111111111111111111111111111111111111
+        marker="<!-- daily-amaru attempted-sha=$value head=$new_head -->"
+        ;;
+      launch)
+        operation=claim-launch
+        value=2026-08-21
+        marker="<!-- daily-amaru day=$value launch-consumed head=$new_head -->"
+        ;;
+    esac
+    case "$prior" in
+      none) ;;
+      legacy)
+        if [ "$kind" = day ]; then
+          printf '<!-- daily-amaru day=%s claim -->\n' "$value" >"$store"
+        else
+          printf '<!-- daily-amaru attempted-sha=%s -->\n' "$value" >"$store"
+        fi
+        ;;
+      same)
+        printf '%s\n' "${marker%"$new_head" -->}$new_head -->" >"$store"
+        ;;
+      changed)
+        printf '%s\n' "${marker%"$new_head" -->}$old_head -->" >"$store"
+        ;;
+      launched)
+        printf '<!-- daily-amaru day=%s launch-consumed head=%s -->\n' \
+          "$value" "$old_head" >"$store"
+        ;;
+    esac
+    before=$(wc -l <"$store")
+    claim_backend_call "$backend" "$root" "$script" "$operation" "$value" "$new_head"
+    if [ "$claim_output" != "$expected_output" ]; then
+      printf 'claim verdict mismatch backend=%s kind=%s prior=%s expected=%s actual=%s\n' \
+        "$backend" "$kind" "$prior" "$expected_output" "$claim_output" >&2
+      return 1
+    fi
+    if { [ "$expected_rc" -eq 0 ] && [ "$claim_rc" -ne 0 ]; } ||
+      { [ "$expected_rc" -ne 0 ] && [ "$claim_rc" -eq 0 ]; }; then
+      printf 'claim exit mismatch backend=%s kind=%s prior=%s expected=%s actual=%s\n' \
+        "$backend" "$kind" "$prior" "$expected_rc" "$claim_rc" >&2
+      return 1
+    fi
+    after=$(wc -l <"$store")
+    appended=0
+    if [ "$expected_rc" -eq 0 ]; then
+      [ "$after" -eq $((before + 1)) ] || return 1
+      tail -n 1 "$store" | grep -Fqx -- "$marker" || return 1
+      appended=1
+    else
+      [ "$after" -eq "$before" ] || return 1
+    fi
+    claim_verdict_observations+=("backend=$backend kind=$kind prior=$prior stdout=$claim_output exit=$expected_rc appended=$appended")
+  done
+}
+
+production_claim_verdict_table_holds() {
+  claim_verdict_table_holds "$1" production 2>/dev/null
+}
+
+effect_order_holds() {
+  local script=$1 claim effect claim_line effect_line
+  ordered_claim_effect_pairs=0
+  run_case order-proof production token app key \
+    daily:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb '' "$script"
+  [ "$case_rc" -eq 0 ] || return 1
+  for claim in 'claim-day ' 'claim-sha-attempt '; do
+    claim_line=$(grep -n -m1 "^$claim" "$case_log" | cut -d: -f1)
+    for effect in 'mutation:bootstrap ' 'mutation:image ' 'mutation:repin ' 'real-launch '; do
+      effect_line=$(grep -n -m1 "^$effect" "$case_log" | cut -d: -f1)
+      [ -n "$claim_line" ] && [ -n "$effect_line" ] &&
+        [ "$claim_line" -lt "$effect_line" ] || return 1
+      ordered_claim_effect_pairs=$((ordered_claim_effect_pairs + 1))
+    done
+  done
+  claim_line=$(grep -n -m1 '^claim-launch ' "$case_log" | cut -d: -f1)
+  effect_line=$(grep -n -m1 '^real-launch ' "$case_log" | cut -d: -f1)
+  [ -n "$claim_line" ] && [ -n "$effect_line" ] &&
+    [ "$claim_line" -lt "$effect_line" ] || return 1
+  ordered_claim_effect_pairs=$((ordered_claim_effect_pairs + 1))
+}
+
+receipt_model_keys() {
+  awk '
+    /^## Receipt fields added$/ { inside = 1; next }
+    inside && /^## / { exit }
+    inside && /^\| `/ {
+      sub(/^\| `/, "")
+      sub(/`.*/, "")
+      print
+    }
+  ' "$repo_root/specs/223-manual-production-trigger/data-model.md"
+}
+
+receipt_model_holds() {
+  local script=$1 state key history
+  state=$(mktemp -d "$tmp_root/receipt-model.XXXXXX")
+  run_case failed-stage production token app key \
+    daily:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$state" "$script"
+  [ "$case_rc" -ne 0 ] || return 1
+  run_case changed production token app key \
+    daily:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "$state" "$script"
+  [ "$case_rc" -eq 0 ] || return 1
+  history=$state/receipt-history
+  mapfile -t receipt_declared_keys < <(receipt_model_keys)
+  [ "${#receipt_declared_keys[@]}" -gt 0 ] || return 1
+  for key in "${receipt_declared_keys[@]}"; do
+    if ! grep -Eq "^$key=" "$history"; then
+      printf 'receipt model key lacks durable evidence: %s\n' "$key" >&2
+      return 1
+    fi
+  done
+  if ! awk -v head=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb '
+    BEGIN { RS="--- receipt ---\n"; found=0 }
+    $0 ~ /(^|\n)stage=launch-cap(\n|$)/ &&
+    $0 ~ /(^|\n)outcome=CLAIMED(\n|$)/ &&
+    $0 ~ "(^|\\n)workflow_head=" head "(\\n|$)" &&
+    $0 ~ /(^|\n)launch_claim=consumed(\n|$)/ { found++ }
+    END { exit(found == 1 ? 0 : 1) }
+  ' "$history"; then
+    printf 'launch-cap receipt lacks exact workflow_head/outcome/launch_claim evidence\n' >&2
+    return 1
+  fi
+}
+
+
+receipt_model_mutant_rejected() {
+  receipt_model_holds "$1" 2>/dev/null
+}
+
+paths_within_223_fence() {
+  local path allowed allowed_path
+  for path in "$@"; do
+    allowed=0
+    for allowed_path in "${issue_223_allowed_paths[@]}"; do
+      [ "$path" = "$allowed_path" ] && allowed=1
+    done
+    [ "$allowed" -eq 1 ] || return 1
+  done
+}
+
+history_base_controls() {
+  local seed=$tmp_root/history-seed
+  local origin=$tmp_root/history-origin.git
+  local positive=$tmp_root/history-positive
+  local negative=$tmp_root/history-negative
+  local control_base
+  local changed_output negative_error=$tmp_root/history-negative.stderr
+  local -a control_paths=()
+
+  git init --quiet --initial-branch=main "$seed" || return 1
+  git -C "$seed" config user.name history-control || return 1
+  git -C "$seed" config user.email history-control@example.invalid || return 1
+  mkdir -p "$seed/.github/workflows" "$seed/tests" || return 1
+  cp "$workflow" "$seed/.github/workflows/daily-amaru.yaml" || return 1
+  printf 'base\n' >"$seed/tests/test-daily-amaru.sh"
+  git -C "$seed" add . || return 1
+  git -C "$seed" commit --quiet -m base || return 1
+  control_base=$(git -C "$seed" rev-parse HEAD) || return 1
+  printf 'head\n' >"$seed/tests/test-daily-amaru.sh"
+  git -C "$seed" commit --quiet -am head || return 1
+  git clone --quiet --bare "$seed" "$origin" || return 1
+
+  git clone --quiet --depth=1 --single-branch --branch main \
+    "file://$origin" "$positive" || return 1
+  [ "$(git -C "$positive" rev-list --count HEAD)" -eq 1 ] || return 1
+  ! git -C "$positive" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
+  ensure_history_commit "$positive" "$control_base" || return 1
+  git -C "$positive" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
+  dry_run_steps_identical \
+    "$positive/.github/workflows/daily-amaru.yaml" "$positive" "$control_base" || return 1
+  changed_output=$(git -C "$positive" diff --name-only "$control_base" --) || return 1
+  mapfile -t control_paths < <(printf '%s' "$changed_output")
+  [ "${#control_paths[@]}" -gt 0 ] || return 1
+  paths_within_223_fence "${control_paths[@]}" || return 1
+
+  git clone --quiet --depth=1 --single-branch --branch main \
+    "file://$origin" "$negative" || return 1
+  ! git -C "$negative" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
+  git -C "$negative" remote set-url origin \
+    "file://$tmp_root/missing-origin.git" || return 1
+  if ensure_history_commit "$negative" "$control_base" \
+    >"$tmp_root/history-negative.stdout" 2>"$negative_error"; then
+    return 1
+  fi
+  grep -Fqx "HISTORY-BASE-UNAVAILABLE repository=$negative commit=$control_base fetch=failed" \
+    "$negative_error" || return 1
+  ! git -C "$negative" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
+
+  register_223_mutant INV-223-PROOFS-NONVACUOUS history-base-unavailable
+  history_positive_fetches=1
+  history_negative_refusals=1
+  history_dry_run_checks=1
+  history_path_censuses=1
+}
+
+head_propagation_holds() {
+  local script=$1 head=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  run_case head-property production token app key "github:$head" '' "$script"
+  [ "$case_rc" -eq 0 ] || return 1
+  grep -Fqx "claim-day 2026-07-31 $head" "$case_log" || return 1
+  grep -Fqx "claim-sha-attempt 1111111111111111111111111111111111111111 $head" \
+    "$case_log" || return 1
+  grep -Fqx "claim-launch 2026-07-31 $head" "$case_log"
+}
+
+history_base_controls || fail 'history baseline controls did not hold'
+routing_holds "$workflow" || fail 'typed dispatch routing is not exact'
+routing_truth_table_holds "$workflow" || fail 'observed workflow conditions failed their truth table'
+dry_run_steps_identical "$workflow" || fail 'dry-run steps changed from the frozen base'
+base_workflow_snapshot=$tmp_root/pre-slice-workflow-for-hash.yaml
+git -C "$repo_root" show "$pre_slice_base:.github/workflows/daily-amaru.yaml" \
+  >"$base_workflow_snapshot" || fail 'history baseline workflow is unreadable'
+base_dry_hash=$(workflow_job_steps "$base_workflow_snapshot" daily-amaru-dry-run |
+  sha256sum | awk '{print $1}')
+current_dry_hash=$(workflow_job_steps "$workflow" daily-amaru-dry-run |
+  sha256sum | awk '{print $1}')
+
+for routing_row in "${routing_census_rows[@]}"; do
+  printf 'ROUTING %s\n' "$routing_row"
+done
+
+# Both production-trigger orderings reach exactly one fake real-launch effect.
+trigger_pairs=(schedule-dispatch dispatch-schedule)
+launch_scenario_launches=()
+for trigger_pair in "${trigger_pairs[@]}"; do
+  first=${trigger_pair%-*}
+  second=${trigger_pair#*-}
+  pair_state="$tmp_root/cap-$trigger_pair"
+  mkdir -p "$pair_state"
+  run_case "$first-first" production token app key \
+    daily:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$pair_state"
+  require_success
+  assert_log_count 1 '^real-launch '
+  run_case "$second-second" production token app key \
+    daily:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "$pair_state"
+  require_failure
+  assert_no_launch
+  assert_honest_failure_receipt day-claim
+  assert_file_contains "$case_receipt" 'error=launch-consumed'
+  launches=$(cat "$pair_state/real-launch-count")
+  [ "$launches" -eq 1 ] || fail "$trigger_pair reached $launches launch effects"
+  launch_scenario_launches+=("$launches")
+  printf 'LAUNCH-SCENARIO first=%s second=%s day=2026-07-31 launches=%s refusal_stage=day-claim error=launch-consumed\n' \
+    "$first" "$second" "$launches"
+done
+
+# A pre-launch death is blocked at the same head and superseded at a new head.
+prelaunch_state="$tmp_root/prelaunch-state"
+mkdir -p "$prelaunch_state"
+run_case failed-stage production token app key \
+  daily:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$prelaunch_state"
+require_failure
+assert_honest_failure_receipt bootstrap-proposal
+markers_before=$(wc -l <"$prelaunch_state/markers")
+receipts_before=$(grep -c '^--- receipt ---$' "$prelaunch_state/receipt-history" || true)
+run_case prelaunch-unchanged production token app key \
+  daily:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$prelaunch_state"
+require_failure
+assert_honest_failure_receipt day-claim
+assert_file_contains "$case_receipt" 'error=unchanged-head'
+run_case prelaunch-changed production token app key \
+  daily:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "$prelaunch_state"
+require_success
+markers_after=$(wc -l <"$prelaunch_state/markers")
+receipts_after=$(grep -c '^--- receipt ---$' "$prelaunch_state/receipt-history" || true)
+[ "$markers_after" -gt "$markers_before" ] || fail 'supersede did not append markers'
+[ "$receipts_after" -gt "$receipts_before" ] || fail 'supersede lost prior receipts'
+assert_file_contains "$case_receipt" \
+  'claim_supersedes=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+printf 'SUPERSEDE-SCENARIO recorded_head=%s current_head=%s verdict=SUPERSEDED superseded_head=%s markers_before=%s markers_after=%s receipts_before=%s receipts_after=%s\n' \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  "$markers_before" "$markers_after" "$receipts_before" "$receipts_after"
+
+# A legacy headless claim differs from every valid current head and is retained.
+legacy_state="$tmp_root/legacy-state"
+mkdir -p "$legacy_state"
+printf '%s\n%s\n' \
+  '<!-- daily-amaru day=2026-07-31 claim -->' \
+  '<!-- daily-amaru attempted-sha=1111111111111111111111111111111111111111 -->' \
+  >"$legacy_state/markers"
+legacy_before=$(wc -l <"$legacy_state/markers")
+run_case legacy-supersede production token app key \
+  daily:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "$legacy_state"
+require_success
+legacy_after=$(wc -l <"$legacy_state/markers")
+[ "$legacy_after" -gt "$legacy_before" ] || fail 'legacy supersede did not append'
+assert_file_contains "$legacy_state/markers" '<!-- daily-amaru day=2026-07-31 claim -->'
+assert_file_contains "$case_receipt" 'claim_supersedes=legacy'
+printf 'SUPERSEDE-SCENARIO recorded_head=legacy current_head=%s verdict=SUPERSEDED superseded_head=legacy markers_before=%s markers_after=%s\n' \
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "$legacy_before" "$legacy_after"
+
+# The production transport itself fails closed when its census command fails.
+census_failure_holds "$transport" || fail 'failed marker census admitted a claim'
+launch_cap_holds "$transport" || fail 'production transport admitted a post-launch claim'
+supersede_holds "$transport" || fail 'production transport violated the supersede rule'
+
+# The controller derives GITHUB_SHA once and every claim child observes it.
+head_propagation_holds "$controller" || fail 'workflow head did not cross every claim child'
+invalid_heads=(absent daily:not-a-sha)
+for invalid_head in "${invalid_heads[@]}"; do
+  run_case "head-${invalid_head%%:*}" test token '' '' "$invalid_head"
+  require_failure
+  assert_honest_failure_receipt head-resolution
+  assert_log_count 0 '^claim-(day|sha-attempt|launch) '
+done
+
+# Production and deterministic transports expose exactly the same claim set.
+claim_operation_sets_match "$transport" "$fake_transport" ||
+  fail 'fixture and production claim operation sets differ'
+
+# The behavioral table is one oracle driven against both implementations.
+claim_verdict_observations=()
+claim_verdict_table_holds "$transport" production ||
+  fail 'production transport failed the claim verdict table'
+claim_verdict_table_holds "$fake_transport" fixture ||
+  fail 'deterministic transport failed the claim verdict table'
+claim_verdict_rows_per_backend=${#claim_verdict_rows[@]}
+claim_verdict_backends=2
+printf 'CLAIM-VERDICT-TABLE rows_per_backend=%s backends=%s observations=%s\n' \
+  "$claim_verdict_rows_per_backend" "$claim_verdict_backends" \
+  "${#claim_verdict_observations[@]}"
+
+# Actual effect-log indexes prove each durable guard precedes what it guards.
+effect_order_holds "$controller" ||
+  fail 'durable claim operations did not precede their guarded effects'
+
+# Every receipt key added by the data model is exercised in durable history.
+receipt_model_holds "$controller" ||
+  fail 'declared #223 receipt fields lack executing durable evidence'
+
+# Applied-then-rejected mutants, one for every critical #223 protection.
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-DISPATCH-ROUTING routing-string-input \
+  dispatch-string-form.yaml "$workflow" \
+  's/inputs[.]production/github.event.inputs.production/g' \
+  'github.event.inputs.production' \
+  'the truthy string-form dispatch input' routing_truth_table_holds
+
+reject_223_mutant INV-223-DRY-RUN-BYTE-UNCHANGED dry-run-byte \
+  dry-run-byte.yaml "$workflow" \
+  's/Exercise the controller through the fake transport/Exercise changed dry-run body/' \
+  'Exercise changed dry-run body' \
+  'a changed dry-run step body' dry_run_steps_identical
+
+reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY launch-cap-exit-open \
+  launch-cap-open.sh "$transport" \
+  's/return 1 # launch-consumed-final/return 0 # launch-consumed-final/' \
+  'return 0 # launch-consumed-final' \
+  'a launch-consumed verdict that exits successfully' launch_cap_holds
+
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-PRELAUNCH-SUPERSEDE supersede-inverted \
+  supersede-inverted.sh "$transport" \
+  's/if \[ "$recorded_head" = "$head" \]; then # unchanged-head-guard/if [ "$recorded_head" != "$head" ]; then # unchanged-head-guard/' \
+  'if [ "$recorded_head" != "$head" ]; then # unchanged-head-guard' \
+  'an inverted unchanged-head guard' supersede_holds
+
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-MARKER-CENSUS-FAILS-CLOSED census-open \
+  census-open.sh "$transport" \
+  's/if ! census=$(marker_census); then # census-fails-closed/if census=$(marker_census); then # census-fails-closed/' \
+  'if census=$(marker_census); then # census-fails-closed' \
+  'a census failure interpreted as an empty census' census_failure_holds
+
+head_mutant="$mutant_root/controller-no-head-export.sh"
+sed '/^export DAILY_AMARU_HEAD=/d' "$controller" >"$head_mutant"
+grep -Fq 'export DAILY_AMARU_HEAD=' "$controller" ||
+  fail 'head propagation mutation has no production line to remove'
+! grep -Fq 'export DAILY_AMARU_HEAD=' "$head_mutant" ||
+  fail 'head propagation mutation did not apply'
+if head_propagation_holds "$head_mutant"; then
+  fail 'controller without head export passed propagation proof'
+fi
+register_223_mutant INV-223-HEAD-CROSSES-PROCESS head-export-removed
+
+fixture_claim_mutant="$mutant_root/fake-transport-no-claim-launch.sh"
+sed 's/^  claim-launch)$/  claim-launch-disabled)/' "$fake_transport" \
+  >"$fixture_claim_mutant"
+grep -Fqx '  claim-launch-disabled)' "$fixture_claim_mutant" ||
+  fail 'fixture claim-set mutation did not apply'
+if claim_operation_sets_match "$transport" "$fixture_claim_mutant"; then
+  fail 'claim operation reconciliation accepted a missing fixture operation'
+fi
+register_223_mutant INV-223-PROOFS-NONVACUOUS fixture-claim-launch-removed
+
+# F1: move the launch claim after the launch effect; the log-order proof must kill it.
+order_mutant="$mutant_root/controller-claim-after-launch.sh"
+awk '
+  /^  claim_operation launch-cap claim-launch no / { next }
+  /^  receipt\[launch_claim\]=consumed$/ { next }
+  /^  write_receipt launch-cap CLAIMED$/ { next }
+  /^  fail_stage launch submission-failed$/ { after_launch_failure = 1 }
+  { print }
+  after_launch_failure && /^fi$/ {
+    print ""
+    print "if [ \"$mode\" = production ]; then"
+    print "  claim_operation launch-cap claim-launch no \"$day\" \"$head\""
+    print "  receipt[launch_claim]=consumed"
+    print "  write_receipt launch-cap CLAIMED"
+    print "fi"
+    after_launch_failure = 0
+  }
+' "$controller" >"$order_mutant"
+[ "$(grep -n '^  claim_operation launch-cap ' "$order_mutant" | cut -d: -f1)" -gt \
+  "$(grep -n '^if ! launch_request=' "$order_mutant" | cut -d: -f1)" ] ||
+  fail 'claim-after-launch mutation did not apply'
+if effect_order_holds "$order_mutant"; then
+  fail 'effect-order proof accepted a launch claim after the launcher'
+fi
+register_223_mutant INV-223-ONE-LAUNCH-PER-DAY claim-after-launch
+
+# F2: production-transport defect classes are all judged by the shared table.
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-PRELAUNCH-SUPERSEDE legacy-marker-ignored \
+  legacy-marker-ignored.sh "$transport" \
+  's/if \[ "$line" = "$legacy_marker" \]; then/if [ "$line" = "ignored-$legacy_marker" ]; then/' \
+  'if [ "$line" = "ignored-$legacy_marker" ]; then' \
+  'a legacy claim ignored by production' production_claim_verdict_table_holds
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-PRELAUNCH-SUPERSEDE legacy-verdict-corrupted \
+  legacy-verdict-corrupted.sh "$transport" \
+  's/previous_head=legacy/previous_head=unrecognized/' \
+  'previous_head=unrecognized' \
+  'a legacy claim reported with an unrecognized predecessor' production_claim_verdict_table_holds
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-PRELAUNCH-SUPERSEDE sha-prefix-blinded \
+  sha-prefix-blinded.sh "$transport" \
+  's/attempted-sha=$value head=/attempted-sha-blind=$value head=/' \
+  'attempted-sha-blind=$value head=' \
+  'a SHA claim scan with the wrong marker prefix' production_claim_verdict_table_holds
+reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY launch-marker-blinded \
+  launch-marker-blinded.sh "$transport" \
+  's/launch-consumed\\ head=/launch-blind\\ head=/g' \
+  'launch-blind\ head=' \
+  'a launch claim scan blind to consumed markers' production_claim_verdict_table_holds
+
+# F5: remove each modeled receipt artifact and require executing evidence to fail.
+# The mutation expressions intentionally match literal shell variable syntax.
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-HEAD-CROSSES-PROCESS receipt-workflow-head-removed \
+  receipt-workflow-head-removed.sh "$controller" \
+  '/^receipt\[workflow_head\]=\$head$/d' \
+  '!receipt[workflow_head]=$head' \
+  'a controller that omits workflow_head receipts' receipt_model_mutant_rejected
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-PRELAUNCH-SUPERSEDE receipt-supersedes-removed \
+  receipt-supersedes-removed.sh "$controller" \
+  '/receipt\[claim_supersedes\]=\$previous_head/d' \
+  '!receipt[claim_supersedes]=$previous_head' \
+  'a controller that omits claim_supersedes receipts' receipt_model_mutant_rejected
+reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY receipt-launch-claim-removed \
+  receipt-launch-claim-removed.sh "$controller" \
+  '/^  receipt\[launch_claim\]=consumed$/d' \
+  '!receipt[launch_claim]=consumed' \
+  'a controller that omits launch_claim receipts' receipt_model_mutant_rejected
+reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY receipt-launch-cap-write-removed \
+  receipt-launch-cap-write-removed.sh "$controller" \
+  '/^  write_receipt launch-cap CLAIMED$/d' \
+  '!write_receipt launch-cap CLAIMED' \
+  'a controller that never durably writes the launch-cap receipt' receipt_model_mutant_rejected
+
+allowed_path_count=${#issue_223_allowed_paths[@]}
+changed_paths_output=$(git -C "$repo_root" diff --name-only "$pre_slice_base" --) ||
+  fail 'history baseline path diff is unreadable'
+mapfile -t changed_paths < <(printf '%s' "$changed_paths_output")
+paths_within_223_fence "${changed_paths[@]}" || fail 'changed path outside #223 fence'
+scope_mutant_paths=("${changed_paths[@]}" outside/issue-223-mutant)
+[ "${#scope_mutant_paths[@]}" -eq $((${#changed_paths[@]} + 1)) ] ||
+  fail 'scope path mutation did not apply'
+if paths_within_223_fence "${scope_mutant_paths[@]}"; then
+  fail 'scope fence accepted an out-of-scope path'
+fi
+register_223_mutant INV-223-SCOPE-AND-EFFECT-FENCE scope-path-outside-fence
+
+# Derive the effect fence from artifacts produced by the executing harness.
+mapfile -t issue_223_effect_artifacts < <(
+  find "$tmp_root" -type f \( -name transport.log -o -name gh.log -o -name effects \)
+)
+forbidden_effects=0
+credential_material_hits=0
+for effect_artifact in "${issue_223_effect_artifacts[@]}"; do
+  for forbidden in 'gh workflow run' 'repo clone' 'pr create' 'pr merge' 'run watch'; do
+    if grep -Fq -- "$forbidden" "$effect_artifact"; then
+      forbidden_effects=$((forbidden_effects + 1))
+    fi
+  done
+  for credential_sentinel in "$secret_value" "$prod_id" "$prod_app" "$prod_key"; do
+    if grep -Fq -- "$credential_sentinel" "$effect_artifact"; then
+      credential_material_hits=$((credential_material_hits + 1))
+    fi
+  done
+done
+[ "$forbidden_effects" -eq 0 ] || fail "effect fence observed $forbidden_effects forbidden effects"
+[ "$credential_material_hits" -eq 0 ] ||
+  fail "effect fence observed $credential_material_hits credential material hits"
+
+# The census itself is executable: registry drift or an untested invariant fails.
+mapfile -t registered_mutants < <(printf '%s\n' "${!issue_223_mutant_invariant[@]}" | sort)
+mapfile -t declared_mutants < <(printf '%s\n' "${issue_223_declared_mutants[@]}" | sort)
+proof_residuals=$(comm -3 \
+  <(printf '%s\n' "${registered_mutants[@]}") \
+  <(printf '%s\n' "${declared_mutants[@]}") | grep -c . || true)
+[ "$proof_residuals" -eq 0 ] ||
+  fail "#223 mutant registry drift: registered=${registered_mutants[*]} declared=${declared_mutants[*]}"
+for invariant in "${issue_223_declared_invariants[@]}"; do
+  invariant_mutants=0
+  for mutant in "${registered_mutants[@]}"; do
+    [ "${issue_223_mutant_invariant[$mutant]}" = "$invariant" ] &&
+      invariant_mutants=$((invariant_mutants + 1))
+  done
+  [ "$invariant_mutants" -gt 0 ] || fail "invariant has no rejecting mutant: $invariant"
+done
+
+# Re-run the live observations after mutant predicates so all reported counts
+# are measurements of the candidate, never side effects left by a rejected mutant.
+routing_truth_table_holds "$workflow" || fail 'final routing census failed'
+census_failure_holds "$transport" || fail 'final marker census failed'
+effect_order_holds "$controller" || fail 'final effect-order census failed'
+claim_verdict_observations=()
+claim_verdict_table_holds "$transport" production || fail 'final production verdict census failed'
+claim_verdict_table_holds "$fake_transport" fixture || fail 'final fixture verdict census failed'
+receipt_model_holds "$controller" || fail 'final receipt-model census failed'
+claim_operation_count=$(claim_operations "$transport" | grep -c . || true)
+production_jobs=$(grep -Ec '^  daily-amaru-scheduled:$' "$workflow" || true)
+controller_callers=$(grep -Ec '^[[:space:]]+scripts/daily-amaru[.]sh$' "$workflow" || true)
+launches_per_day=${launch_scenario_launches[0]}
+for launches in "${launch_scenario_launches[@]}"; do
+  [ "$launches" -eq "$launches_per_day" ] || fail 'launch scenario counts disagree'
+done
+routing_mutants=0
+dry_run_mutants=0
+launch_cap_mutants=0
+for mutant in "${registered_mutants[@]}"; do
+  case "${issue_223_mutant_invariant[$mutant]}" in
+    INV-223-DISPATCH-ROUTING) routing_mutants=$((routing_mutants + 1)) ;;
+    INV-223-DRY-RUN-BYTE-UNCHANGED) dry_run_mutants=$((dry_run_mutants + 1)) ;;
+    INV-223-ONE-LAUNCH-PER-DAY) launch_cap_mutants=$((launch_cap_mutants + 1)) ;;
+  esac
+done
+printf 'DISPATCH-ROUTING rows=%s production_jobs=%s controller_callers=%s mutants_rejected=%s\n' \
+  "${#routing_census_rows[@]}" "$production_jobs" "$controller_callers" \
+  "$routing_mutants"
+printf 'DRY-RUN-BYTE-IDENTITY base=%s current=%s mutants_rejected=%s\n' \
+  "$base_dry_hash" "$current_dry_hash" "$dry_run_mutants"
+printf 'LAUNCH-CAP trigger_pairs=%s launches_per_day=%s refusal=launch-consumed ordered_claim_effect_pairs=%s mutants_rejected=%s\n' \
+  "${#trigger_pairs[@]}" "$launches_per_day" "$ordered_claim_effect_pairs" \
+  "$launch_cap_mutants"
+printf 'PRELAUNCH-SUPERSEDE unchanged=blocked changed=admitted legacy=admitted append_only=1 table_rows=%s\n' \
+  "$claim_verdict_rows_per_backend"
+printf 'CENSUS-FAILS-CLOSED operations=%s positive_controls=%s forced_failures=%s comments_unchanged=%s\n' \
+  "$claim_operation_count" "$census_positive_controls" "$census_forced_failures" \
+  "$census_unchanged_stores"
+printf 'HEAD-PROPAGATION source=GITHUB_SHA claims_observed=%s invalid_heads_refused=%s receipt_keys=%s\n' \
+  "$claim_operation_count" "${#invalid_heads[@]}" "${#receipt_declared_keys[@]}"
+printf 'CLAIM-OPERATION-RECONCILIATION operations=%s matched=1 verdict_observations=%s\n' \
+  "$claim_operation_count" "${#claim_verdict_observations[@]}"
+printf 'HISTORY-BASE-CONTROLS positive_fetches=%s negative_refusals=%s dry_run_checks=%s path_censuses=%s mutants_rejected=1\n' \
+  "$history_positive_fetches" "$history_negative_refusals" \
+  "$history_dry_run_checks" "$history_path_censuses"
+printf 'SCOPE-EFFECT-FENCE changed_paths=%s allowed_paths=%s effect_artifacts=%s forbidden_effects=%s credential_material_hits=%s\n' \
+  "${#changed_paths[@]}" "$allowed_path_count" "${#issue_223_effect_artifacts[@]}" \
+  "$forbidden_effects" "$credential_material_hits"
+printf 'PROOF-CENSUS invariants=%s claim_operations=%s mutants_rejected=%s residuals=%s\n' \
+  "${#issue_223_declared_invariants[@]}" "$claim_operation_count" \
+  "${#registered_mutants[@]}" "$proof_residuals"
+pass issue-223-manual-production-cap


### PR DESCRIPTION
Closes #223

## What

Makes the Daily Amaru production path testable on demand while moving the spend
cap out of "only the schedule can fire" and into the controller's own
claim/marker code.

- `workflow_dispatch` gains a typed boolean input `production` (default
  `false`). `false` and every `pull_request` run exactly the existing dry-run
  job, byte-unchanged; `true` runs the same production job the schedule runs —
  one definition, no parallel path.
- Markers on issue #210 gain the two facts they were missing: which workflow
  head made a claim, and whether the day's one real launch is already spent. The
  cap is then enforced identically for both triggers, and the launch claim is
  published *before* the launcher, so an attempt that dies at the launcher
  consumes the day rather than silently freeing it.
- A day claimed by an attempt that died BEFORE launching is re-attemptable iff
  the workflow head has moved since that claim; the re-attempt appends a
  superseding claim naming the previous head. A claim with no recorded head —
  every marker written before this change, including 2026-08-19 — counts as a
  differing head. Issue #210 stays append-only: both attempts' markers and
  receipts survive. A day whose launch was claimed is never superseded again
  that day.
- The marker census now fails closed. Previously `issue_bodies | grep -Fqx`
  inside `if` was fail-open: with `pipefail`, a failed `gh` made the pipeline
  non-zero, the `if` read false, and the claim proceeded as though no marker
  existed — a transient GitHub error could authorise a second launch.

## Proof

Every protection is exercised in `tests/test-daily-amaru.sh` — the proof this
repository actually runs in hosted CI — and each is shown able to fail with a
mutant proved to have applied before its red is believed. The suite carries a
mutant registry whose counts are derived from the registry rather than written
as constants, a routing truth table evaluated over condition strings extracted
from the workflow file, an 11-row verdict table driven against both the
production transport and the deterministic fixture so the fixture cannot mask a
production defect, an ordering assertion read from the captured effect log, and
a receipt-model check driven from the declared key list.

No test reaches a real Antithesis launch, a real dispatch, an external
repository mutation, or credential material.

Three independent audits ran against this branch; the accepted head carries
0 blocking findings and one named ADVISORY residual,
`FU-223-EFFECT-CENSUS-CONTROL`, recorded in `tasks.md`.

GitHub's own expression evaluator is not executable locally: the first real
`production=true` dispatch is that boundary's smoke.

Contract: `specs/223-manual-production-trigger/`.
