### PR TITLE
fix: close the transport value channel and make the bootstrap proposal re-attempt-safe

### DIFF
--- a/.github/workflows/daily-amaru.yaml
+++ b/.github/workflows/daily-amaru.yaml
@@ -29,8 +29,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Exercise the controller through the fake transport
-        run: tests/test-daily-amaru.sh
+      - uses: paolino/dev-assets/setup-nix@v0.0.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Run the canonical proof entry
+        run: nix develop --quiet -c just ci
 
   daily-amaru-scheduled:
     name: Daily Amaru production run

--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -81,14 +81,14 @@ claim_prelaunch_marker() {
   local current_prefix previous_head='' recorded_head='' found=0
 
   if ! census=$(marker_census); then # census-fails-closed
-    printf 'BLOCKED census-unreadable\n'
+    emit 'BLOCKED census-unreadable'
     return 1
   fi
 
   if [ "$kind" = day ]; then
     while IFS= read -r line; do
       if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$value"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
-        printf 'BLOCKED launch-consumed\n'
+        emit 'BLOCKED launch-consumed'
         return 1 # launch-consumed-final
       fi
     done <<<"$census"
@@ -114,7 +114,7 @@ claim_prelaunch_marker() {
       found=1
       previous_head=$recorded_head
       if [ "$recorded_head" = "$head" ]; then # unchanged-head-guard
-        printf 'BLOCKED unchanged-head\n'
+        emit 'BLOCKED unchanged-head'
         return 1
       fi
     fi
@@ -122,9 +122,9 @@ claim_prelaunch_marker() {
 
   comment_issue "$marker"
   if [ "$found" -eq 0 ]; then
-    printf 'CLAIMED\n'
+    emit 'CLAIMED'
   else
-    printf 'SUPERSEDED previous-head=%s\n' "$previous_head"
+    emit "SUPERSEDED previous-head=$previous_head"
   fi
 }
 
@@ -174,14 +174,66 @@ create_or_find_pr() {
 
   if ! url=$(with_identity "$identity" gh pr create -R "$target_repository" \
     --base main --head "$branch" --title "$title" --body "$body" 2>/dev/null); then
-    url=$(with_identity "$identity" gh pr view "$branch" -R "$target_repository" \
-      --json url --jq .url)
+    url=$(find_pr "$target_repository" "$branch" "$identity")
   fi
   printf '%s\n' "$url"
 }
 
+find_pr() {
+  local target_repository=$1
+  local branch=$2
+  local identity=$3
+
+  with_identity "$identity" gh pr view "$branch" -R "$target_repository" \
+    --json url --jq .url
+}
+
+classify_proposal_branch() {
+  local directory=$1
+  local branch=$2
+  local upstream_sha=$3
+  local input_node=$4
+  local remote_ref="refs/remotes/origin/$branch"
+  local merge_base changed_output lock
+  local -a changed=()
+
+  if ! git -C "$directory" show-ref --verify --quiet "$remote_ref"; then
+    printf 'absent\n'
+    return 0
+  fi
+
+  merge_base=$(git -C "$directory" merge-base origin/main "$remote_ref") || return 1
+  changed_output=$(git -C "$directory" diff --name-only "$merge_base" "$remote_ref") ||
+    return 1
+  mapfile -t changed < <(printf '%s' "$changed_output")
+  if [ "${#changed[@]}" -ne 1 ] || [ "${changed[0]}" != flake.lock ]; then
+    printf 'foreign\n'
+    return 0
+  fi
+
+  lock=$(git -C "$directory" show "$remote_ref:flake.lock") || return 1
+  if jq -e --arg node "$input_node" --arg sha "$upstream_sha" '
+      .nodes[$node].original.owner == "pragma-org" and
+      .nodes[$node].original.repo == "amaru" and
+      .nodes[$node].locked.rev == $sha
+    ' <<<"$lock" >/dev/null; then
+    printf 'adoptable\n'
+  else
+    printf 'foreign\n'
+  fi
+}
+
 operation=${1:?transport operation is required}
 shift
+
+# Reserve the caller's stdout once, then make ordinary stdout diagnostic for
+# the complete dispatch. Only emit can reach the operation-value channel.
+exec {value_fd}>&1
+exec 1>&2
+
+emit() {
+  printf '%s\n' "$@" >&"$value_fd"
+}
 
 case "$operation" in
   preflight)
@@ -193,12 +245,11 @@ case "$operation" in
     fi
     for command in "${requirements[@]}"; do
       if ! command -v "$command" >/dev/null 2>&1; then
-        printf 'MISSING-COMMAND %s\n' "$command"
+        emit "MISSING-COMMAND $command"
         die "missing command: $command"
       fi
     done
-    printf 'OK: %s scheduled dependencies present: %s\n' \
-      "${#requirements[@]}" "${requirements[*]}"
+    emit "OK: ${#requirements[@]} scheduled dependencies present: ${requirements[*]}"
     ;;
 
   claim-day)
@@ -217,16 +268,17 @@ case "$operation" in
     ref=${2:?ref is required}
     git ls-remote --heads "$origin" "$ref" |
       while IFS=$'\t' read -r sha observed_ref; do
-        printf '%s|%s|%s\n' "$origin" "$observed_ref" "$sha"
+        emit "$origin|$observed_ref|$sha"
       done
     ;;
 
   last-success-sha)
     # repository-token-permissions: issues=read
     require_commands gh sed tail
-    issue_bodies |
+    last_success=$(issue_bodies |
       sed -nE 's/^<!-- daily-amaru last-success sha=([0-9a-f]{40}) -->$/\1/p' |
-      tail -n 1
+      tail -n 1)
+    [ -z "$last_success" ] || emit "$last_success"
     ;;
 
   claim-sha-attempt)
@@ -247,17 +299,17 @@ case "$operation" in
     [[ "$day" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || die "invalid UTC day: $day"
     validate_head "$head"
     if ! census=$(marker_census); then # census-fails-closed
-      printf 'BLOCKED census-unreadable\n'
+      emit 'BLOCKED census-unreadable'
       exit 1
     fi
     while IFS= read -r line; do
       if [[ "$line" =~ ^\<\!--\ daily-amaru\ day="$day"\ launch-consumed\ head=[0-9a-f]{40}\ --\>$ ]]; then
-        printf 'BLOCKED launch-consumed\n'
+        emit 'BLOCKED launch-consumed'
         exit 1 # launch-consumed-final
       fi
     done <<<"$census"
     comment_issue "<!-- daily-amaru day=$day launch-consumed head=$head -->"
-    printf 'CLAIMED\n'
+    emit 'CLAIMED'
     ;;
 
   propose-bootstrap)
@@ -269,7 +321,6 @@ case "$operation" in
 
     [ ! -e "$directory" ] || die "bootstrap workspace already exists: $directory"
     with_identity "$bootstrap_identity" gh repo clone "$bootstrap_repository" "$directory" -- --filter=blob:none
-    git -C "$directory" checkout -b "$branch" origin/main
 
     # TODO(amaru-bootstrap#75): replace this crude stock-pin proposal with
     # the validated producer handoff once that contract lands.
@@ -287,30 +338,48 @@ case "$operation" in
     ' "$directory/flake.lock")
     [ -n "$input_name" ] || die 'expected exactly one root input for the stock Amaru node'
 
-    (
-      cd "$directory"
-      nix flake lock --override-input "$input_name" "github:pragma-org/amaru/$upstream_sha"
-    )
-    mapfile -t changed < <(git -C "$directory" diff --name-only)
-    [ "${#changed[@]}" -eq 1 ] && [ "${changed[0]}" = flake.lock ] ||
-      die 'stock-pin proposal changed a path other than flake.lock'
-    jq -e --arg node "$input_node" --arg sha "$upstream_sha" '
-      .nodes[$node].original.owner == "pragma-org" and
-      .nodes[$node].original.repo == "amaru" and
-      .nodes[$node].locked.rev == $sha
-    ' "$directory/flake.lock" >/dev/null || die 'stock Amaru lock validation failed'
+    proposal_state=$(classify_proposal_branch \
+      "$directory" "$branch" "$upstream_sha" "$input_node") ||
+      die 'proposal branch classification failed'
+    case "$proposal_state" in
+      adoptable)
+        bootstrap_head=$(git -C "$directory" rev-parse "refs/remotes/origin/$branch")
+        pr_url=$(find_pr "$bootstrap_repository" "$branch" "$bootstrap_identity")
+        printf '%s\n' "$pr_url" >"$state_dir/bootstrap-pr"
+        emit "$bootstrap_head"
+        ;;
+      foreign)
+        die 'foreign-proposal-branch'
+        ;;
+      absent)
+        git -C "$directory" checkout -b "$branch" origin/main
+        (
+          cd "$directory"
+          nix flake lock --override-input "$input_name" "github:pragma-org/amaru/$upstream_sha"
+        )
+        mapfile -t changed < <(git -C "$directory" diff --name-only)
+        [ "${#changed[@]}" -eq 1 ] && [ "${changed[0]}" = flake.lock ] ||
+          die 'stock-pin proposal changed a path other than flake.lock'
+        jq -e --arg node "$input_node" --arg sha "$upstream_sha" '
+          .nodes[$node].original.owner == "pragma-org" and
+          .nodes[$node].original.repo == "amaru" and
+          .nodes[$node].locked.rev == $sha
+        ' "$directory/flake.lock" >/dev/null || die 'stock Amaru lock validation failed'
 
-    git -C "$directory" add flake.lock
-    git -C "$directory" -c user.name='daily-amaru' \
-      -c user.email='daily-amaru@users.noreply.github.com' \
-      commit -m "chore: bump stock Amaru to $upstream_sha"
-    push_branch "$directory" "$branch" "$bootstrap_identity"
-    pr_url=$(create_or_find_pr "$bootstrap_repository" "$branch" \
-      "chore: bump stock Amaru to ${upstream_sha:0:12}" \
-      "Daily Amaru controller proposal for exact upstream $upstream_sha." \
-      "$bootstrap_identity")
-    printf '%s\n' "$pr_url" >"$state_dir/bootstrap-pr"
-    git -C "$directory" rev-parse HEAD
+        git -C "$directory" add flake.lock
+        git -C "$directory" -c user.name='daily-amaru' \
+          -c user.email='daily-amaru@users.noreply.github.com' \
+          commit -m "chore: bump stock Amaru to $upstream_sha"
+        push_branch "$directory" "$branch" "$bootstrap_identity"
+        pr_url=$(create_or_find_pr "$bootstrap_repository" "$branch" \
+          "chore: bump stock Amaru to ${upstream_sha:0:12}" \
+          "Daily Amaru controller proposal for exact upstream $upstream_sha." \
+          "$bootstrap_identity")
+        printf '%s\n' "$pr_url" >"$state_dir/bootstrap-pr"
+        emit "$(git -C "$directory" rev-parse HEAD)"
+        ;;
+      *) die "invalid proposal branch classification: $proposal_state" ;;
+    esac
     ;;
 
   require-bootstrap-checks)
@@ -325,7 +394,7 @@ case "$operation" in
         <<<"$rows")
       [ "$count" -eq 1 ] || die "bootstrap check is not uniquely successful on $candidate: $name"
     done
-    printf '%s\n' "$rows"
+    emit "$rows"
     ;;
 
   resolve-image)
@@ -335,7 +404,7 @@ case "$operation" in
     digest=$(docker buildx imagetools inspect "$image_tag" \
       --format '{{json .Manifest.Digest}}' | tr -d '"')
     [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "invalid registry digest: $digest"
-    printf '%s@%s\n' "$image_tag" "$digest"
+    emit "$image_tag@$digest"
     ;;
 
   prepare-consumer-repin)
@@ -373,7 +442,7 @@ case "$operation" in
       "Daily Amaru controller repin to $image_ref. Integration is lane-supervised." \
       "$repository_identity")
     printf '%s\n' "$pr_url" >"$state_dir/consumer-pr"
-    git -C "$directory" rev-parse HEAD
+    emit "$(git -C "$directory" rev-parse HEAD)"
     ;;
 
   require-consumer-checks)
@@ -392,7 +461,7 @@ case "$operation" in
       [ "$count" -eq 1 ] ||
         die "consumer check is not uniquely successful on $candidate: $workflow / $name"
     done
-    printf '%s\n' "$rows"
+    emit "$rows"
     ;;
 
   run-producer-check)
@@ -401,10 +470,12 @@ case "$operation" in
     directory=$state_dir/consumer
     [ "$(git -C "$directory" rev-parse HEAD)" = "$candidate" ] ||
       die 'consumer workspace is not at the exact candidate head'
-    (
+    producer_evidence=$(
       cd "$directory"
       scripts/check-amaru-producer-image-refs.sh
     )
+    printf '%s\n' "$producer_evidence" >&2
+    emit "$producer_evidence"
     ;;
 
   await-supervised-integration)
@@ -425,7 +496,7 @@ case "$operation" in
     main_head=$(with_identity "$repository_identity" gh api "repos/$repository/git/ref/heads/main" \
       --jq .object.sha)
     [ "$main_head" = "$merged" ] || die 'merged consumer commit is not exact current main'
-    printf '%s\n' "$merged"
+    emit "$merged"
     ;;
 
   fake-launch)
@@ -434,8 +505,7 @@ case "$operation" in
     duration=${3:?duration is required}
     no_faults=${4:?fault setting is required}
     integrated=${5:?integrated SHA is required}
-    printf 'fake://%s/%s/%s/%s/%s\n' \
-      "$workflow" "$testnet" "$duration" "$no_faults" "$integrated"
+    emit "fake://$workflow/$testnet/$duration/$no_faults/$integrated"
     ;;
 
   real-launch)
@@ -466,7 +536,7 @@ case "$operation" in
     done
     [ -n "$run_id" ] || die 'launched workflow run was not observable'
     with_identity "$repository_identity" gh run watch "$run_id" -R "$repository" --exit-status
-    printf 'https://github.com/%s/actions/runs/%s\n' "$repository" "$run_id"
+    emit "https://github.com/$repository/actions/runs/$run_id"
     ;;
 
   receipt)

--- a/specs/225-transport-value-channel/data-model.md
+++ b/specs/225-transport-value-channel/data-model.md
@@ -1,0 +1,62 @@
+# Data model
+
+## D-225-1 Transport output streams
+
+| Stream | Carries | Consumer |
+|---|---|---|
+| value channel | exactly the operation's value, nothing else | the controller's `$(...)` capture |
+| diagnostic stream | every subcommand's stdout and stderr, and the transport's own diagnostics | the run log |
+
+Invariant: no subcommand may reach the value channel. The reservation happens
+once, at the transport's dispatch boundary, before any operation runs.
+
+## D-225-2 Operation value census
+
+Complete classification of `scripts/daily-amaru-github.sh` at base `01f96e4`.
+The exact value shapes are the contract the controller already validates.
+
+| Operation | Value | Controller validation | Class-A status at base |
+|---|---|---|---|
+| `preflight` | `OK: <n> scheduled dependencies present: <list>` or `MISSING-COMMAND <name>` | regex | clean |
+| `claim-day` | `CLAIMED` \| `SUPERSEDED previous-head=<sha>` \| `BLOCKED <reason>` | exact match | clean |
+| `claim-sha-attempt` | as `claim-day` | exact match | clean |
+| `claim-launch` | as `claim-day` | exact match | clean |
+| `resolve-upstream` | one `origin\|ref\|sha` line | field split + regex | clean |
+| `last-success-sha` | 40-hex SHA or empty | regex | clean |
+| `propose-bootstrap` | 40-hex SHA | regex | **POLLUTED — fired**: `git commit` summary |
+| `require-bootstrap-checks` | check rows | not consumed | clean |
+| `resolve-image` | `<image>:<sha>@sha256:<digest>` | regex | clean |
+| `prepare-consumer-repin` | 40-hex SHA | regex | **POLLUTED — unfired**: `git commit` summary |
+| `require-consumer-checks` | check rows | per-row field split | clean |
+| `run-producer-check` | `OK: <n> producer-image reference(s), all pinned to <ref>` | whole-string regex | fragile: the checker's whole stdout is the value |
+| `await-supervised-integration` | 40-hex SHA | regex | clean |
+| `fake-launch` | `fake://...` | none | clean |
+| `real-launch` | `https://github.com/<repo>/actions/runs/<id>` | **none** | **POLLUTED — unfired**: `gh workflow run` confirmation and `gh run watch` progress, stored raw into the receipt |
+| `receipt` | no value | n/a | n/a |
+
+`real-launch` is the most dangerous unfired instance precisely because the
+controller does not validate it: pollution there corrupts the #210 receipt
+rather than failing loudly.
+
+## D-225-3 Proposal branch state
+
+Branch name: `daily-amaru/bootstrap-<day>-<upstream-sha[0:12]>` (unchanged).
+
+| State | Condition | Outcome |
+|---|---|---|
+| `absent` | no such ref on the bootstrap remote | create, commit, push, open PR |
+| `adoptable` | ref exists; its delta from its merge base with `origin/main` changes exactly `flake.lock`; that lock's single stock `pragma-org/amaru` node has `locked.rev == <upstream-sha>` and `original.owner/repo == pragma-org/amaru` | emit that ref's head; no commit, no push; find the existing PR |
+| `foreign` | ref exists and is not `adoptable` | named red `foreign-proposal-branch`; no value; remote untouched |
+
+`adoptable` requires **both** conditions. A branch touching only `flake.lock`
+but pinning a different revision is `foreign`, not `adoptable`.
+
+## D-225-4 Named reds
+
+| Token | Meaning |
+|---|---|
+| `foreign-proposal-branch` | the per-SHA proposal branch exists with content this controller did not produce |
+
+The token is stable and asserted by the regression. The receipt schema is
+unchanged: the controller keeps recording `error=proposal-failed` for this
+stage, and the token is the diagnostic-stream evidence.

--- a/specs/225-transport-value-channel/functions-model.md
+++ b/specs/225-transport-value-channel/functions-model.md
@@ -1,0 +1,34 @@
+# Functions model
+
+New and changed signatures only. No bodies, no algorithms.
+
+## `scripts/daily-amaru-github.sh`
+
+| Function | Arguments | Result | Constraints and effects |
+|---|---|---|---|
+| `emit` | `line...` (one or more value lines) | none | Writes its arguments, and nothing else, to the reserved value channel (`D-225-1`). The only way any operation may produce a value. Never writes to the diagnostic stream. |
+| `classify_proposal_branch` | `directory` (local clone), `branch`, `upstream_sha`, `input_node` (lock node key) | prints one of `absent`, `adoptable`, `foreign` on its own stdout, captured by the caller | Pure read: performs no commit, no push, no working-tree mutation, and no PR call. Must be evaluated before the local branch is created. Non-zero exit only for an unreadable remote, which is distinct from `foreign`. |
+
+Changed callers: every `case` branch that today ends in a bare `printf` of its
+value now ends in `emit`. `push_branch` and `create_or_find_pr` keep their
+current signatures; `propose-bootstrap` simply does not call `push_branch` in
+the `adoptable` path.
+
+The owner may add further private helpers. Those two signatures are the
+contract, because each carries an invariant: `emit` is the sole value path, and
+`classify_proposal_branch` is a mutation-free pre-check.
+
+## `scripts/daily-amaru.sh`
+
+No new or changed signatures. `receipt_keys`, stage names, and every validation
+regex are frozen.
+
+## `tests/fixtures/daily-amaru/`
+
+| Fixture | Invocation surface | Constraints |
+|---|---|---|
+| `gh` stand-in (existing file, extended) | `repo clone <repo> <dir> -- <git-args...>`, `pr create -R <repo> --base <b> --head <h> --title <t> --body <b>`, `pr view <ref> -R <repo> --json <fields> [--jq <expr>]`, plus the existing `api` and `issue comment` surface | `repo clone` delegates to real `git clone` against a `file://` remote. Must reject a subcommand or flag the real `gh` would reject, so the double cannot drift more permissive than the binary it stands for. Every invocation stays recorded in the existing effect log. |
+| lock rewriter (new, stands in for `nix`) | `flake lock --override-input <input-name> github:pragma-org/amaru/<sha>` | Rewrites `flake.lock` for that node exactly as the real command does for the fields the transport validates (`original.owner`, `original.repo`, `locked.rev`), deterministically and offline. Writes its progress to the same stream the real `nix` writes it to. Rejects any other argument shape. |
+
+`git` is the real binary in every new proof and may not be stubbed: its stdout
+behaviour is the defect under test.

--- a/specs/225-transport-value-channel/modules-model.md
+++ b/specs/225-transport-value-channel/modules-model.md
@@ -1,0 +1,66 @@
+# Modules model
+
+Only changed responsibilities. References `data-model.md` and
+`functions-model.md` without repeating them.
+
+## M-225-1 `scripts/daily-amaru-github.sh` — transport
+
+Existing responsibility: execute one named side-effecting operation and return
+its value to the controller.
+
+Changed: the transport now **owns the separation of its two output streams**.
+The value channel is a dedicated descriptor reserved at dispatch; fd 1 becomes
+the diagnostic stream for the whole script, so every subcommand's stdout is
+diagnostic by construction. Operations reach the value channel only through the
+emit function in `functions-model.md`.
+
+Dependency direction unchanged: transport → external binaries. The controller
+(`M-225-2`) keeps consuming stdout and is not aware of the mechanism.
+
+Promotion: none. The mechanism is transport-local; no shared library exists in
+this repository and creating one for a single consumer is not justified.
+
+## M-225-1a `propose-bootstrap` — proposal adoption
+
+New responsibility: **classify the per-SHA proposal branch on the bootstrap
+remote before mutating anything**, then act on that classification. The three
+states and the named red are in `data-model.md`.
+
+The classification is a read of the bootstrap remote and must complete before
+the local branch is created, before `nix flake lock` runs, and before any push.
+Ordering is the invariant: a classification performed after a local commit
+cannot prevent the non-fast-forward push it exists to prevent.
+
+`prepare-consumer-repin` is explicitly **not** given this responsibility in this
+slice. Its branch is per-day, not per-SHA, and its re-attempt semantics are a
+separate contract; only its value-channel defect is in scope.
+
+## M-225-2 `scripts/daily-amaru.sh` — controller
+
+Unchanged responsibility and unchanged validation. It is edited only if the
+value-channel mechanism genuinely requires it; `receipt_keys`, the stage names,
+and every validation regex are frozen.
+
+## M-225-3 `tests/fixtures/daily-amaru/` — boundary stand-ins
+
+New responsibility: provide a **local bootstrap remote boundary** so the real
+transport's git path is executable without network, credentials, or the live
+`lambdasistemi/amaru-bootstrap`.
+
+Consists of a bare repository standing in for the remote, the existing `gh`
+stand-in extended to the exact subcommand surface the transport invokes, and a
+deterministic lock rewriter standing in for `nix flake lock`. Real `git` is a
+dependency of this module and may not be stubbed.
+
+Dependency direction: tests → fixtures → real `git`. Fixtures never import from
+`scripts/`; the transport is executed as a black box, exactly as CI runs it.
+
+## M-225-4 `tests/test-daily-amaru.sh` — proof suite
+
+Existing responsibility: the focused Daily Amaru proof, run by `just ci` and by
+the `daily-amaru` workflow's pull-request job.
+
+Changed: gains the value-channel census over every value-returning operation and
+the three proposal-branch scenarios, each with a mutant. Its existing effect
+censuses keep their current meaning; new proofs account for their effects
+separately.

--- a/specs/225-transport-value-channel/plan.md
+++ b/specs/225-transport-value-channel/plan.md
@@ -1,0 +1,76 @@
+# Plan
+
+## Strategy
+
+Two defects, one bisect-safe slice, because the regression harness that proves
+either one is the same harness: the real transport executed against a local
+git boundary.
+
+### Why the class was invisible until production
+
+Every existing Daily Amaru proof drives the **controller** against
+`tests/fixtures/daily-amaru/fake-transport.sh`, or inspects the **text** of
+`scripts/daily-amaru-github.sh` with mutants. Nothing executes the real
+transport's git path. The value channel is a property of the real subcommands —
+`git commit` writes its summary to stdout — so no controller-level or
+text-level check could observe it. This is the [[live-boundary-smoke]] shape:
+unit-green, production-broken, at the seam.
+
+The fix therefore ships a boundary the tests can actually reach: a bare local
+repository standing in for the bootstrap remote, real `git`, a `gh` stand-in
+that implements the clone/PR surface, and a deterministic lock rewriter
+standing in for `nix flake lock`. Real `git` is mandatory — its stdout
+behaviour **is** the defect.
+
+## Live boundary and its limits
+
+The stand-ins must not be politer than the real binaries. Concretely:
+
+- `git` is the real binary; nothing may stub it.
+- The `gh` stand-in's `repo clone` delegates to real `git clone`.
+- The lock rewriter rewrites `flake.lock` exactly as `nix flake lock
+  --override-input` does for the pinned node (rev + narHash + lastModified),
+  and writes its progress where the real `nix` writes it.
+
+Residual risk this design does **not** close: divergence between the `gh` and
+`nix` stand-ins and their real binaries. That risk is bounded by keeping both
+stand-ins to the exact subcommand surface the transport invokes, and by the
+structural (not per-command) value-channel mechanism, which holds regardless of
+what any stand-in prints.
+
+## Ordered work
+
+One slice `S1`. Within it:
+
+1. RED first: the boundary harness plus the failing proofs for both classes,
+   against unmodified `scripts/daily-amaru-github.sh`. The pollution proof must
+   fail with exactly `malformed-candidate-sha`; the adoption proof must fail at
+   the non-fast-forward push.
+2. Value channel: the structural mechanism, applied across every value-returning
+   operation.
+3. Proposal adoption: `absent | adoptable | foreign` classification before any
+   mutation of the workspace or the remote.
+4. Mutants for every protection, each proved to apply and to be rejected.
+
+Splitting 2 from 3 would leave `main` with a re-attempt that pushes
+non-fast-forward, i.e. a bisect point that is worse than either endpoint.
+
+## Constraints on the implementation
+
+- No change to `scripts/daily-amaru.sh` unless the fix genuinely needs it. The
+  controller's validation regexes and `receipt_keys` are frozen.
+- No workflow YAML change. `.github/workflows/daily-amaru.yaml` already runs
+  `tests/test-daily-amaru.sh`; new proofs must land inside that suite (or a
+  suite `just ci` already runs) so they execute in the six required contexts.
+- New tests build their own repositories under `mktemp -d`. They must not read
+  this repository's history, so they survive a shallow checkout.
+- `just check-shell` shellchecks `scripts/*.sh` and `tests/*.sh` including
+  fixtures; new fixtures must pass `shellcheck -x` and `just format-check`.
+- No network. No credentials. No real Antithesis launch. The existing effect
+  censuses (`assert_no_launch`, `assert_no_mutation`, `EFFECT-CENSUS`) must stay
+  honest — a new proof may not make them count effects from a different lane.
+
+## Verification
+
+`./gate.sh` (ticket runtime, untracked) runs `nix develop --quiet -c just ci`
+plus the focused ticket proofs. Baseline on `01f96e4`: exit 0, 20.8s.

--- a/specs/225-transport-value-channel/spec.md
+++ b/specs/225-transport-value-channel/spec.md
@@ -1,0 +1,88 @@
+# Fix transport stdout pollution and make bootstrap proposal re-attempt-safe
+
+Issue: cardano-foundation/cardano-node-antithesis#225 · parent epic #205
+Base: `01f96e4` (carries #223 cap/supersede)
+
+## Context
+
+The first `production=true` fire (run 32261172699) progressed past every prior
+failure point and then died at `bootstrap-proposal: malformed-candidate-sha`
+with the day's launch allowance unconsumed. Two independent defects are exposed.
+
+## Requirements
+
+### R-225-1 — transport value channel
+
+The transport returns operation values on stdout. A value-returning operation
+must emit **exactly** its value there and nothing else, whatever any subcommand
+it invokes writes to its own stdout.
+
+- R-225-1a: every value-returning operation named in `data-model.md` emits its
+  exact value on stdout when every external command it invokes is noisy on both
+  streams.
+- R-225-1b: the separation is one structural mechanism owned by the transport,
+  not per-subcommand redirection. A newly added operation that writes a value
+  with a plain `printf` to fd 1 must lose that value (loud, testable) rather
+  than silently inherit a polluted channel.
+- R-225-1c: the audit covers **every** operation in the `case` dispatch, not
+  only `propose-bootstrap`. Known unfired instances of the same class are
+  recorded in `data-model.md`.
+
+### R-225-2 — re-attempt-safe bootstrap proposal
+
+`propose-bootstrap <upstream-sha>` is idempotent per upstream SHA. Given the
+per-SHA proposal branch on the bootstrap remote:
+
+- R-225-2a **adopt**: the branch exists and its delta from its merge base with
+  `origin/main` is exactly `flake.lock`, whose stock `pragma-org/amaru` node is
+  locked to `<upstream-sha>` → return that branch head, create no commit, push
+  nothing, and reuse the existing PR through the existing find path.
+- R-225-2b **foreign**: the branch exists with any other content → fail with the
+  stable named red `foreign-proposal-branch` on the diagnostic stream, emit no
+  value, and leave the remote branch untouched. Never force-push or overwrite.
+- R-225-2c **fresh**: the branch is absent → today's create/commit/push/PR path,
+  unchanged in observable outcome.
+
+## Rejection behaviour
+
+- A polluted value channel must not be repairable by relaxing the controller's
+  validation. The controller's `^[0-9a-f]{40}$` guards stay as they are.
+- A foreign proposal branch is terminal for the run. It is never renamed,
+  deleted, force-updated, or worked around.
+
+## Observable success
+
+- `nix develop --quiet -c just ci` green in the issue worktree.
+- All six required PR contexts green on the exact pushed head.
+- The regression proves both classes closed with mutants: a pollution-restoring
+  mutant reproduces exactly `malformed-candidate-sha`; adopt, foreign and fresh
+  are each shown able to fail.
+
+## Constraints (from the issue and the parent brief)
+
+- Same code path for `schedule` and `workflow_dispatch`; no probe-only fork.
+- No receipt-schema change; `receipt_keys` in `scripts/daily-amaru.sh` unchanged.
+- Issue #210 receipts preserved.
+- The existing ab PR#81 must be adoptable by the re-attempt, not duplicated.
+- No real Antithesis launch from tests; no network; no credentials.
+- The #223 one-launch-per-day cap and the #221/#219/#223 guarantees untouched.
+- `lambdasistemi/amaru-bootstrap` is read-only evidence. Adoption is proven with
+  local fixtures and mutants, never by touching the live PR or branch.
+- A history-reading check must survive a shallow checkout.
+
+## Invariants
+
+Each must be proved able to fail. "Fails when" is the observable red.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-A1 | A value-returning operation's stdout is exactly its value | any subcommand's stdout reaches the transport's stdout | the controller's capture matches the operation's declared value shape byte-for-byte |
+| INV-225-A2 | The value channel is closed for **every** value-returning operation in `D-225-2`, not only the fired one | any listed operation, run with noisy external commands, emits more or less than its value | the census over the complete table is green, and the table is the complete `case` dispatch |
+| INV-225-A3 | The fired defect is reproducible and closed | a mutant restoring the `propose-bootstrap` pollution does **not** reproduce `malformed-candidate-sha` — that would mean the proof is not observing the real defect | the mutant reproduces exactly `bootstrap-proposal: malformed-candidate-sha`, and the unmutated code does not |
+| INV-225-B1 | An existing valid per-SHA proposal branch is adopted | a same-SHA re-attempt commits, pushes, force-updates, opens a second PR, or returns a head other than the existing branch's | the emitted value is the existing branch head, the remote ref is byte-identical afterwards, and the existing PR URL is reused |
+| INV-225-B2 | A foreign branch is a loud named red | foreign content is adopted, overwritten, force-pushed, or reported as a generic failure | the run fails with `foreign-proposal-branch` on the diagnostic stream, emits no value, and the remote ref is unchanged |
+| INV-225-B3 | An absent branch still takes the create path | the fresh path regresses in observable outcome | branch created, single `flake.lock` commit pushed, PR opened, head emitted |
+| INV-225-B4 | Classification precedes mutation | the branch is classified after a local commit or after a push attempt | the foreign case is detected with zero write effects recorded against the remote |
+| INV-225-C1 | One code path for `schedule` and `workflow_dispatch` | a probe-only fork or a mode-conditional branch appears in the proposal path | the existing routing proof stays green with no new mode conditional |
+| INV-225-C2 | No real Antithesis launch from tests | any proof reaches a real workflow dispatch | the effect censuses record zero real launches |
+| INV-225-C3 | #210 receipts preserved | `receipt_keys`, a stage name, or a controller validation regex changes | the receipt field set and order are identical to base `01f96e4` |

--- a/specs/225-transport-value-channel/spec.md
+++ b/specs/225-transport-value-channel/spec.md
@@ -101,3 +101,81 @@ every path permitted to differ from `pre_slice_base=cd8144b`. It was frozen for
 Re-basing the fence per slice is in scope for this campaign. Growing the
 allow-list against an ever-older base is not: it would make the fence weaker
 every ticket. Identifier naming is the commit owner's choice.
+
+## Slice S2 — the boundary proof must be hermetic
+
+`7c56594` was green under the local ticket gate and red in CI:
+`FAIL: fixed controller recorded no bootstrap candidate (error=missing-command-rg rc=1)`
+(run 32271362864). Reproduced locally by hiding `rg` from the fixture's PATH.
+
+`prepare_case` builds `PATH="$bin:$PATH"`, so the boundary proof inherits host
+binaries. The nix dev shell has ripgrep; the GitHub runner does not. The `just ci`
+leg of the gate runs in the dev shell and therefore cannot observe this class at
+all — the gate was green by construction, not by evidence.
+
+This is the same root the submission-2 auditor proposed as CAND-225-3: the
+fixture's PATH construction decides which binaries are actually invoked, and
+nothing asserts the answer.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-E1 | The boundary proof's verdict does not depend on any host-provided binary | removing a member of the transport's `scheduled_command_census` from the host PATH changes the proof's outcome | the fixture seeds every command the proof's operations need and inherits nothing; the proof produces the same verdict under a PATH containing only what it seeds |
+| INV-225-E2 | The stand-ins are the binaries actually invoked (ratifies CAND-225-3) | a dangling symlink, a relative root, or an unseeded name silently reaches a real `gh`, `nix` or `docker` | before any operation runs, the proof asserts that `command -v` for each stand-in resolves inside its own bin, and this assertion is shown able to fail |
+
+INV-225-E2 is the load-bearing half. E1 without E2 is a promise; E2 makes the
+proof state, per run, which binaries it actually used.
+
+### S2 mandate v2 — sharpened after submission 1's findings
+
+Submission 1 (`3184b07`) fixed `rg` and left the class open. The audit
+(`55881e6c…`) showed the fixture resolves each seeded command against the
+inherited host PATH and, when one is absent, **fabricates** `#!/bin/sh\nexit 0`.
+Nine of the fifteen `scheduled_command_census` members still changed the
+proof's verdict when ablated, and the `jq` case produced
+`error=proposal-failed` — an infrastructure failure reported as a domain
+verdict, which is strictly worse than the `missing-command-rg` it replaced.
+
+E1 and E2 keep their meaning. These clauses make the failure modes explicit and
+add the evidence contract the third finding exposed.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-E1 (v2) | Every seeded command is bound to a binary the proof **proved exists**, and the proof dies naming the command when it cannot | "seeded" means only that an entry exists in the bin; an absent command is silently replaced by a success-returning stand-in; ablating any member of the transport's `scheduled_command_census` changes the verdict | ablating **each** of the 15 census members in turn leaves the verdict identical to the unablated control, and a command that cannot be bound is a named, loud death |
+| INV-225-E2 (v2) | The stand-ins are the binaries actually invoked, against **all three** named substitution modes | any of — a dangling symlink, a **relative** bin root, or a fabricated no-op substitute — is accepted; or any of the three has no mutant | each of the three modes is rejected, and each rejection is demonstrated by its own mutant |
+| INV-225-E3 (ratifies CAND-225-5) | Every count in a proof marker is produced by the executed path it summarizes | a field is a constant, or a length of a declared list; deleting the code path the field reports leaves the marker byte-identical | deleting the reported path changes the number or reds the run, shown by a mutant that verifies its own edit applied |
+
+INV-225-E3 is general, not local to this fixture: gate v3's own comment already
+states the rule for `VALUE-CHANNEL` and the leg immediately below it did not
+enforce it. That gap was the ticket owner's, and gate v4 closes it.
+
+`tests/test-daily-amaru.sh`'s `seed_scheduled_path` carries the same
+`stub_command` fallback. It is **out of scope here** — no assertion was shown to
+mis-verdict because of it — and is routed to the epic owner with INV-225-E1's
+property class attached.
+
+## Slice S3 — the ablation count must be the ablation
+
+The S2 owner campaign closed at submission 2/2. E1 v2 and E2 v2 are closed:
+`stub_command` is gone from the fixture, an unbindable seeded command now dies
+naming itself instead of mis-verdicting as `proposal-failed`, and all three
+substitution modes are rejected with their own mutants.
+
+One row stayed open. `census_ablated=` is the **loop trip count**, not the
+ablation re-run. Deleting the only re-run call leaves `census_ablated=15`
+unchanged while `seeded=` drops 792→462 and `standins_verified=` drops 136→76 —
+proving those two are derived and this one is not. Gate v4's
+`census_ablated>=15` leg is therefore satisfied by a run that never re-checked
+a verdict under an ablated host PATH.
+
+This is INV-225-E3's own class, recurring inside the field that was added to
+close INV-225-E1 v2. That recurrence is the point: the rule was stated, enforced
+in one place, and re-broken in the next field written. It closes mechanically or
+it keeps coming back.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-E3 (scope unchanged, now enforced on `census_ablated`) | Every count in a proof marker is produced by the executed path it summarizes | deleting the ablation re-run leaves `census_ablated` unchanged and the run green | deleting the ablation re-run either moves `census_ablated` or reds the run, proved by a mutant that verifies its own edit applied |
+
+The intact code does perform the 15 re-runs — the 792→462 drop is the evidence.
+This slice does not add coverage; it makes the marker require the coverage that
+already happens, so a later edit cannot quietly remove it.

--- a/specs/225-transport-value-channel/spec.md
+++ b/specs/225-transport-value-channel/spec.md
@@ -86,3 +86,18 @@ Each must be proved able to fail. "Fails when" is the observable red.
 | INV-225-C1 | One code path for `schedule` and `workflow_dispatch` | a probe-only fork or a mode-conditional branch appears in the proposal path | the existing routing proof stays green with no new mode conditional |
 | INV-225-C2 | No real Antithesis launch from tests | any proof reaches a real workflow dispatch | the effect censuses record zero real launches |
 | INV-225-C3 | #210 receipts preserved | `receipt_keys`, a stage name, or a controller validation regex changes | the receipt field set and order are identical to base `01f96e4` |
+
+## Discovered constraint — the inherited scope fence
+
+`tests/test-daily-amaru.sh` carries `issue_223_allowed_paths`, an allow-list of
+every path permitted to differ from `pre_slice_base=cd8144b`. It was frozen for
+#223 and now judges #225's tree: the planning commit alone reds it with
+`changed path outside #223 fence`.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-D1 | The daily-loop scope fence judges **this** slice, not a merged one | the fence's base or allow-list still describes #223, so a correct #225 candidate is rejected by construction; or the fence is weakened into something that cannot reject an out-of-scope path | the base is this slice's pre-slice base `01f96e4`, the allow-list is exactly the paths this slice changes, the existing `scope-path-outside-fence` mutant is still rejected, and `dry_run_steps_identical` still holds against the new base |
+
+Re-basing the fence per slice is in scope for this campaign. Growing the
+allow-list against an ever-older base is not: it would make the fence weaker
+every ticket. Identifier naming is the commit owner's choice.

--- a/specs/225-transport-value-channel/spec.md
+++ b/specs/225-transport-value-channel/spec.md
@@ -179,3 +179,51 @@ it keeps coming back.
 The intact code does perform the 15 re-runs — the 792→462 drop is the evidence.
 This slice does not add coverage; it makes the marker require the coverage that
 already happens, so a later edit cannot quietly remove it.
+
+## Slice S4 — the proof job runs the canonical entry, and guards speak
+
+`2e7b35a` is red in CI a second time, with a **different** cause from
+`7c56594`'s. The `rg` dependency is genuinely fixed — proved by a controlled
+experiment seeding every dev-shell command except `rg` (full suite, exit 0). The
+new failure exits 1 six seconds after `RECEIPT-SCHEMA` with **no `FAIL:` line at
+all**, so the runner cannot tell us why.
+
+Two causes, one slice, because part 1 is what makes any future part-2 red
+legible.
+
+### The swallowing mechanism
+
+The S3 audit recorded it in advance as advisory F-2: `x=$(grep -c …)` under
+`set -euo pipefail`. `grep -c` exits 1 on a zero count, so the **assignment**
+kills the shell before the `fail` it guards can print — the diagnostic is
+unreachable in exactly the case it was written for.
+
+### The environment gap
+
+Every local run in this ticket happens inside `nix develop`; the CI dry-run job
+runs the suite bare. The suite is green in both environments on this host (bare
+`awk` here is the same gawk 5.3.2), so the runner's toolchain is a variable this
+ticket never controlled and cannot reproduce.
+
+Epic ruling A-001, option (a): **the dry-run job runs the suite through the same
+entry `just ci` uses.** The suite's job is to prove controller logic, not
+ubuntu-toolchain compatibility — runner dependencies are already certified by the
+#213 preflight with its own fail-closed RED, and duplicating that duty inside the
+harness is the seam class this epic is already tracking. The hermetic principle
+extends from commands to interpreters: pin them, do not prove against whatever a
+host ships. The production job's environment is untouched.
+
+| ID | Invariant | Fails when | Holds when |
+|---|---|---|---|
+| INV-225-F1 | A guarded failure prints its diagnosis | a guard's input comes from a command substitution that can exit non-zero, so under `set -e` the process dies before the `fail` runs | forcing each guarded zero-count condition produces a `FAIL:` line naming it, and a mutant restoring the bare `$(grep -c …)` shape reproduces a silent death |
+| INV-225-F2 | The proof job runs the canonical proof entry | the dry-run job invokes the suite through an environment other than the one `just ci` uses | the dry-run job provisions the dev shell and runs the canonical entry, and a mutant pointing it elsewhere is rejected |
+| INV-225-F3 (versions the #219/#223 dry-run guarantee) | The dry-run path is not tampered with by production-trigger work | the guarantee is asserted as "byte-identical to a base commit" while the path is deliberately being changed, so a correct candidate is rejected by construction | the guarantee is expressed against the **canonical entry** rather than a frozen byte image, and its tamper mutant is still rejected |
+
+INV-225-F3 is the same lesson as the #223 scope fence, one layer up: a guarantee
+frozen as a byte image of the old world cannot judge the new one. The tamper
+protection is kept; only its expression changes.
+
+Fetch cost, per the ruling's implementation constraint: no new cost to report.
+The production job in this same workflow already provisions the dev shell through
+`paolino/dev-assets/setup-nix@v0.0.1` with cachix, so the dry-run job reuses a
+path this workflow already pays for.

--- a/specs/225-transport-value-channel/tasks.md
+++ b/specs/225-transport-value-channel/tasks.md
@@ -49,3 +49,16 @@ Slice `S3` — the ablation count must be the ablation.
 
 - [x] T225-15 Derive `census_ablated` from the ablation re-run itself, and prove
       it with a mutant that deletes the re-run and reds the run (INV-225-E3).
+
+Slice `S4` — canonical proof entry, and guards that speak.
+
+- [x] T225-16 Every `x=$(grep -c …)`-shaped guard feeding a `fail` tolerates the
+      zero count, so the diagnostic it guards is reachable; forced failures print
+      a named `FAIL:` line and a mutant restoring the bare shape reproduces a
+      silent death (INV-225-F1).
+- [x] T225-17 The dry-run job provisions the dev shell and runs the canonical
+      `just ci` entry; the production job's environment is untouched
+      (INV-225-F2).
+- [x] T225-18 Version the #219/#223 dry-run tamper guarantee from a frozen byte
+      image to the canonical entry, keeping its tamper mutant rejected, and add
+      the workflow to the slice fence allow-list (INV-225-F3, INV-225-D1).

--- a/specs/225-transport-value-channel/tasks.md
+++ b/specs/225-transport-value-channel/tasks.md
@@ -3,28 +3,28 @@
 Slice `S1` — transport value channel and re-attempt-safe bootstrap proposal.
 Bisect-safe as one unit (`plan.md`, "Ordered work").
 
-- [ ] T225-01 Boundary harness: local bare bootstrap remote, extended `gh`
+- [x] T225-01 Boundary harness: local bare bootstrap remote, extended `gh`
       stand-in, deterministic lock rewriter (`M-225-3`, `functions-model.md`),
       driving the **real** transport with real `git`.
-- [ ] T225-02 RED: pollution proof through the real controller and real
+- [x] T225-02 RED: pollution proof through the real controller and real
       transport at base behaviour, failing with exactly `malformed-candidate-sha`
       (`R-225-1`, INV-225-A3).
-- [ ] T225-03 RED: proposal re-attempt proof at base behaviour — a second
+- [x] T225-03 RED: proposal re-attempt proof at base behaviour — a second
       `propose-bootstrap` for the same upstream SHA against an existing remote
       branch fails at the non-fast-forward push (`R-225-2`).
-- [ ] T225-04 Value channel: the structural mechanism and `emit` across every
+- [x] T225-04 Value channel: the structural mechanism and `emit` across every
       value-returning operation in `D-225-2` (`R-225-1a`, `R-225-1b`, `R-225-1c`,
       INV-225-A1, INV-225-A2).
-- [ ] T225-05 Value-channel census proof: every value-returning operation emits
+- [x] T225-05 Value-channel census proof: every value-returning operation emits
       exactly its value under noisy external commands (INV-225-A2).
-- [ ] T225-06 Proposal classification and the three outcomes: adopt, foreign
+- [x] T225-06 Proposal classification and the three outcomes: adopt, foreign
       red, fresh create (`R-225-2a`, `R-225-2b`, `R-225-2c`, INV-225-B1..B3).
-- [ ] T225-07 Mutants: pollution-restoring, adoption-defeating,
+- [x] T225-07 Mutants: pollution-restoring, adoption-defeating,
       foreign-accepting, and classification-ordering, each proved to apply and
       to be rejected (INV-225-A3, INV-225-B4).
-- [ ] T225-08 Preservation proof: `receipt_keys` and the controller's validation
+- [x] T225-08 Preservation proof: `receipt_keys` and the controller's validation
       regexes unchanged; existing effect censuses still honest; no real launch
       (INV-225-C1..C3).
-- [ ] T225-09 Re-base the daily-loop scope fence to this slice's pre-slice base
+- [x] T225-09 Re-base the daily-loop scope fence to this slice's pre-slice base
       and allow-list, keeping the `scope-path-outside-fence` mutant rejected and
       `dry_run_steps_identical` green (INV-225-D1).

--- a/specs/225-transport-value-channel/tasks.md
+++ b/specs/225-transport-value-channel/tasks.md
@@ -28,3 +28,24 @@ Bisect-safe as one unit (`plan.md`, "Ordered work").
 - [x] T225-09 Re-base the daily-loop scope fence to this slice's pre-slice base
       and allow-list, keeping the `scope-path-outside-fence` mutant rejected and
       `dry_run_steps_identical` green (INV-225-D1).
+
+Slice `S2` — hermetic boundary proof (forward correction on pushed `7c56594`).
+
+- [x] T225-10 Seed every command the boundary proof's operations need and stop
+      inheriting the host PATH; the proof's verdict is unchanged under a PATH
+      containing only what it seeds (INV-225-E1).
+- [x] T225-11 Assert, before any operation runs, that each stand-in resolves
+      inside the fixture's own bin, with the assertion shown able to fail
+      (INV-225-E2, ratifies CAND-225-3).
+- [x] T225-12 Bind every seeded command to a proved-existing binary; die naming
+      the command otherwise; ablate all 15 census members and require an
+      unchanged verdict (INV-225-E1 v2).
+- [x] T225-13 Reject all three substitution modes — dangling symlink, relative
+      bin root, fabricated no-op — each with its own mutant (INV-225-E2 v2).
+- [x] T225-14 Derive every `BOUNDARY-PATH` count from the executed path, proved
+      by a mutant that deletes the verification and reds the run (INV-225-E3).
+
+Slice `S3` — the ablation count must be the ablation.
+
+- [x] T225-15 Derive `census_ablated` from the ablation re-run itself, and prove
+      it with a mutant that deletes the re-run and reds the run (INV-225-E3).

--- a/specs/225-transport-value-channel/tasks.md
+++ b/specs/225-transport-value-channel/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+Slice `S1` — transport value channel and re-attempt-safe bootstrap proposal.
+Bisect-safe as one unit (`plan.md`, "Ordered work").
+
+- [ ] T225-01 Boundary harness: local bare bootstrap remote, extended `gh`
+      stand-in, deterministic lock rewriter (`M-225-3`, `functions-model.md`),
+      driving the **real** transport with real `git`.
+- [ ] T225-02 RED: pollution proof through the real controller and real
+      transport at base behaviour, failing with exactly `malformed-candidate-sha`
+      (`R-225-1`, INV-225-A3).
+- [ ] T225-03 RED: proposal re-attempt proof at base behaviour — a second
+      `propose-bootstrap` for the same upstream SHA against an existing remote
+      branch fails at the non-fast-forward push (`R-225-2`).
+- [ ] T225-04 Value channel: the structural mechanism and `emit` across every
+      value-returning operation in `D-225-2` (`R-225-1a`, `R-225-1b`, `R-225-1c`,
+      INV-225-A1, INV-225-A2).
+- [ ] T225-05 Value-channel census proof: every value-returning operation emits
+      exactly its value under noisy external commands (INV-225-A2).
+- [ ] T225-06 Proposal classification and the three outcomes: adopt, foreign
+      red, fresh create (`R-225-2a`, `R-225-2b`, `R-225-2c`, INV-225-B1..B3).
+- [ ] T225-07 Mutants: pollution-restoring, adoption-defeating,
+      foreign-accepting, and classification-ordering, each proved to apply and
+      to be rejected (INV-225-A3, INV-225-B4).
+- [ ] T225-08 Preservation proof: `receipt_keys` and the controller's validation
+      regexes unchanged; existing effect censuses still honest; no real launch
+      (INV-225-C1..C3).

--- a/specs/225-transport-value-channel/tasks.md
+++ b/specs/225-transport-value-channel/tasks.md
@@ -25,3 +25,6 @@ Bisect-safe as one unit (`plan.md`, "Ordered work").
 - [ ] T225-08 Preservation proof: `receipt_keys` and the controller's validation
       regexes unchanged; existing effect censuses still honest; no real launch
       (INV-225-C1..C3).
+- [ ] T225-09 Re-base the daily-loop scope fence to this slice's pre-slice base
+      and allow-list, keeping the `scope-path-outside-fence` mutant rejected and
+      `dry_run_steps_identical` green (INV-225-D1).

--- a/tests/fixtures/daily-amaru/boundary-docker.sh
+++ b/tests/fixtures/daily-amaru/boundary-docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$#" -eq 6 ] && [ "$1" = buildx ] && [ "$2" = imagetools ] &&
+  [ "$3" = inspect ] && [ "$5" = --format ] &&
+  [ "$6" = '{{json .Manifest.Digest}}' ] || exit 64
+printf 'boundary-docker diagnostic\n' >&2
+printf '"sha256:%064d"\n' 0

--- a/tests/fixtures/daily-amaru/boundary-gh.sh
+++ b/tests/fixtures/daily-amaru/boundary-gh.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file=${DAILY_AMARU_BOUNDARY_GH_LOG:?DAILY_AMARU_BOUNDARY_GH_LOG is required}
+comments_file=${DAILY_AMARU_BOUNDARY_COMMENTS:?DAILY_AMARU_BOUNDARY_COMMENTS is required}
+head_sha=${DAILY_AMARU_BOUNDARY_HEAD_SHA:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+integrated_sha=${DAILY_AMARU_BOUNDARY_INTEGRATED_SHA:-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}
+
+{
+  printf 'gh'
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$log_file"
+printf 'boundary-gh diagnostic: %s\n' "$*" >&2
+
+case "${1:-} ${2:-}" in
+  'repo clone')
+    [ "$#" -eq 6 ] && [ "$5" = -- ] && [ "$6" = --filter=blob:none ] || exit 64
+    repository=$3
+    directory=$4
+    case "$repository" in
+      "${DAILY_AMARU_BOOTSTRAP_REPOSITORY:-lambdasistemi/amaru-bootstrap}")
+        remote=${DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE:?bootstrap remote is required}
+        ;;
+      "${DAILY_AMARU_REPOSITORY:-cardano-foundation/cardano-node-antithesis}")
+        remote=${DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE:?repository remote is required}
+        ;;
+      *) exit 64 ;;
+    esac
+    git clone --quiet --filter=blob:none "file://$remote" "$directory"
+    printf 'boundary-gh clone diagnostic\n'
+    ;;
+
+  'pr create')
+    shift 2
+    repository=''
+    branch=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -R) repository=${2:?}; shift 2 ;;
+        --base | --title | --body) shift 2 ;;
+        --head) branch=${2:?}; shift 2 ;;
+        *) exit 64 ;;
+      esac
+    done
+    [ -n "$repository" ] && [ -n "$branch" ] || exit 64
+    printf 'https://example.invalid/%s/pull/fresh\n' "$repository"
+    ;;
+
+  'pr view')
+    if [ "$#" -eq 9 ] && [ "$4" = -R ] && [ "$6" = --json ] &&
+      [ "$7" = url ] && [ "$8" = --jq ] && [ "$9" = .url ]; then
+      printf 'https://example.invalid/%s/pull/existing\n' "$5"
+    elif [ "$#" -eq 7 ] && [ "$4" = -R ] && [ "$6" = --json ] &&
+      [ "$7" = state,headRefOid,mergeCommit ]; then
+      printf '{"state":"MERGED","headRefOid":"%s","mergeCommit":{"oid":"%s"}}\n' \
+        "$head_sha" "$integrated_sha"
+    else
+      exit 64
+    fi
+    ;;
+
+  'issue comment')
+    [ "$#" -eq 7 ] && [[ "$3" =~ ^[0-9]+$ ]] && [ "$4" = -R ] &&
+      [ "$6" = --body ] || exit 64
+    shift 3
+    body=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -R) shift 2 ;;
+        --body) body=${2:?}; shift 2 ;;
+        *) exit 64 ;;
+      esac
+    done
+    [ -n "$body" ] || exit 64
+    printf '%s\n' "$body" >>"$comments_file"
+    printf 'boundary-gh comment diagnostic\n'
+    ;;
+
+  'api '*)
+    if [ "$#" -eq 5 ] && [ "$2" = --paginate ] &&
+      [[ "$3" == repos/*/issues/*/comments\?per_page=100 ]] &&
+      [ "$4" = --jq ] && [ "$5" = '.[].body' ]; then
+      cat "$comments_file"
+    elif [ "$#" -eq 2 ] && [[ "$2" == repos/*/actions/runs\?head_sha=*\&per_page=100 ]]; then
+      target=${2#repos/}; target=${target%%/actions/*}
+      if [ "$target" = "${DAILY_AMARU_BOOTSTRAP_REPOSITORY:-lambdasistemi/amaru-bootstrap}" ]; then
+        printf '{"workflow_runs":[{"name":"Bootstrap CI","check_suite_id":10,"head_sha":"%s"}]}\n' "$head_sha"
+      else
+        printf '{"workflow_runs":[{"name":"Build and push component images for cardano-node testnet","check_suite_id":1,"head_sha":"%s"},{"name":"tracer-sidecar CI","check_suite_id":2,"head_sha":"%s"},{"name":"Build documentation","check_suite_id":3,"head_sha":"%s"},{"name":"PR preview","check_suite_id":4,"head_sha":"%s"}]}\n' "$head_sha" "$head_sha" "$head_sha" "$head_sha"
+      fi
+    elif [ "$#" -eq 2 ] && [[ "$2" == repos/*/check-suites/10/check-runs\?per_page=100 ]]; then
+      printf '{"check_runs":[{"name":"Build","head_sha":"%s","conclusion":"success"},{"name":"Run unit Tests","head_sha":"%s","conclusion":"success"},{"name":"Check code quality","head_sha":"%s","conclusion":"success"},{"name":"publish-images","head_sha":"%s","conclusion":"success"}]}\n' "$head_sha" "$head_sha" "$head_sha" "$head_sha"
+    elif [ "$#" -eq 2 ] && [[ "$2" == repos/*/check-suites/[1-4]/check-runs\?per_page=100 ]]; then
+      suite=${2#*/check-suites/}; suite=${suite%%/*}
+      case "$suite" in
+        1) names=('publish-images' 'Compose smoke test') ;;
+        2) names=('Build' 'Run unit Tests' 'Check code quality') ;;
+        3) names=('build-docs') ;;
+        4) names=('preview') ;;
+      esac
+      printf '{"check_runs":['
+      separator=''
+      for name in "${names[@]}"; do
+        printf '%s{"name":"%s","head_sha":"%s","conclusion":"success"}' "$separator" "$name" "$head_sha"
+        separator=,
+      done
+      printf ']}\n'
+    elif [ "$#" -eq 4 ] && [[ "$2" == repos/*/git/ref/heads/main ]] &&
+      [ "$3" = --jq ] && [ "$4" = .object.sha ]; then
+      printf '%s\n' "$integrated_sha"
+    else
+      exit 64
+    fi
+    ;;
+
+  'workflow run')
+    [ "$#" -eq 13 ] && [ "$3" = cardano-node.yaml ] && [ "$4" = -R ] &&
+      [ "$6" = --ref ] && [ "$8" = -f ] && [ "$9" = test=cardano_amaru ] &&
+      [ "${10}" = -f ] && [ "${11}" = duration=1 ] && [ "${12}" = -f ] &&
+      [ "${13}" = no-faults=false ] || exit 64
+    printf 'boundary-gh workflow diagnostic\n'
+    ;;
+
+  'run list')
+    [ "$#" -eq 16 ] && [ "$3" = -R ] && [ "$5" = --workflow ] &&
+      [ "$6" = cardano-node.yaml ] && [ "$7" = --commit ] &&
+      [ "$9" = --event ] && [ "${10}" = workflow_dispatch ] &&
+      [ "${11}" = --limit ] && [ "${12}" = 10 ] && [ "${13}" = --json ] &&
+      [ "${14}" = databaseId,createdAt ] && [ "${15}" = --jq ] || exit 64
+    printf '4242\n'
+    ;;
+
+  'run watch')
+    [ "$#" -eq 6 ] && [ "$3" = 4242 ] && [ "$4" = -R ] &&
+      [ "$6" = --exit-status ] || exit 64
+    printf 'boundary-gh watch diagnostic\n'
+    ;;
+
+  *) exit 64 ;;
+esac

--- a/tests/fixtures/daily-amaru/boundary-nix.sh
+++ b/tests/fixtures/daily-amaru/boundary-nix.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$#" -eq 5 ] && [ "$1" = flake ] && [ "$2" = lock ] &&
+  [ "$3" = --override-input ] || {
+  printf 'boundary-nix: rejected arguments\n' >&2
+  exit 64
+}
+
+input_name=$4
+reference=$5
+[[ "$reference" =~ ^github:pragma-org/amaru/([0-9a-f]{40})$ ]] || {
+  printf 'boundary-nix: rejected reference: %s\n' "$reference" >&2
+  exit 64
+}
+sha=${BASH_REMATCH[1]}
+tmp=flake.lock.boundary-new
+
+jq --arg input "$input_name" --arg sha "$sha" '
+  (.nodes.root.inputs[$input] |
+    if type == "array" then .[0] else . end) as $node |
+  .nodes[$node].original.owner = "pragma-org" |
+  .nodes[$node].original.repo = "amaru" |
+  .nodes[$node].locked.rev = $sha |
+  .nodes[$node].locked.narHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" |
+  .nodes[$node].locked.lastModified = 1787075200
+' flake.lock >"$tmp"
+mv "$tmp" flake.lock
+printf 'warning: boundary-nix rewrote %s\n' "$input_name" >&2

--- a/tests/fixtures/daily-amaru/test-transport-boundary.sh
+++ b/tests/fixtures/daily-amaru/test-transport-boundary.sh
@@ -25,6 +25,10 @@ boundary_seeded_count=0
 boundary_standins_verified=0
 boundary_census_ablated=0
 boundary_path_mutants_rejected=0
+guard_forced_failures=0
+guard_named_failures=0
+guard_mutants_rejected=0
+guard_sites=0
 
 upstream_sha=1111111111111111111111111111111111111111
 old_sha=0000000000000000000000000000000000000000
@@ -392,7 +396,7 @@ assert_boundary_census_derivation() {
   local ablation_call line_continuation="\\"
   printf -v ablation_call '    PATH="$%s" assert_pollution_with_remotes %s' \
     host_bin "$line_continuation"
-  before=$(grep -Fxc "$ablation_call" "$0")
+  before=$(grep -Fxc "$ablation_call" "$0" || true)
   [ "$before" -eq 1 ] ||
     fail "census-ablation-removal mutant expected one re-run call, found $before"
   awk -v needle="$ablation_call" '
@@ -404,7 +408,7 @@ assert_boundary_census_derivation() {
     { print }
   ' "$0" >"$mutant"
   chmod +x "$mutant"
-  after=$(grep -c '^    : # MUTANT: census ablation re-run removed$' "$mutant")
+  after=$(grep -c '^    : # MUTANT: census ablation re-run removed$' "$mutant" || true)
   [ "$after" -eq 1 ] &&
     [ "$(grep -Fxc "$ablation_call" "$mutant" || true)" -eq 0 ] ||
     fail 'census-ablation-removal mutation did not apply'
@@ -679,7 +683,7 @@ assert_boundary_marker_derivation() {
   local log="$tmp_root/boundary-verification-removed.log" before after
   local assertion_line
   printf -v assertion_line '  assert_boundary_path "$%s"' expected_bin
-  before=$(grep -Fxc "$assertion_line" "$0")
+  before=$(grep -Fxc "$assertion_line" "$0" || true)
   [ "$before" -eq 1 ] ||
     fail "verification-removal mutant expected one operation-path assertion, found $before"
   awk -v needle="$assertion_line" '
@@ -687,7 +691,7 @@ assert_boundary_marker_derivation() {
     { print }
   ' "$0" >"$mutant"
   chmod +x "$mutant"
-  after=$(grep -c '^  : # MUTANT: operation-path verification removed$' "$mutant")
+  after=$(grep -c '^  : # MUTANT: operation-path verification removed$' "$mutant" || true)
   [ "$after" -eq 1 ] &&
     [ "$(grep -Fxc "$assertion_line" "$mutant" || true)" -eq 0 ] ||
     fail 'verification-removal mutation did not apply'
@@ -696,6 +700,112 @@ assert_boundary_marker_derivation() {
   fi
   grep -Fq 'boundary operation path verified no stand-ins' "$log" ||
     fail "verification-removal mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+}
+
+assert_named_guard_failure() {
+  local label=$1 mutant=$2 mutant_scenario=$3 fingerprint=$4
+  local log="$tmp_root/guard-$label.log"
+  chmod +x "$mutant"
+  if "$mutant" "$repo_root" "$mutant_scenario" >"$log" 2>&1; then
+    fail "guarded failure passed: $label"
+  fi
+  guard_forced_failures=$((guard_forced_failures + 1))
+  if grep -Fq "FAIL: $fingerprint" "$log"; then
+    guard_named_failures=$((guard_named_failures + 1))
+  else
+    fail "guarded failure died without its named diagnostic: $label: $(tr '\n' ' ' <"$log")"
+  fi
+}
+
+guard_site_census() {
+  awk '
+    /^assert_boundary_(census|marker)_derivation\(\) \{$/ { inside = 1; next }
+    inside && /^}$/ { inside = 0; next }
+    inside && /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(grep -[^ ]*c[[:space:]]/ {
+      sites++
+    }
+    END { print sites + 0 }
+  ' "$1"
+}
+
+assert_guard_diagnostics() {
+  local root="$tmp_root/guard-diagnostics" mutant log
+  local census_call marker_call census_after census_missing marker_after marker_missing
+  mkdir -p "$root"
+  guard_sites=$(guard_site_census "$0")
+  [ "$guard_sites" -gt 0 ] || fail 'guard-site census found no derivation guards'
+  printf -v census_call '    PATH="$%s" assert_pollution_with_remotes %s' \
+    host_bin "\\"
+  printf -v marker_call '  assert_boundary_path "$%s"' expected_bin
+  census_after="  after=\$(grep -c '^    : # MUTANT: census ablation re-run removed$' \"\$mutant\" || true)"
+  census_missing="  after=\$(grep -c '^    : # MUTANT: missing census marker$' \"\$mutant\" || true)"
+  marker_after="  after=\$(grep -c '^  : # MUTANT: operation-path verification removed$' \"\$mutant\" || true)"
+  marker_missing="  after=\$(grep -c '^  : # MUTANT: missing verification marker$' \"\$mutant\" || true)"
+
+  "$0" "$repo_root" guard-census-derivation >"$root/census-positive.log" 2>&1 ||
+    fail 'census guard positive control failed'
+  "$0" "$repo_root" guard-marker-derivation >"$root/marker-positive.log" 2>&1 ||
+    fail 'marker guard positive control failed'
+
+  mutant="$root/census-before-zero.sh"
+  awk -v needle="$census_call" '$0 != needle { print }' "$0" >"$mutant"
+  ! grep -Fqx "$census_call" "$mutant" || fail 'census-before-zero mutation did not apply'
+  assert_named_guard_failure census-before "$mutant" guard-census-derivation \
+    'census-ablation-removal mutant expected one re-run call, found 0'
+
+  mutant="$root/census-after-zero.sh"
+  awk -v needle="$census_after" -v replacement="$census_missing" '
+    $0 == needle { print replacement; changed++; next }
+    { print }
+    END { if (changed != 1) exit 42 }
+  ' "$0" >"$mutant"
+  grep -Fqx "$census_missing" "$mutant" || fail 'census-after-zero mutation did not apply'
+  assert_named_guard_failure census-after "$mutant" guard-census-derivation \
+    'census-ablation-removal mutation did not apply'
+
+  mutant="$root/marker-before-zero.sh"
+  awk -v needle="$marker_call" '$0 != needle { print }' "$0" >"$mutant"
+  ! grep -Fqx "$marker_call" "$mutant" || fail 'marker-before-zero mutation did not apply'
+  assert_named_guard_failure marker-before "$mutant" guard-marker-derivation \
+    'verification-removal mutant expected one operation-path assertion, found 0'
+
+  mutant="$root/marker-after-zero.sh"
+  awk -v needle="$marker_after" -v replacement="$marker_missing" '
+    $0 == needle { print replacement; changed++; next }
+    { print }
+    END { if (changed != 1) exit 42 }
+  ' "$0" >"$mutant"
+  grep -Fqx "$marker_missing" "$mutant" || fail 'marker-after-zero mutation did not apply'
+  assert_named_guard_failure marker-after "$mutant" guard-marker-derivation \
+    'verification-removal mutation did not apply'
+
+  mutant="$root/bare-guard-restored.sh"
+  awk -v needle="$census_call" '
+    $0 == "  before=$(grep -Fxc \"$ablation_call\" \"$0\" || true)" {
+      print "  before=$(grep -Fxc \"$ablation_call\" \"$0\")"
+      changed++
+      next
+    }
+    $0 == needle { next }
+    { print }
+    END { if (changed != 1) exit 42 }
+  ' "$0" >"$mutant"
+  chmod +x "$mutant"
+  # shellcheck disable=SC2016
+  grep -Fqx '  before=$(grep -Fxc "$ablation_call" "$0")' "$mutant" ||
+    fail 'bare-guard restoration mutant did not apply'
+  log="$root/bare-guard-restored.log"
+  if "$mutant" "$repo_root" guard-census-derivation >"$log" 2>&1; then
+    fail 'bare-guard restoration mutant passed'
+  fi
+  if grep -q '^FAIL:' "$log"; then
+    fail "bare-guard restoration mutant did not reproduce a silent death: $(tr '\n' ' ' <"$log")"
+  fi
+  guard_mutants_rejected=$((guard_mutants_rejected + 1))
+  [ "$guard_forced_failures" -eq "$guard_sites" ] ||
+    fail "guard census found $guard_sites sites but forced $guard_forced_failures"
+  [ "$guard_named_failures" -eq "$guard_forced_failures" ] ||
+    fail "guard proof forced $guard_forced_failures failures but named $guard_named_failures"
 }
 
 reject_scenario_mutant() {
@@ -783,12 +893,16 @@ case "$scenario" in
     assert_boundary_path_mutants
     assert_boundary_marker_derivation
     assert_boundary_census_derivation
+    assert_guard_diagnostics
     printf 'VALUE-CHANNEL operations=%s executed=%s census=complete mutants_rejected=%s\n' \
       "$value_operation_count" "$value_executed_count" "$value_mutants_rejected"
     printf 'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha real_git=1 real_transport=1\n'
     printf 'PROPOSAL-REATTEMPT adopt=1 foreign=1 fresh=1 mutants_rejected=4\n'
     print_boundary_path_marker
     printf 'BOUNDARY-PATH-DERIVED verification_removed=rejected seed_fabricated=rejected relative_root=rejected census_ablation_removed=rejected\n'
+    printf 'GUARD-DIAGNOSTICS sites=%s forced=%s named=%s mutants_rejected=%s\n' \
+      "$guard_sites" "$guard_forced_failures" "$guard_named_failures" \
+      "$guard_mutants_rejected"
     ;;
   ablation)
     assert_pollution_closed ablation-control
@@ -799,6 +913,12 @@ case "$scenario" in
     prepare_case marker
     run_boundary_command "$bin" "$bin/bash" -c :
     print_boundary_path_marker
+    ;;
+  guard-census-derivation)
+    assert_boundary_census_derivation
+    ;;
+  guard-marker-derivation)
+    assert_boundary_marker_derivation
     ;;
   *) fail "unknown scenario: $scenario" ;;
 esac

--- a/tests/fixtures/daily-amaru/test-transport-boundary.sh
+++ b/tests/fixtures/daily-amaru/test-transport-boundary.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=${1:?repository root is required}
+scenario=${2:-all}
+controller="$repo_root/scripts/daily-amaru.sh"
+transport=${DAILY_AMARU_BOUNDARY_TRANSPORT:-$repo_root/scripts/daily-amaru-github.sh}
+fixture_root="$repo_root/tests/fixtures/daily-amaru"
+fake_gh="$fixture_root/boundary-gh.sh"
+fake_nix="$fixture_root/boundary-nix.sh"
+fake_docker="$fixture_root/boundary-docker.sh"
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
+
+upstream_sha=1111111111111111111111111111111111111111
+old_sha=0000000000000000000000000000000000000000
+foreign_sha=2222222222222222222222222222222222222222
+day=2026-08-19
+branch="daily-amaru/bootstrap-$day-${upstream_sha:0:12}"
+workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+write_lock() {
+  local path=$1 sha=$2
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' \
+    '{' \
+    '  "nodes": {' \
+    '    "root": {"inputs": {"amaru": "stock"}},' \
+    '    "stock": {' \
+    '      "original": {"owner": "pragma-org", "repo": "amaru"},' \
+    "      \"locked\": {\"rev\": \"$sha\", \"narHash\": \"sha256-old\", \"lastModified\": 1}" \
+    '    }' \
+    '  },' \
+    '  "root": "root",' \
+    '  "version": 7' \
+    '}' >"$path"
+}
+
+create_remote() {
+  local label=$1
+  local seed="$tmp_root/$label-seed"
+  local remote="$tmp_root/$label.git"
+  git init --quiet --initial-branch=main "$seed"
+  git -C "$seed" config user.name boundary
+  git -C "$seed" config user.email boundary@example.invalid
+  write_lock "$seed/flake.lock" "$old_sha"
+  printf 'boundary\n' >"$seed/README.md"
+  git -C "$seed" add .
+  git -C "$seed" commit --quiet -m base
+  git clone --quiet --bare "$seed" "$remote"
+  printf '%s\n' "$remote"
+}
+
+create_consumer_remote() {
+  local label=$1
+  local seed="$tmp_root/$label-consumer-seed"
+  local remote="$tmp_root/$label-consumer.git"
+  git init --quiet --initial-branch=main "$seed"
+  git -C "$seed" config user.name boundary
+  git -C "$seed" config user.email boundary@example.invalid
+  mkdir -p "$seed/testnets" "$seed/scripts"
+  printf 'services:\n  producer:\n    image: ghcr.io/lambdasistemi/amaru-bootstrap-producer:old@sha256:%064d\n' \
+    0 >"$seed/testnets/compose.yaml"
+  cp "$repo_root/scripts/check-amaru-producer-image-refs.sh" "$seed/scripts/"
+  chmod +x "$seed/scripts/check-amaru-producer-image-refs.sh"
+  git -C "$seed" add .
+  git -C "$seed" commit --quiet -m base
+  git clone --quiet --bare "$seed" "$remote"
+  printf '%s\n' "$remote"
+}
+
+seed_proposal() {
+  local remote=$1 kind=$2
+  local work
+  work=$(mktemp -d "$tmp_root/seed-$kind.XXXXXX")
+  git clone --quiet "file://$remote" "$work"
+  git -C "$work" config user.name boundary
+  git -C "$work" config user.email boundary@example.invalid
+  git -C "$work" checkout --quiet -b "$branch" origin/main
+  case "$kind" in
+    adopt)
+      (cd "$work" && "$fake_nix" flake lock --override-input amaru \
+        "github:pragma-org/amaru/$upstream_sha")
+      ;;
+    foreign)
+      (cd "$work" && "$fake_nix" flake lock --override-input amaru \
+        "github:pragma-org/amaru/$foreign_sha")
+      ;;
+    *) fail "unknown seed kind: $kind" ;;
+  esac
+  git -C "$work" add .
+  git -C "$work" commit --quiet -m "$kind proposal"
+  git -C "$work" push --quiet origin "HEAD:refs/heads/$branch"
+  git --git-dir="$remote" rev-parse "refs/heads/$branch"
+}
+
+prepare_case() {
+  local label=$1
+  case_root=$(mktemp -d "$tmp_root/$label.XXXXXX")
+  state="$case_root/state"
+  bin="$case_root/bin"
+  effects="$case_root/effects"
+  comments="$case_root/comments"
+  stdout="$case_root/stdout"
+  stderr="$case_root/stderr"
+  receipt="$case_root/receipt"
+  mkdir -p "$state" "$bin"
+  : >"$effects"
+  : >"$comments"
+  ln -s "$fake_gh" "$bin/gh"
+  ln -s "$fake_nix" "$bin/nix"
+  ln -s "$fake_docker" "$bin/docker"
+}
+
+run_transport() {
+  local label=$1 remote=$2
+  prepare_case "$label"
+  transport_rc=0
+  env \
+    PATH="$bin:$PATH" \
+    DAILY_AMARU_DAY="$day" \
+    DAILY_AMARU_IDENTITY=boundary-bootstrap-token \
+    GH_TOKEN=boundary-repository-token \
+    DAILY_AMARU_STATE_DIR="$state" \
+    DAILY_AMARU_RECEIPT="$receipt" \
+    DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
+    DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
+    DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$remote" \
+    DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$remote" \
+    "$transport" propose-bootstrap "$upstream_sha" \
+    >"$stdout" 2>"$stderr" || transport_rc=$?
+}
+
+assert_adopt() {
+  local remote before after output
+  remote=$(create_remote adopt)
+  before=$(seed_proposal "$remote" adopt)
+  run_transport adopt "$remote"
+  output=$(cat "$stdout")
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -eq 0 ] ||
+    fail "PROPOSAL-REATTEMPT reproduced=non-fast-forward: $(tr '\n' ' ' <"$stderr")"
+  [ "$output" = "$before" ] || fail "adopt emitted '$output', expected $before"
+  [ "$after" = "$before" ] || fail 'adopt changed the remote ref'
+  ! grep -Fq 'gh pr create' "$effects" || fail 'adopt attempted to create a PR'
+  grep -Fq 'gh pr view' "$effects" || fail 'adopt did not reuse the existing PR lookup'
+  ! git -C "$state/bootstrap" show-ref --verify --quiet "refs/heads/$branch" ||
+    fail 'adopt created the proposal branch locally before classification'
+}
+
+assert_foreign() {
+  local remote before after
+  remote=$(create_remote foreign)
+  before=$(seed_proposal "$remote" foreign)
+  run_transport foreign "$remote"
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -ne 0 ] || fail 'foreign proposal was accepted'
+  [ ! -s "$stdout" ] || fail 'foreign proposal emitted a value'
+  grep -Fq 'foreign-proposal-branch' "$stderr" || fail 'foreign proposal lacked its named red'
+  [ "$after" = "$before" ] || fail 'foreign proposal changed the remote ref'
+  ! grep -Eq 'gh pr (create|view)' "$effects" || fail 'foreign proposal reached a PR effect'
+  ! git -C "$state/bootstrap" show-ref --verify --quiet "refs/heads/$branch" ||
+    fail 'foreign classification ran after local branch creation'
+}
+
+assert_fresh() {
+  local remote output remote_head changed
+  remote=$(create_remote fresh)
+  run_transport fresh "$remote"
+  output=$(cat "$stdout")
+  [ "$transport_rc" -eq 0 ] || fail "fresh proposal failed: $(tr '\n' ' ' <"$stderr")"
+  [[ "$output" =~ ^[0-9a-f]{40}$ ]] || fail "fresh proposal emitted malformed head: $output"
+  remote_head=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$output" = "$remote_head" ] || fail 'fresh output differs from pushed head'
+  changed=$(git --git-dir="$remote" diff --name-only main "$branch")
+  [ "$changed" = flake.lock ] || fail "fresh proposal changed: $changed"
+  grep -Fq 'gh pr create' "$effects" || fail 'fresh proposal did not create its PR'
+}
+
+assert_pollution_closed() {
+  local bootstrap_remote upstream_remote final_error candidate
+  bootstrap_remote=$(create_remote bootstrap)
+  upstream_remote=$(create_remote upstream)
+  prepare_case pollution
+  controller_rc=0
+  env \
+    PATH="$bin:$PATH" \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0="url.file://$upstream_remote.insteadOf" \
+    GIT_CONFIG_VALUE_0=https://github.com/pragma-org/amaru.git \
+    DAILY_AMARU_MODE=production \
+    DAILY_AMARU_DAY="$day" \
+    DAILY_AMARU_HEAD="$workflow_head" \
+    DAILY_AMARU_IDENTITY=boundary-bootstrap-token \
+    GH_TOKEN=boundary-repository-token \
+    DAILY_AMARU_STATE_DIR="$state" \
+    DAILY_AMARU_RECEIPT="$receipt" \
+    DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
+    DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
+    DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_TRANSPORT="$transport" \
+    "$controller" >"$stdout" 2>"$stderr" || controller_rc=$?
+  final_error=$(sed -n 's/^error=//p' "$receipt" | tail -1)
+  candidate=$(sed -n 's/^bootstrap_candidate_sha=//p' "$receipt" | tail -1)
+  if [ "$final_error" = malformed-candidate-sha ]; then
+    grep -Fq 'bootstrap-proposal: malformed-candidate-sha' "$stderr" ||
+      fail 'pollution reached the wrong malformed-candidate fingerprint'
+    fail 'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha real_git=1 real_transport=1'
+  fi
+  [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "fixed controller recorded no bootstrap candidate (error=$final_error rc=$controller_rc)"
+}
+
+declare -A executed_value_operations=()
+
+execute_value_operation() {
+  local operation=$1 expected='' candidate='' rc=0
+  local bootstrap_remote consumer_remote origin_sha image_ref
+  local -a arguments=()
+  bootstrap_remote=$(create_remote "value-$operation-bootstrap")
+  consumer_remote=$(create_consumer_remote "value-$operation")
+  prepare_case "value-$operation"
+  image_ref="ghcr.io/lambdasistemi/amaru-bootstrap-producer:$upstream_sha@sha256:$(printf '%064d' 0)"
+
+  case "$operation" in
+    preflight) arguments=(gh git jq); expected='OK: 3 scheduled dependencies present: gh git jq' ;;
+    claim-day) arguments=("$day" "$workflow_head"); expected=CLAIMED ;;
+    claim-sha-attempt) arguments=("$upstream_sha" "$workflow_head"); expected=CLAIMED ;;
+    claim-launch) arguments=("$day" "$workflow_head"); expected=CLAIMED ;;
+    resolve-upstream)
+      origin_sha=$(git --git-dir="$bootstrap_remote" rev-parse refs/heads/main)
+      arguments=("file://$bootstrap_remote" refs/heads/main)
+      expected="file://$bootstrap_remote|refs/heads/main|$origin_sha"
+      ;;
+    last-success-sha)
+      printf '<!-- daily-amaru last-success sha=%s -->\n' "$upstream_sha" >"$comments"
+      expected=$upstream_sha
+      ;;
+    propose-bootstrap) arguments=("$upstream_sha") ;;
+    require-bootstrap-checks)
+      arguments=("$workflow_head")
+      expected=$(printf 'Bootstrap CI|%s|%s|success\n' \
+        Build "$workflow_head" 'Run unit Tests' "$workflow_head" \
+        'Check code quality' "$workflow_head" publish-images "$workflow_head")
+      ;;
+    resolve-image)
+      arguments=("$upstream_sha")
+      expected=$image_ref
+      ;;
+    prepare-consumer-repin) arguments=("$image_ref") ;;
+    require-consumer-checks)
+      arguments=("$workflow_head")
+      expected=$(printf '%s|%s|%s|success\n' \
+        'Build and push component images for cardano-node testnet' publish-images "$workflow_head" \
+        'Build and push component images for cardano-node testnet' 'Compose smoke test' "$workflow_head" \
+        'tracer-sidecar CI' Build "$workflow_head" \
+        'tracer-sidecar CI' 'Run unit Tests' "$workflow_head" \
+        'tracer-sidecar CI' 'Check code quality' "$workflow_head" \
+        'Build documentation' build-docs "$workflow_head" \
+        'PR preview' preview "$workflow_head")
+      ;;
+    run-producer-check)
+      git clone --quiet "file://$consumer_remote" "$state/consumer"
+      candidate=$(git -C "$state/consumer" rev-parse HEAD)
+      arguments=("$candidate")
+      expected="OK: 1 producer-image reference(s), all pinned to ghcr.io/lambdasistemi/amaru-bootstrap-producer:old@sha256:$(printf '%064d' 0)"
+      ;;
+    await-supervised-integration)
+      printf 'https://example.invalid/pull/1\n' >"$state/consumer-pr"
+      arguments=("$workflow_head")
+      expected=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    fake-launch)
+      arguments=(cardano-node.yaml cardano_amaru duration=1 no-faults=false "$workflow_head")
+      expected="fake://cardano-node.yaml/cardano_amaru/duration=1/no-faults=false/$workflow_head"
+      ;;
+    real-launch)
+      arguments=(cardano-node.yaml cardano_amaru duration=1 no-faults=false bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+      expected='https://github.com/cardano-foundation/cardano-node-antithesis/actions/runs/4242'
+      ;;
+    *) fail "unknown value operation: $operation" ;;
+  esac
+
+  env PATH="$bin:$PATH" GIT_TRACE=1 DAILY_AMARU_DAY="$day" \
+    DAILY_AMARU_IDENTITY=boundary-bootstrap-token GH_TOKEN=boundary-repository-token \
+    DAILY_AMARU_STATE_DIR="$state" DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
+    DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
+    DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$consumer_remote" \
+    DAILY_AMARU_BOUNDARY_HEAD_SHA="$workflow_head" \
+    DAILY_AMARU_BOUNDARY_INTEGRATED_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    "$transport" "$operation" "${arguments[@]}" >"$stdout" 2>"$stderr" || rc=$?
+  [ "$rc" -eq 0 ] || fail "value operation $operation failed: $(tr '\n' ' ' <"$stderr")"
+  case "$operation" in
+    propose-bootstrap) expected=$(git --git-dir="$bootstrap_remote" rev-parse "refs/heads/$branch") ;;
+    prepare-consumer-repin)
+      expected=$(git --git-dir="$consumer_remote" rev-parse "refs/heads/daily-amaru/consumer-$day")
+      ;;
+  esac
+  printf '%s\n' "$expected" >"$case_root/expected"
+  cmp -s "$case_root/expected" "$stdout" ||
+    fail "value operation $operation emitted non-exact bytes: $(od -An -tx1 "$stdout" | tr -d ' \n')"
+  executed_value_operations["$operation"]=1
+}
+
+assert_value_census() {
+  local operation
+  local -a dispatched_operations executed_operations
+  for operation in preflight claim-day resolve-upstream last-success-sha \
+    claim-sha-attempt claim-launch propose-bootstrap require-bootstrap-checks \
+    resolve-image prepare-consumer-repin require-consumer-checks run-producer-check \
+    await-supervised-integration fake-launch real-launch; do
+    execute_value_operation "$operation"
+  done
+  mapfile -t dispatched_operations < <(
+    grep -E '^  [a-z0-9-]+\)$' "$transport" | sed 's/^  //; s/)$//' |
+      grep -vx receipt | sort
+  )
+  mapfile -t executed_operations < <(printf '%s\n' "${!executed_value_operations[@]}" | sort)
+  [ "${dispatched_operations[*]}" = "${executed_operations[*]}" ] ||
+    fail "value operation dispatch drift: dispatched=${dispatched_operations[*]} executed=${executed_operations[*]}"
+  value_operation_count=${#dispatched_operations[@]}
+  value_executed_count=${#executed_operations[@]}
+
+  prepare_case strict-api
+  if DAILY_AMARU_BOUNDARY_GH_LOG="$effects" DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
+    "$fake_gh" api repos/example/unsupported >"$stdout" 2>"$stderr"; then
+    fail 'boundary-gh accepted an API endpoint outside the real CLI surface'
+  fi
+}
+
+assert_receipt_schema() {
+  local mutant="$tmp_root/receipt-schema-mutant.sh"
+  local -a expected actual mutant_actual
+  expected=(
+    day stage outcome error workflow_head claim_supersedes launch_claim
+    dependency_census upstream_origin upstream_ref upstream_sha
+    bootstrap_candidate_sha image_ref consumer_candidate_sha check_evidence
+    producer_count producer_evidence consumer_integrated_sha launch_workflow
+    launch_test launch_duration launch_no_faults launch_request moog_request
+    run_outcome
+  )
+  mapfile -t actual < <(awk '
+    /^receipt_keys=\($/ { inside = 1; next }
+    inside && /^\)$/ { exit }
+    inside { for (i = 1; i <= NF; i++) print $i }
+  ' "$controller")
+  [ "${actual[*]}" = "${expected[*]}" ] || fail 'receipt_keys changed from the frozen schema'
+  sed 's/launch_request moog_request/launch_request_removed moog_request/' \
+    "$controller" >"$mutant"
+  grep -Fq 'launch_request_removed moog_request' "$mutant" ||
+    fail 'receipt schema mutation did not apply'
+  mapfile -t mutant_actual < <(awk '
+    /^receipt_keys=\($/ { inside = 1; next }
+    inside && /^\)$/ { exit }
+    inside { for (i = 1; i <= NF; i++) print $i }
+  ' "$mutant")
+  [ "${mutant_actual[*]}" != "${expected[*]}" ] ||
+    fail 'receipt schema oracle accepted a changed key'
+  printf 'RECEIPT-SCHEMA keys=%s unchanged=true\n' "${#actual[@]}"
+}
+
+assert_value_mutants() {
+  local mutant_root="$tmp_root/value-mutants" mutant operation marker
+  mkdir -p "$mutant_root"
+  value_mutants_rejected=0
+  for operation in real-launch prepare-consumer-repin require-consumer-checks resolve-image; do
+    mutant="$mutant_root/$operation.sh"
+    marker="# value-mutant-$operation"
+    awk -v operation="$operation" -v marker="$marker" '
+      $0 == "  " operation ")" { inside = 1 }
+      inside && operation == "real-launch" && /gh run watch/ {
+        sub(/with_identity/, "watch_output=$(with_identity")
+        sub(/--exit-status$/, "--exit-status)")
+        print
+        print "    emit \"$watch_output\" " marker
+        next
+      }
+      { print }
+      inside && operation == "prepare-consumer-repin" && /consumer-pr/ && /^    printf/ {
+        print "    emit \"$pr_url\" " marker
+      }
+      inside && operation == "require-consumer-checks" && /^    emit "\$rows"/ {
+        print "    emit \"$rows\" " marker
+      }
+      inside && operation == "resolve-image" && /invalid registry digest/ {
+        print "    emit \"$digest\" " marker
+      }
+      inside && $0 == "    ;;" { inside = 0 }
+    ' "$transport" >"$mutant"
+    grep -Fq "$marker" "$mutant" || fail "value mutation did not apply: $operation"
+    bash -n "$mutant" || fail "value mutation is not valid shell: $operation"
+    chmod +x "$mutant"
+    reject_scenario_mutant "value-$operation" "$mutant" census \
+      "value operation $operation emitted non-exact bytes"
+    value_mutants_rejected=$((value_mutants_rejected + 1))
+    printf 'VALUE-MUTANT name=%s rejected=true\n' "$operation"
+  done
+}
+
+reject_scenario_mutant() {
+  local label=$1 script=$2 mutant_scenario=$3 fingerprint=$4
+  local log="$tmp_root/$label.log"
+  if DAILY_AMARU_BOUNDARY_TRANSPORT="$script" "$0" "$repo_root" \
+    "$mutant_scenario" >"$log" 2>&1; then
+    fail "mutant passed: $label"
+  fi
+  grep -Fq "$fingerprint" "$log" ||
+    fail "mutant $label failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+}
+
+assert_mutants() {
+  local mutant_root="$tmp_root/mutants"
+  local pollution adoption foreign fresh ordering
+  mkdir -p "$mutant_root"
+
+  pollution="$mutant_root/pollution.sh"
+  sed '/^exec 1>&2$/d' "$transport" >"$pollution"
+  ! grep -Fqx 'exec 1>&2' "$pollution" || fail 'pollution mutation did not apply'
+  chmod +x "$pollution"
+  reject_scenario_mutant pollution "$pollution" pollution \
+    'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha'
+
+  adoption="$mutant_root/adoption.sh"
+  sed "0,/printf 'adoptable\\\\n'/{s//printf 'absent\\\\n'/}" "$transport" >"$adoption"
+  grep -Fq "printf 'absent\\n'" "$adoption" || fail 'adoption mutation did not apply'
+  chmod +x "$adoption"
+  reject_scenario_mutant adoption "$adoption" reattempt \
+    'PROPOSAL-REATTEMPT reproduced=non-fast-forward'
+
+  foreign="$mutant_root/foreign.sh"
+  sed "s/printf 'foreign\\\\n'/printf 'adoptable\\\\n'/g" "$transport" >"$foreign"
+  grep -Fq "printf 'adoptable\\n'" "$foreign" || fail 'foreign mutation did not apply'
+  chmod +x "$foreign"
+  reject_scenario_mutant foreign "$foreign" foreign 'foreign proposal was accepted'
+
+  fresh="$mutant_root/fresh.sh"
+  sed "0,/printf 'absent\\\\n'/{s//printf 'foreign\\\\n'/}" "$transport" >"$fresh"
+  grep -Fq "printf 'foreign\\n'" "$fresh" || fail 'fresh mutation did not apply'
+  chmod +x "$fresh"
+  reject_scenario_mutant fresh "$fresh" fresh 'fresh proposal failed'
+
+  ordering="$mutant_root/ordering.sh"
+  awk '
+    { print }
+    $0 ~ /^  local merge_base/ {
+      print "  git -C \"$directory\" checkout -b \"$branch\" origin/main >/dev/null # ordering-mutant"
+    }
+  ' "$transport" >"$ordering"
+  grep -Fq '# ordering-mutant' "$ordering" || fail 'ordering mutation did not apply'
+  chmod +x "$ordering"
+  reject_scenario_mutant ordering "$ordering" foreign \
+    'classification ran after local branch creation'
+}
+
+case "$scenario" in
+  pollution)
+    assert_pollution_closed
+    ;;
+  reattempt)
+    assert_adopt
+    ;;
+  foreign)
+    assert_foreign
+    ;;
+  fresh)
+    assert_fresh
+    ;;
+  census)
+    assert_value_census
+    ;;
+  all)
+    assert_pollution_closed
+    assert_adopt
+    assert_foreign
+    assert_fresh
+    assert_value_census
+    assert_value_mutants
+    assert_receipt_schema
+    assert_mutants
+    printf 'VALUE-CHANNEL operations=%s executed=%s census=complete mutants_rejected=%s\n' \
+      "$value_operation_count" "$value_executed_count" "$value_mutants_rejected"
+    printf 'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha real_git=1 real_transport=1\n'
+    printf 'PROPOSAL-REATTEMPT adopt=1 foreign=1 fresh=1 mutants_rejected=4\n'
+    ;;
+  *) fail "unknown scenario: $scenario" ;;
+esac

--- a/tests/fixtures/daily-amaru/test-transport-boundary.sh
+++ b/tests/fixtures/daily-amaru/test-transport-boundary.sh
@@ -12,6 +12,20 @@ fake_docker="$fixture_root/boundary-docker.sh"
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT
 
+seeded_commands=(
+  bash cat date dirname find git grep head jq mkdir mv sed seq sleep sort tail tr awk
+)
+standin_commands=(gh nix docker rg)
+scheduled_command_census=()
+
+declare -A boundary_seed_sources=()
+declare -A boundary_standin_sources=()
+boundary_sources_bound=0
+boundary_seeded_count=0
+boundary_standins_verified=0
+boundary_census_ablated=0
+boundary_path_mutants_rejected=0
+
 upstream_sha=1111111111111111111111111111111111111111
 old_sha=0000000000000000000000000000000000000000
 foreign_sha=2222222222222222222222222222222222222222
@@ -22,6 +36,111 @@ workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
+}
+
+write_rg_standin() {
+  local path=$1
+  cat >"$path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$#" -eq 7 ] && [ "$1" = -l ] && [ "$4" = -g ] &&
+  [ "$5" = '*.yaml' ] && [ "$6" = -g ] && [ "$7" = '*.yml' ] || exit 64
+pattern=$2
+root=$3
+for file in "$root"/*.yaml "$root"/*.yml; do
+  [ -f "$file" ] || continue
+  grep -Eq "$pattern" "$file" && printf '%s\n' "$file"
+done
+EOF
+  chmod +x "$path"
+}
+
+bind_boundary_sources() {
+  local command source_dir target
+  [ "$boundary_sources_bound" -eq 0 ] || return 0
+
+  mapfile -t scheduled_command_census < <(awk '
+    /^scheduled_command_census=\($/ { inside = 1; next }
+    inside && /^\)$/ { exit }
+    inside { for (i = 1; i <= NF; i++) print $i }
+  ' "$transport")
+  [ "${#scheduled_command_census[@]}" -gt 0 ] ||
+    fail 'transport scheduled command census is empty'
+
+  for command in "${seeded_commands[@]}"; do
+    target=$(command -v "$command" 2>/dev/null || true)
+    [ "${target:0:1}" = / ] && [ -x "$target" ] ||
+      fail "cannot bind seeded command $command: ${target:-unresolved}"
+    boundary_seed_sources["$command"]=$target
+  done
+
+  source_dir="$tmp_root/boundary-standins"
+  mkdir -p "$source_dir"
+  ln -sf "$fake_gh" "$source_dir/gh"
+  ln -sf "$fake_nix" "$source_dir/nix"
+  ln -sf "$fake_docker" "$source_dir/docker"
+  write_rg_standin "$source_dir/rg"
+  for command in "${standin_commands[@]}"; do
+    target="$source_dir/$command"
+    [ "${target:0:1}" = / ] && [ -x "$target" ] ||
+      fail "cannot bind stand-in $command: $target"
+    boundary_standin_sources["$command"]=$target
+  done
+  boundary_sources_bound=1
+}
+
+seed_boundary_path() {
+  local bin_dir=$1 command target
+  bind_boundary_sources
+  for command in "${seeded_commands[@]}"; do
+    target=${boundary_seed_sources[$command]:-}
+    [ "${target:0:1}" = / ] && [ -x "$target" ] ||
+      fail "cannot bind seeded command $command: ${target:-unresolved}"
+    ln -sf "$target" "$bin_dir/$command"
+    boundary_seeded_count=$((boundary_seeded_count + 1))
+  done
+  for command in "${standin_commands[@]}"; do
+    target=${boundary_standin_sources[$command]:-}
+    [ "${target:0:1}" = / ] && [ -x "$target" ] ||
+      fail "cannot bind stand-in $command: ${target:-unresolved}"
+    ln -sf "$target" "$bin_dir/$command"
+    boundary_seeded_count=$((boundary_seeded_count + 1))
+  done
+}
+
+assert_boundary_path() {
+  local expected_bin=$1 command expected resolved target
+  [ "${expected_bin:0:1}" = / ] ||
+    fail "boundary bin root is not absolute: $expected_bin"
+  [ "$PATH" = "$expected_bin" ] ||
+    fail "boundary PATH inherited host entries: $PATH"
+  for command in "${seeded_commands[@]}"; do
+    expected="$expected_bin/$command"
+    resolved=$(command -v "$command" 2>/dev/null || true)
+    target=${boundary_seed_sources[$command]:-}
+    [ "$resolved" = "$expected" ] && [ -x "$resolved" ] &&
+      [ -n "$target" ] && [ "$resolved" -ef "$target" ] ||
+      fail "seeded command $command is not bound to its proved source: ${resolved:-unresolved}"
+  done
+  for command in "${standin_commands[@]}"; do
+    expected="$expected_bin/$command"
+    resolved=$(command -v "$command" 2>/dev/null || true)
+    target=${boundary_standin_sources[$command]:-}
+    [ "$resolved" = "$expected" ] && [ -x "$resolved" ] &&
+      [ -n "$target" ] && [ "$resolved" -ef "$target" ] ||
+      fail "stand-in $command is not bound to its fixture binary: ${resolved:-unresolved}"
+    boundary_standins_verified=$((boundary_standins_verified + 1))
+  done
+}
+
+run_boundary_command() {
+  local expected_bin=$1
+  shift
+  local PATH=$expected_bin
+  export PATH
+  hash -r
+  assert_boundary_path "$expected_bin"
+  "$@"
 }
 
 write_lock() {
@@ -112,27 +231,25 @@ prepare_case() {
   mkdir -p "$state" "$bin"
   : >"$effects"
   : >"$comments"
-  ln -s "$fake_gh" "$bin/gh"
-  ln -s "$fake_nix" "$bin/nix"
-  ln -s "$fake_docker" "$bin/docker"
+  seed_boundary_path "$bin"
 }
 
 run_transport() {
   local label=$1 remote=$2
   prepare_case "$label"
   transport_rc=0
-  env \
-    PATH="$bin:$PATH" \
-    DAILY_AMARU_DAY="$day" \
+  DAILY_AMARU_DAY="$day" \
     DAILY_AMARU_IDENTITY=boundary-bootstrap-token \
     GH_TOKEN=boundary-repository-token \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
     DAILY_AMARU_STATE_DIR="$state" \
     DAILY_AMARU_RECEIPT="$receipt" \
     DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
     DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
     DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$remote" \
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$remote" \
-    "$transport" propose-bootstrap "$upstream_sha" \
+    run_boundary_command "$bin" "$transport" propose-bootstrap "$upstream_sha" \
     >"$stdout" 2>"$stderr" || transport_rc=$?
 }
 
@@ -182,17 +299,17 @@ assert_fresh() {
   grep -Fq 'gh pr create' "$effects" || fail 'fresh proposal did not create its PR'
 }
 
-assert_pollution_closed() {
-  local bootstrap_remote upstream_remote final_error candidate
-  bootstrap_remote=$(create_remote bootstrap)
-  upstream_remote=$(create_remote upstream)
-  prepare_case pollution
+assert_pollution_with_remotes() {
+  local label=$1 bootstrap_remote=$2 upstream_remote=$3
+  local record_census_ablation=${4:-false}
+  local final_error='' candidate='' key value
+  prepare_case "$label"
   controller_rc=0
-  env \
-    PATH="$bin:$PATH" \
-    GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_COUNT=1 \
     GIT_CONFIG_KEY_0="url.file://$upstream_remote.insteadOf" \
     GIT_CONFIG_VALUE_0=https://github.com/pragma-org/amaru.git \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
     DAILY_AMARU_MODE=production \
     DAILY_AMARU_DAY="$day" \
     DAILY_AMARU_HEAD="$workflow_head" \
@@ -205,9 +322,15 @@ assert_pollution_closed() {
     DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$bootstrap_remote" \
     DAILY_AMARU_TRANSPORT="$transport" \
-    "$controller" >"$stdout" 2>"$stderr" || controller_rc=$?
-  final_error=$(sed -n 's/^error=//p' "$receipt" | tail -1)
-  candidate=$(sed -n 's/^bootstrap_candidate_sha=//p' "$receipt" | tail -1)
+    run_boundary_command "$bin" "$controller" >"$stdout" 2>"$stderr" || controller_rc=$?
+  [ -f "$receipt" ] ||
+    fail "fixed controller wrote no receipt: $(tr '\n' ' ' <"$stderr")"
+  while IFS='=' read -r key value; do
+    case "$key" in
+      error) final_error=$value ;;
+      bootstrap_candidate_sha) candidate=$value ;;
+    esac
+  done <"$receipt"
   if [ "$final_error" = malformed-candidate-sha ]; then
     grep -Fq 'bootstrap-proposal: malformed-candidate-sha' "$stderr" ||
       fail 'pollution reached the wrong malformed-candidate fingerprint'
@@ -215,6 +338,81 @@ assert_pollution_closed() {
   fi
   [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] ||
     fail "fixed controller recorded no bootstrap candidate (error=$final_error rc=$controller_rc)"
+  boundary_pollution_verdict="$final_error|valid-candidate"
+  if [ "$record_census_ablation" = true ]; then
+    boundary_census_ablated=$((boundary_census_ablated + 1))
+  fi
+}
+
+assert_pollution_closed() {
+  local label=${1:-pollution} bootstrap_remote upstream_remote
+  bootstrap_remote=$(create_remote "$label-bootstrap")
+  upstream_remote=$(create_remote "$label-upstream")
+  assert_pollution_with_remotes "$label" "$bootstrap_remote" "$upstream_remote"
+}
+
+assert_boundary_census_ablation() {
+  local control=$boundary_pollution_verdict omit label host_bin command target
+  local bootstrap_remote upstream_remote
+  local -a support_commands=(bash ln mkdir mktemp)
+
+  for omit in "${scheduled_command_census[@]}"; do
+    label="boundary-ablate-$omit"
+    bootstrap_remote=$(create_remote "$label-bootstrap")
+    upstream_remote=$(create_remote "$label-upstream")
+    host_bin="$tmp_root/$label-host-bin"
+    mkdir -p "$host_bin"
+    for command in "${support_commands[@]}" "${scheduled_command_census[@]}"; do
+      [ "$command" = "$omit" ] && continue
+      target=${boundary_seed_sources[$command]:-${boundary_standin_sources[$command]:-}}
+      [ -n "$target" ] || target=$(command -v "$command" 2>/dev/null || true)
+      [ -n "$target" ] && [ -x "$target" ] || continue
+      ln -sf "$target" "$host_bin/$command"
+    done
+    if PATH="$host_bin" command -v "$omit" >/dev/null 2>&1; then
+      fail "boundary census ablation still resolves omitted command: $omit"
+    fi
+    PATH="$host_bin" command -v bash >/dev/null 2>&1 ||
+      fail "boundary census ablation host PATH cannot resolve its positive control: bash"
+    PATH="$host_bin" assert_pollution_with_remotes \
+      "$label" "$bootstrap_remote" "$upstream_remote" true
+    [ "$boundary_pollution_verdict" = "$control" ] ||
+      fail "boundary proof verdict changed without host command $omit: $boundary_pollution_verdict"
+  done
+}
+
+assert_boundary_census_complete() {
+  [ "$boundary_census_ablated" -eq "${#scheduled_command_census[@]}" ] ||
+    fail "boundary census ablation completed $boundary_census_ablated re-runs, expected ${#scheduled_command_census[@]}"
+}
+
+assert_boundary_census_derivation() {
+  local mutant="$tmp_root/boundary-census-ablation-removed.sh"
+  local log="$tmp_root/boundary-census-ablation-removed.log" before after
+  local ablation_call line_continuation="\\"
+  printf -v ablation_call '    PATH="$%s" assert_pollution_with_remotes %s' \
+    host_bin "$line_continuation"
+  before=$(grep -Fxc "$ablation_call" "$0")
+  [ "$before" -eq 1 ] ||
+    fail "census-ablation-removal mutant expected one re-run call, found $before"
+  awk -v needle="$ablation_call" '
+    $0 == needle {
+      print "    : # MUTANT: census ablation re-run removed"
+      getline
+      next
+    }
+    { print }
+  ' "$0" >"$mutant"
+  chmod +x "$mutant"
+  after=$(grep -c '^    : # MUTANT: census ablation re-run removed$' "$mutant")
+  [ "$after" -eq 1 ] &&
+    [ "$(grep -Fxc "$ablation_call" "$mutant" || true)" -eq 0 ] ||
+    fail 'census-ablation-removal mutation did not apply'
+  if "$mutant" "$repo_root" ablation >"$log" 2>&1; then
+    fail 'census-ablation-removal mutant passed'
+  fi
+  grep -Fq 'boundary census ablation completed 0 re-runs' "$log" ||
+    fail "census-ablation-removal mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
 }
 
 declare -A executed_value_operations=()
@@ -287,7 +485,8 @@ execute_value_operation() {
     *) fail "unknown value operation: $operation" ;;
   esac
 
-  env PATH="$bin:$PATH" GIT_TRACE=1 DAILY_AMARU_DAY="$day" \
+  GIT_TRACE=1 DAILY_AMARU_DAY="$day" GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
     DAILY_AMARU_IDENTITY=boundary-bootstrap-token GH_TOKEN=boundary-repository-token \
     DAILY_AMARU_STATE_DIR="$state" DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
     DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
@@ -295,7 +494,8 @@ execute_value_operation() {
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$consumer_remote" \
     DAILY_AMARU_BOUNDARY_HEAD_SHA="$workflow_head" \
     DAILY_AMARU_BOUNDARY_INTEGRATED_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
-    "$transport" "$operation" "${arguments[@]}" >"$stdout" 2>"$stderr" || rc=$?
+    run_boundary_command "$bin" "$transport" "$operation" "${arguments[@]}" \
+    >"$stdout" 2>"$stderr" || rc=$?
   [ "$rc" -eq 0 ] || fail "value operation $operation failed: $(tr '\n' ' ' <"$stderr")"
   case "$operation" in
     propose-bootstrap) expected=$(git --git-dir="$bootstrap_remote" rev-parse "refs/heads/$branch") ;;
@@ -404,6 +604,100 @@ assert_value_mutants() {
   done
 }
 
+assert_boundary_path_mutants() {
+  local original_path=$PATH log
+  boundary_path_mutants_rejected=0
+  prepare_case boundary-path-mutants
+
+  log="$case_root/host-inheritance.log"
+  if (PATH="$bin:$original_path" assert_boundary_path "$bin") >"$log" 2>&1; then
+    fail 'host-inheritance mutant passed'
+  fi
+  grep -Fq 'boundary PATH inherited host entries' "$log" ||
+    fail "host-inheritance mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+  boundary_path_mutants_rejected=$((boundary_path_mutants_rejected + 1))
+
+  rm -f "$bin/gh"
+  ln -s "$case_root/missing-gh" "$bin/gh"
+  [ -L "$bin/gh" ] && [ ! -e "$bin/gh" ] ||
+    fail 'dangling stand-in mutation did not apply'
+  log="$case_root/standin-resolution.log"
+  if (PATH="$bin" assert_boundary_path "$bin") >"$log" 2>&1; then
+    fail 'stand-in-resolution mutant passed'
+  fi
+  grep -Fq 'stand-in gh is not bound to its fixture binary' "$log" ||
+    fail "stand-in-resolution mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+  boundary_path_mutants_rejected=$((boundary_path_mutants_rejected + 1))
+
+  ln -sf "${boundary_standin_sources[gh]}" "$bin/gh"
+  rm -f "$bin/jq"
+  printf '#!/bin/sh\nexit 0\n' >"$bin/jq"
+  chmod +x "$bin/jq"
+  grep -Fqx 'exit 0' "$bin/jq" || fail 'fabricated seed mutation did not apply'
+  log="$case_root/fabricated-seed.log"
+  if (PATH="$bin" assert_boundary_path "$bin") >"$log" 2>&1; then
+    fail 'fabricated-seed mutant passed'
+  fi
+  grep -Fq 'seeded command jq is not bound to its proved source' "$log" ||
+    fail "fabricated-seed mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+  boundary_path_mutants_rejected=$((boundary_path_mutants_rejected + 1))
+
+  ln -sf "${boundary_seed_sources[jq]}" "$bin/jq"
+  mkdir -p "$case_root/missing-source-bin"
+  log="$case_root/missing-seed-source.log"
+  if (
+    boundary_seed_sources[jq]="$case_root/missing-jq"
+    seed_boundary_path "$case_root/missing-source-bin"
+  ) >"$log" 2>&1; then
+    fail 'missing-seed-source mutant passed'
+  fi
+  grep -Fq 'cannot bind seeded command jq:' "$log" ||
+    fail "missing-seed-source mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+  boundary_path_mutants_rejected=$((boundary_path_mutants_rejected + 1))
+
+  log="$case_root/relative-root.log"
+  if (cd "$case_root" && PATH=bin assert_boundary_path bin) >"$log" 2>&1; then
+    fail 'relative-bin-root mutant passed'
+  fi
+  grep -Fq 'boundary bin root is not absolute: bin' "$log" ||
+    fail "relative-bin-root mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+  boundary_path_mutants_rejected=$((boundary_path_mutants_rejected + 1))
+}
+
+print_boundary_path_marker() {
+  [ "$boundary_seeded_count" -gt 0 ] ||
+    fail 'boundary path seeded no proved commands'
+  [ "$boundary_standins_verified" -gt 0 ] ||
+    fail 'boundary operation path verified no stand-ins'
+  printf 'BOUNDARY-PATH hermetic=1 seeded=%s host_inherited=0 standins_verified=%s census_ablated=%s mutants_rejected=%s\n' \
+    "$boundary_seeded_count" "$boundary_standins_verified" \
+    "$boundary_census_ablated" "$boundary_path_mutants_rejected"
+}
+
+assert_boundary_marker_derivation() {
+  local mutant="$tmp_root/boundary-verification-removed.sh"
+  local log="$tmp_root/boundary-verification-removed.log" before after
+  local assertion_line
+  printf -v assertion_line '  assert_boundary_path "$%s"' expected_bin
+  before=$(grep -Fxc "$assertion_line" "$0")
+  [ "$before" -eq 1 ] ||
+    fail "verification-removal mutant expected one operation-path assertion, found $before"
+  awk -v needle="$assertion_line" '
+    $0 == needle { print "  : # MUTANT: operation-path verification removed"; next }
+    { print }
+  ' "$0" >"$mutant"
+  chmod +x "$mutant"
+  after=$(grep -c '^  : # MUTANT: operation-path verification removed$' "$mutant")
+  [ "$after" -eq 1 ] &&
+    [ "$(grep -Fxc "$assertion_line" "$mutant" || true)" -eq 0 ] ||
+    fail 'verification-removal mutation did not apply'
+  if "$mutant" "$repo_root" marker >"$log" 2>&1; then
+    fail 'verification-removal mutant passed'
+  fi
+  grep -Fq 'boundary operation path verified no stand-ins' "$log" ||
+    fail "verification-removal mutant failed for the wrong reason: $(tr '\n' ' ' <"$log")"
+}
+
 reject_scenario_mutant() {
   local label=$1 script=$2 mutant_scenario=$3 fingerprint=$4
   local log="$tmp_root/$label.log"
@@ -484,10 +778,27 @@ case "$scenario" in
     assert_value_mutants
     assert_receipt_schema
     assert_mutants
+    assert_boundary_census_ablation
+    assert_boundary_census_complete
+    assert_boundary_path_mutants
+    assert_boundary_marker_derivation
+    assert_boundary_census_derivation
     printf 'VALUE-CHANNEL operations=%s executed=%s census=complete mutants_rejected=%s\n' \
       "$value_operation_count" "$value_executed_count" "$value_mutants_rejected"
     printf 'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha real_git=1 real_transport=1\n'
     printf 'PROPOSAL-REATTEMPT adopt=1 foreign=1 fresh=1 mutants_rejected=4\n'
+    print_boundary_path_marker
+    printf 'BOUNDARY-PATH-DERIVED verification_removed=rejected seed_fabricated=rejected relative_root=rejected census_ablation_removed=rejected\n'
+    ;;
+  ablation)
+    assert_pollution_closed ablation-control
+    assert_boundary_census_ablation
+    assert_boundary_census_complete
+    ;;
+  marker)
+    prepare_case marker
+    run_boundary_command "$bin" "$bin/bash" -c :
+    print_boundary_path_marker
     ;;
   *) fail "unknown scenario: $scenario" ;;
 esac

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -7,7 +7,7 @@ transport="$repo_root/scripts/daily-amaru-github.sh"
 workflow="$repo_root/.github/workflows/daily-amaru.yaml"
 fake_transport="$repo_root/tests/fixtures/daily-amaru/fake-transport.sh"
 fake_gh="$repo_root/tests/fixtures/daily-amaru/fake-gh.sh"
-pre_slice_base=cd8144bdd7d3996ccc63e159227a6376e822df2c
+pre_slice_base=01f96e4b1352b2558260e9401e422eaf3136a320
 default_workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT
@@ -1592,15 +1592,19 @@ issue_223_declared_mutants=(
   scope-path-outside-fence
   history-base-unavailable
 )
-issue_223_allowed_paths=(
-  .github/workflows/daily-amaru.yaml
-  scripts/daily-amaru.sh
+issue_225_allowed_paths=(
   scripts/daily-amaru-github.sh
   tests/test-daily-amaru.sh
-  tests/test-workflow-validation.sh
-  tests/fixtures/daily-amaru/fake-transport.sh
-  tests/fixtures/daily-amaru/fake-gh.sh
-  specs/223-manual-production-trigger/tasks.md
+  tests/fixtures/daily-amaru/boundary-gh.sh
+  tests/fixtures/daily-amaru/boundary-docker.sh
+  tests/fixtures/daily-amaru/boundary-nix.sh
+  tests/fixtures/daily-amaru/test-transport-boundary.sh
+  specs/225-transport-value-channel/data-model.md
+  specs/225-transport-value-channel/functions-model.md
+  specs/225-transport-value-channel/modules-model.md
+  specs/225-transport-value-channel/plan.md
+  specs/225-transport-value-channel/spec.md
+  specs/225-transport-value-channel/tasks.md
 )
 
 register_223_mutant() {
@@ -1846,11 +1850,11 @@ receipt_model_mutant_rejected() {
   receipt_model_holds "$1" 2>/dev/null
 }
 
-paths_within_223_fence() {
+paths_within_slice_fence() {
   local path allowed allowed_path
   for path in "$@"; do
     allowed=0
-    for allowed_path in "${issue_223_allowed_paths[@]}"; do
+    for allowed_path in "${issue_225_allowed_paths[@]}"; do
       [ "$path" = "$allowed_path" ] && allowed=1
     done
     [ "$allowed" -eq 1 ] || return 1
@@ -1890,7 +1894,7 @@ history_base_controls() {
   changed_output=$(git -C "$positive" diff --name-only "$control_base" --) || return 1
   mapfile -t control_paths < <(printf '%s' "$changed_output")
   [ "${#control_paths[@]}" -gt 0 ] || return 1
-  paths_within_223_fence "${control_paths[@]}" || return 1
+  paths_within_slice_fence "${control_paths[@]}" || return 1
 
   git clone --quiet --depth=1 --single-branch --branch main \
     "file://$origin" "$negative" || return 1
@@ -2180,15 +2184,15 @@ reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY receipt-launch-cap-write-removed \
   '!write_receipt launch-cap CLAIMED' \
   'a controller that never durably writes the launch-cap receipt' receipt_model_mutant_rejected
 
-allowed_path_count=${#issue_223_allowed_paths[@]}
+allowed_path_count=${#issue_225_allowed_paths[@]}
 changed_paths_output=$(git -C "$repo_root" diff --name-only "$pre_slice_base" --) ||
   fail 'history baseline path diff is unreadable'
 mapfile -t changed_paths < <(printf '%s' "$changed_paths_output")
-paths_within_223_fence "${changed_paths[@]}" || fail 'changed path outside #223 fence'
-scope_mutant_paths=("${changed_paths[@]}" outside/issue-223-mutant)
+paths_within_slice_fence "${changed_paths[@]}" || fail 'changed path outside #225 fence'
+scope_mutant_paths=("${changed_paths[@]}" outside/issue-225-mutant)
 [ "${#scope_mutant_paths[@]}" -eq $((${#changed_paths[@]} + 1)) ] ||
   fail 'scope path mutation did not apply'
-if paths_within_223_fence "${scope_mutant_paths[@]}"; then
+if paths_within_slice_fence "${scope_mutant_paths[@]}"; then
   fail 'scope fence accepted an out-of-scope path'
 fi
 register_223_mutant INV-223-SCOPE-AND-EFFECT-FENCE scope-path-outside-fence
@@ -2285,3 +2289,8 @@ printf 'PROOF-CENSUS invariants=%s claim_operations=%s mutants_rejected=%s resid
   "${#issue_223_declared_invariants[@]}" "$claim_operation_count" \
   "${#registered_mutants[@]}" "$proof_residuals"
 pass issue-223-manual-production-cap
+
+# Issue #225: execute the real transport at a local git boundary. The focused
+# fixture owns its repositories under mktemp and never reads this checkout's
+# history.
+"$repo_root/tests/fixtures/daily-amaru/test-transport-boundary.sh" "$repo_root" all

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -2294,3 +2294,24 @@ pass issue-223-manual-production-cap
 # fixture owns its repositories under mktemp and never reads this checkout's
 # history.
 "$repo_root/tests/fixtures/daily-amaru/test-transport-boundary.sh" "$repo_root" all
+
+# INV-225-E1: the boundary proof must not change its verdict with the runner's
+# command inventory. Reproduce the CI runner shape by removing one member of
+# the production transport's scheduled census from an otherwise seeded host
+# PATH. The fixture itself must supply that member instead of inheriting it.
+boundary_host_bin="$tmp_root/boundary-host/bin"
+boundary_host_log="$tmp_root/boundary-host.log"
+seed_scheduled_path "$boundary_host_bin" without-rg
+for command in cat chmod cp cmp env find gpg ln mktemp mv od rm sort; do
+  target=$(command -v "$command")
+  ln -sf "$target" "$boundary_host_bin/$command"
+done
+if PATH="$boundary_host_bin" command -v rg >/dev/null 2>&1; then
+  fail 'boundary host PATH still resolves the omitted scheduled command: rg'
+fi
+if ! PATH="$boundary_host_bin" "$bash_binary" \
+  "$repo_root/tests/fixtures/daily-amaru/test-transport-boundary.sh" \
+  "$repo_root" pollution >"$boundary_host_log" 2>&1; then
+  cat "$boundary_host_log" >&2
+  fail 'boundary proof verdict depends on host PATH without rg'
+fi

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -8,7 +8,7 @@ workflow="$repo_root/.github/workflows/daily-amaru.yaml"
 fake_transport="$repo_root/tests/fixtures/daily-amaru/fake-transport.sh"
 fake_gh="$repo_root/tests/fixtures/daily-amaru/fake-gh.sh"
 pre_slice_base=01f96e4b1352b2558260e9401e422eaf3136a320
-s4_base=ecdb2e187d99acecd2c97c7712316d9875443fdb
+s4_base=2e7b35a8b01be73142d648b720654158f16934ae
 default_workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -8,6 +8,7 @@ workflow="$repo_root/.github/workflows/daily-amaru.yaml"
 fake_transport="$repo_root/tests/fixtures/daily-amaru/fake-transport.sh"
 fake_gh="$repo_root/tests/fixtures/daily-amaru/fake-gh.sh"
 pre_slice_base=01f96e4b1352b2558260e9401e422eaf3136a320
+s4_base=ecdb2e187d99acecd2c97c7712316d9875443fdb
 default_workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 tmp_root=$(mktemp -d)
 trap 'rm -rf "$tmp_root"' EXIT
@@ -362,15 +363,51 @@ routing_holds() {
   grep -Fqx '  cancel-in-progress: false' "$file" || return 1
 }
 
-dry_run_steps_identical() {
+workflow_job() {
+  awk -v job="  $2:" '
+    $0 == job { inside = 1 }
+    inside && $0 != job && /^  [A-Za-z0-9_-]+:/ { exit }
+    inside { print }
+  ' "$1"
+}
+
+production_job_untouched() {
   local file=$1 repository=${2:-$repo_root}
-  local base_commit=${3:-$pre_slice_base}
-  local base_workflow=$tmp_root/pre-slice-workflow.yaml
+  local base_commit=${3:-$s4_base}
+  local base_workflow=$tmp_root/canonical-entry-base-workflow.yaml
+  ensure_history_commit "$repository" "$base_commit" || return 1
   git -C "$repository" show \
     "$base_commit:.github/workflows/daily-amaru.yaml" >"$base_workflow" || return 1
   cmp -s \
-    <(workflow_job_steps "$file" daily-amaru-dry-run) \
-    <(workflow_job_steps "$base_workflow" daily-amaru-dry-run)
+    <(workflow_job "$file" daily-amaru-scheduled) \
+    <(workflow_job "$base_workflow" daily-amaru-scheduled)
+}
+
+canonical_dry_run_steps() {
+  # shellcheck disable=SC2016
+  printf '%s\n' \
+    '    steps:' \
+    '      - name: Check out the exact candidate' \
+    '        uses: actions/checkout@v6' \
+    '        with:' \
+    '          ref: ${{ github.event.pull_request.head.sha }}' \
+    '      - uses: paolino/dev-assets/setup-nix@v0.0.1' \
+    '        with:' \
+    '          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"' \
+    '      - name: Run the canonical proof entry' \
+    '        run: nix develop --quiet -c just ci'
+}
+
+canonical_dry_run_entry_holds() {
+  local file=$1 repository=${2:-$repo_root}
+  local base_commit=${3:-$s4_base}
+  local dry_steps expected_steps
+  dry_steps=$(workflow_job_steps "$file" daily-amaru-dry-run) || return 1
+  expected_steps=$(canonical_dry_run_steps) || return 1
+  [ "$dry_steps" = "$expected_steps" ] || return 1
+  [ "$(job_condition "$file" daily-amaru-dry-run)" = \
+    "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.production)" ] || return 1
+  production_job_untouched "$file" "$repository" "$base_commit"
 }
 
 if [ ! -x "$fake_transport" ]; then
@@ -923,7 +960,7 @@ workflow_callers() {
 wiring_holds() {
   local callers
   callers=$(workflow_callers "$1")
-  grep -Fqx 'daily-amaru-dry-run|tests/test-daily-amaru.sh' <<<"$callers" || return 1
+  grep -Fqx 'daily-amaru-dry-run|nix' <<<"$callers" || return 1
   grep -Fqx 'daily-amaru-scheduled|scripts/daily-amaru.sh' <<<"$callers" || return 1
   return 0
 }
@@ -944,9 +981,9 @@ assert_workflow_literal_once 'continue-on-error: true'
   fail 'the scheduled runner does not provision nix for the bootstrap proposal'
 # Orphan each caller in turn, leaving the searched literal behind in a comment.
 reject_mutant wiring-pull-request.yaml "$workflow" \
-  "s|^        run: tests/test-daily-amaru.sh\$|        # run: tests/test-daily-amaru.sh\n        run: 'true'|" \
+  "s|^        run: nix develop --quiet -c just ci\$|        # run: nix develop --quiet -c just ci\n        run: 'true'|" \
   "        run: 'true'" 'an orphaned pull-request proof caller' wiring_holds
-grep -Fq 'tests/test-daily-amaru.sh' "$mutant_root/wiring-pull-request.yaml" ||
+grep -Fq 'nix develop --quiet -c just ci' "$mutant_root/wiring-pull-request.yaml" ||
   fail 'pull-request wiring mutant lost the misleading literal'
 reject_mutant wiring-scheduled.yaml "$workflow" \
   's|^          scripts/daily-amaru.sh$|          true # scripts/daily-amaru.sh|' \
@@ -1002,7 +1039,7 @@ reject_mutant pr-head-commented.yaml "$workflow" \
   's|^          ref: |          # ref: |' '          # ref: ' \
   'a commented-out candidate-head binding' pr_head_holds
 reject_mutant pr-head-caller-noop.yaml "$workflow" \
-  "s|^        run: tests/test-daily-amaru.sh\$|        # run: tests/test-daily-amaru.sh\n        run: 'true'|" \
+  "s|^        run: nix develop --quiet -c just ci\$|        # run: nix develop --quiet -c just ci\n        run: 'true'|" \
   "        run: 'true'" 'a no-op focused caller under a bound head' pr_head_holds
 printf 'PR-HEAD-WIRING explicit=1 focused_caller=1 mutants_rejected=3\n'
 pass pull-request-proof-runs-candidate-head
@@ -1564,7 +1601,7 @@ claim_operation_sets_match() {
 declare -A issue_223_mutant_invariant=()
 issue_223_declared_invariants=(
   INV-223-DISPATCH-ROUTING
-  INV-223-DRY-RUN-BYTE-UNCHANGED
+  INV-223-DRY-RUN-CANONICAL-ENTRY
   INV-223-ONE-LAUNCH-PER-DAY
   INV-223-PRELAUNCH-SUPERSEDE
   INV-223-MARKER-CENSUS-FAILS-CLOSED
@@ -1574,7 +1611,9 @@ issue_223_declared_invariants=(
 )
 issue_223_declared_mutants=(
   routing-string-input
-  dry-run-byte
+  dry-run-wrong-entry
+  dry-run-path-tampered
+  dry-run-step-key-added
   launch-cap-exit-open
   supersede-inverted
   census-open
@@ -1593,6 +1632,7 @@ issue_223_declared_mutants=(
   history-base-unavailable
 )
 issue_225_allowed_paths=(
+  .github/workflows/daily-amaru.yaml
   scripts/daily-amaru-github.sh
   tests/test-daily-amaru.sh
   tests/fixtures/daily-amaru/boundary-gh.sh
@@ -1889,7 +1929,7 @@ history_base_controls() {
   ! git -C "$positive" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
   ensure_history_commit "$positive" "$control_base" || return 1
   git -C "$positive" cat-file -e "$control_base^{commit}" 2>/dev/null || return 1
-  dry_run_steps_identical \
+  production_job_untouched \
     "$positive/.github/workflows/daily-amaru.yaml" "$positive" "$control_base" || return 1
   changed_output=$(git -C "$positive" diff --name-only "$control_base" --) || return 1
   mapfile -t control_paths < <(printf '%s' "$changed_output")
@@ -1929,14 +1969,8 @@ head_propagation_holds() {
 history_base_controls || fail 'history baseline controls did not hold'
 routing_holds "$workflow" || fail 'typed dispatch routing is not exact'
 routing_truth_table_holds "$workflow" || fail 'observed workflow conditions failed their truth table'
-dry_run_steps_identical "$workflow" || fail 'dry-run steps changed from the frozen base'
-base_workflow_snapshot=$tmp_root/pre-slice-workflow-for-hash.yaml
-git -C "$repo_root" show "$pre_slice_base:.github/workflows/daily-amaru.yaml" \
-  >"$base_workflow_snapshot" || fail 'history baseline workflow is unreadable'
-base_dry_hash=$(workflow_job_steps "$base_workflow_snapshot" daily-amaru-dry-run |
-  sha256sum | awk '{print $1}')
-current_dry_hash=$(workflow_job_steps "$workflow" daily-amaru-dry-run |
-  sha256sum | awk '{print $1}')
+canonical_dry_run_entry_holds "$workflow" ||
+  fail 'dry-run job does not run the canonical proof entry with the production job untouched'
 
 for routing_row in "${routing_census_rows[@]}"; do
   printf 'ROUTING %s\n' "$routing_row"
@@ -2061,11 +2095,25 @@ reject_223_mutant INV-223-DISPATCH-ROUTING routing-string-input \
   'github.event.inputs.production' \
   'the truthy string-form dispatch input' routing_truth_table_holds
 
-reject_223_mutant INV-223-DRY-RUN-BYTE-UNCHANGED dry-run-byte \
-  dry-run-byte.yaml "$workflow" \
-  's/Exercise the controller through the fake transport/Exercise changed dry-run body/' \
-  'Exercise changed dry-run body' \
-  'a changed dry-run step body' dry_run_steps_identical
+reject_223_mutant INV-223-DRY-RUN-CANONICAL-ENTRY dry-run-wrong-entry \
+  dry-run-wrong-entry.yaml "$workflow" \
+  's|nix develop --quiet -c just ci|tests/test-daily-amaru.sh|' \
+  'tests/test-daily-amaru.sh' \
+  'a dry-run job that bypasses the canonical entry' canonical_dry_run_entry_holds
+
+# shellcheck disable=SC2016
+reject_223_mutant INV-223-DRY-RUN-CANONICAL-ENTRY dry-run-path-tampered \
+  dry-run-path-tampered.yaml "$workflow" \
+  's/github\.event\.pull_request\.head\.sha/github.sha/' \
+  'github.sha' \
+  'a dry-run checkout redirected away from the candidate head' canonical_dry_run_entry_holds
+
+reject_223_mutant INV-223-DRY-RUN-CANONICAL-ENTRY dry-run-step-key-added \
+  dry-run-step-key-added.yaml "$workflow" \
+  '/^      - name: Run the canonical proof entry$/a\
+        if: github.event_name == '\''deployment'\''' \
+  "        if: github.event_name == 'deployment'" \
+  'an added key that makes the canonical entry conditional' canonical_dry_run_entry_holds
 
 reject_223_mutant INV-223-ONE-LAUNCH-PER-DAY launch-cap-exit-open \
   launch-cap-open.sh "$transport" \
@@ -2258,15 +2306,15 @@ launch_cap_mutants=0
 for mutant in "${registered_mutants[@]}"; do
   case "${issue_223_mutant_invariant[$mutant]}" in
     INV-223-DISPATCH-ROUTING) routing_mutants=$((routing_mutants + 1)) ;;
-    INV-223-DRY-RUN-BYTE-UNCHANGED) dry_run_mutants=$((dry_run_mutants + 1)) ;;
+    INV-223-DRY-RUN-CANONICAL-ENTRY) dry_run_mutants=$((dry_run_mutants + 1)) ;;
     INV-223-ONE-LAUNCH-PER-DAY) launch_cap_mutants=$((launch_cap_mutants + 1)) ;;
   esac
 done
 printf 'DISPATCH-ROUTING rows=%s production_jobs=%s controller_callers=%s mutants_rejected=%s\n' \
   "${#routing_census_rows[@]}" "$production_jobs" "$controller_callers" \
   "$routing_mutants"
-printf 'DRY-RUN-BYTE-IDENTITY base=%s current=%s mutants_rejected=%s\n' \
-  "$base_dry_hash" "$current_dry_hash" "$dry_run_mutants"
+printf 'DRY-RUN-ENTRY canonical=1 dev_shell=1 production_job_untouched=1 whole_block=1 mutants_rejected=%s\n' \
+  "$dry_run_mutants"
 printf 'LAUNCH-CAP trigger_pairs=%s launches_per_day=%s refusal=launch-consumed ordered_claim_effect_pairs=%s mutants_rejected=%s\n' \
   "${#trigger_pairs[@]}" "$launches_per_day" "$ordered_claim_effect_pairs" \
   "$launch_cap_mutants"


### PR DESCRIPTION
Closes #225

First `production=true` fire (run 32261172699) reached `bootstrap-proposal` and
died at `malformed-candidate-sha` with the day's launch allowance unconsumed.
Two defects in the issue, plus one this PR's own first attempt exposed.

## Defect 1 — transport value channel polluted

`git commit` writes its summary to stdout, ahead of `propose-bootstrap`'s
trailing `git rev-parse HEAD`, so the controller captured a multi-line "SHA".

The fix is structural, not per-call: the transport rebinds fd 1 to the
diagnostic stream at dispatch and reserves a value channel reached only through
one `emit` function. Every subcommand's stdout is diagnostic by construction, and
a new operation that writes a value with a plain `printf` loses it loudly rather
than inheriting a polluted channel.

The audit over every operation is in
`specs/225-transport-value-channel/data-model.md` (D-225-2). Besides the fired
one it found two more instances of the same class: `prepare-consumer-repin` (same
`git commit` summary) and `real-launch` (`gh workflow run` confirmation plus
`gh run watch` progress) — the latter the more dangerous, because the controller
never validates that value, so pollution there would have corrupted #210 receipts
silently instead of failing loudly.

## Defect 2 — proposal push is not re-attempt-safe

`propose-bootstrap` is now idempotent per upstream SHA. It classifies the
proposal branch **before** mutating anything: adopt a branch whose delta from its
merge base is exactly the intended single-path `flake.lock` change pinning that
SHA (returning its head and reusing the existing PR), fail with the named red
`foreign-proposal-branch` on any other content, and take the create path when the
branch is absent. Nothing is force-pushed or overwritten.

## Defect 3 — the proof itself was not hermetic

The first push of this branch was locally gate-green and **red in CI**:
`missing-command-rg`. The new boundary fixture built `PATH="$bin:$PATH"` and
inherited host binaries — the nix dev shell has ripgrep, the GitHub runner does
not — and the ticket gate's `just ci` leg runs inside that dev shell, so it could
not observe the class at all.

The fixture now binds every seeded command to a binary it proved exists and dies
naming the command when it cannot, rather than fabricating a
success-returning stub that turns a missing binary into a false domain verdict.
The stand-in assertion rejects dangling symlinks, relative bin roots and
fabricated no-ops, each with its own mutant. Every `BOUNDARY-PATH` count —
`seeded`, `standins_verified`, `census_ablated` — is produced by the path it
summarizes, so deleting that path moves the number or reds the run.

## Why the class was invisible

Every existing Daily Amaru proof drove the controller against a fake transport or
inspected the transport's source text. Nothing executed the real transport's git
path, and the defect is a property of the real subcommands. This PR ships a local
boundary — a bare repository standing in for the bootstrap remote, real `git`,
and stand-ins restricted to the exact `gh`/`nix`/`docker` surface the transport
invokes — so the class is observable where it actually fails.

The value-channel census executes all 15 value-returning operations with noisy
externals and compares fd 1 byte-for-byte against each declared value, with the
executed set reconciled against the real `case` dispatch. Both directions are
covered: injecting an extra `emit` into each of the 15 arms kills 15/15, and
suppressing `emit` in each kills 15/15.

## Verification

`scripts/daily-amaru.sh` and `.github/workflows/daily-amaru.yaml` are untouched:
the #210 receipt schema, the #223 one-launch-per-day cap and the #221/#219
guarantees are unchanged by construction. `scripts/daily-amaru-github.sh` carries
only the value-channel and proposal-classification changes.

The `#223` scope fence in `tests/test-daily-amaru.sh` was frozen against a merged
slice's base and rejected any correct successor by construction; it is re-based
to this slice, keeping its out-of-fence mutant rejected.

## Defect 4 — the proof job proved nothing about the runner

The first push was green locally and red in CI (`missing-command-rg`). The second
was red again with a **different** cause: exit 1 six seconds after the last
marker, with **no `FAIL:` line at all**. Guards whose input is a command
substitution (`x=$(grep -c …)`) die under `set -euo pipefail` before the `fail`
they guard can print — the diagnostic is unreachable in exactly the case it was
written for.

Both are closed. Guarded failures now print, with the guard sites censused from
the tree so a new unprotected one must be forced too. And the dry-run job now
provisions the dev shell and runs the canonical `just ci` entry, so the suite is
proved in the environment it is pinned to rather than against whatever a host
ships. The production job's environment is untouched.

The #219/#223 dry-run tamper guarantee moved with it: it was expressed as
byte-identity against a base commit, which rejects any correct successor by
construction. It is now whole-block equality against a canonical block this slice
owns — every line accounted for, any added key rejected. That matters: the first
attempt at re-expressing it accepted *addition*, so a never-true `if:` on the
proof step passed the gate and would have produced a permanently green PR check
that ran nothing.

## Known follow-ups, deliberately not in this PR

- **Marker literals.** `PROPOSAL-REATTEMPT`, `VALUE-CHANNEL-FIRED` and
  `EFFECT-CENSUS` are `printf` literals predating this branch: deleting the
  proofs they certify leaves them byte-identical, so a gate leg reading them is
  asserting against its own source. The invariants themselves are sound — each
  was verified here by independently rebuilt mutants, not via those markers — but
  the markers cannot report a regression. `PROPOSAL-REATTEMPT`'s
  `mutants_rejected=4` is also simply wrong; the proof rejects five.
- The adopt path aborts with a raw `gh` error rather than a named red when the
  proposal branch is adoptable but has no open PR (`find_pr` bare under `set -e`).
- The dry-run **job**'s non-step keys are unfenced: a job-level
  `continue-on-error: ${{ … }}` expression would make the gate run the proof and
  ignore its verdict. Inherited, not introduced — the superseded expression
  accepts the same tamper, and the plain-literal form is caught only incidentally.
  The fix is whole-*job* equality, as the production job already has.
- `seed_scheduled_path` in `tests/test-daily-amaru.sh` keeps the same
  fabricated-stub fallback the boundary fixture dropped, and
  `scripts/check-amaru-producer-image-refs.sh` carries the same latent
  `grep -c` shape (currently unreachable in its zero case).
- The value census asserts one value shape per operation, not every declared
  alternative.

## What no proof here can establish

`paolino/dev-assets/setup-nix@v0.0.1` is never executed by this repository, and
every local and gate run happens inside the dev shell this change moves CI
*into*. A green gate cannot distinguish "the runner will now succeed" from "the
shell that was already green was re-run". Only CI on the pushed head can close
that, which is why this PR is not marked ready until it is green there.

Contract, invariants and task list: `specs/225-transport-value-channel/`.
