### PR TITLE
fix: atomically refresh peer snapshots in unattended Amaru bumps

### DIFF
--- a/scripts/daily-amaru-github.sh
+++ b/scripts/daily-amaru-github.sh
@@ -188,13 +188,38 @@ find_pr() {
     --json url --jq .url
 }
 
+atomic_path_census() {
+  local expected_lock=0 expected_record=0 path
+  [ "$#" -eq 2 ] || return 1
+  for path in "$@"; do
+    case "$path" in
+      flake.lock) expected_lock=1 ;;
+      nix/peer-snapshots/resolution.json) expected_record=1 ;;
+      *) return 1 ;;
+    esac
+  done
+  [ "$expected_lock" -eq 1 ] && [ "$expected_record" -eq 1 ]
+}
+
+lock_node_by_origin() {
+  local lock=$1 owner=$2 repo=$3
+  jq -r --arg owner "$owner" --arg repo "$repo" '
+    [.nodes | to_entries[] |
+     select(.value.original.owner == $owner and
+            .value.original.repo == $repo) | .key] |
+    if length == 1 then .[0] else empty end
+  ' <<<"$lock"
+}
+
 classify_proposal_branch() {
   local directory=$1
   local branch=$2
   local upstream_sha=$3
   local input_node=$4
   local remote_ref="refs/remotes/origin/$branch"
-  local merge_base changed_output lock
+  local merge_base changed_output lock record configs_node
+  local lock_amaru lock_configs record_amaru record_configs
+  local commit_count main_sha
   local -a changed=()
 
   if ! git -C "$directory" show-ref --verify --quiet "$remote_ref"; then
@@ -203,24 +228,71 @@ classify_proposal_branch() {
   fi
 
   merge_base=$(git -C "$directory" merge-base origin/main "$remote_ref") || return 1
+  main_sha=$(git -C "$directory" rev-parse origin/main) || return 1
+  commit_count=$(git -C "$directory" rev-list --count "$merge_base..$remote_ref") ||
+    return 1
   changed_output=$(git -C "$directory" diff --name-only "$merge_base" "$remote_ref") ||
     return 1
-  mapfile -t changed < <(printf '%s' "$changed_output")
-  if [ "${#changed[@]}" -ne 1 ] || [ "${changed[0]}" != flake.lock ]; then
+  mapfile -t changed < <(printf '%s\n' "$changed_output")
+  if [ "$merge_base" != "$main_sha" ] || [ "$commit_count" -ne 1 ] ||
+    ! atomic_path_census "${changed[@]}"; then
     printf 'foreign\n'
     return 0
   fi
 
   lock=$(git -C "$directory" show "$remote_ref:flake.lock") || return 1
-  if jq -e --arg node "$input_node" --arg sha "$upstream_sha" '
-      .nodes[$node].original.owner == "pragma-org" and
-      .nodes[$node].original.repo == "amaru" and
-      .nodes[$node].locked.rev == $sha
-    ' <<<"$lock" >/dev/null; then
+  if ! record=$(git -C "$directory" show "$remote_ref:nix/peer-snapshots/resolution.json"); then
+    printf 'foreign\n'
+    return 0
+  fi
+  configs_node=$(lock_node_by_origin "$lock" cardano-foundation cardano-configurations)
+  lock_amaru=$(jq -er --arg node "$input_node" '.nodes[$node].locked.rev' \
+    <<<"$lock") || {
+    printf 'foreign\n'
+    return 0
+  }
+  lock_configs=$(jq -er --arg node "$configs_node" '.nodes[$node].locked.rev' \
+    <<<"$lock") || {
+    printf 'foreign\n'
+    return 0
+  }
+  record_amaru=$(jq -er '.amaru_rev' <<<"$record") || {
+    printf 'foreign\n'
+    return 0
+  }
+  record_configs=$(jq -er '.configs_rev' <<<"$record") || {
+    printf 'foreign\n'
+    return 0
+  }
+  if [[ "$lock_amaru" =~ ^[0-9a-f]{40}$ ]] &&
+    [[ "$lock_configs" =~ ^[0-9a-f]{40}$ ]] &&
+    [ "$lock_amaru" = "$upstream_sha" ] &&
+    [ "$record_amaru" = "$upstream_sha" ] &&
+    [ "$lock_configs" = "$record_configs" ]; then
     printf 'adoptable\n'
   else
     printf 'foreign\n'
   fi
+}
+
+root_input_for_node() {
+  local lock_file=$1 node=$2
+  jq -r --arg node "$node" '
+    [.nodes.root.inputs | to_entries[] |
+     select((if (.value | type) == "array" then .value[0] else .value end) == $node) |
+     .key] | if length == 1 then .[0] else empty end
+  ' "$lock_file"
+}
+
+resolver_failed() {
+  emit 'RESOLVER-FAILED'
+  die 'peer-snapshot-resolution-failed'
+}
+
+invoke_cloned_resolver() {
+  local directory=$1
+  [ -x "$directory/scripts/resolve-peer-snapshots" ] || return 1
+  (cd "$directory" && ./scripts/resolve-peer-snapshots --write)
 }
 
 operation=${1:?transport operation is required}
@@ -324,19 +396,18 @@ case "$operation" in
 
     # TODO(amaru-bootstrap#75): replace this crude stock-pin proposal with
     # the validated producer handoff once that contract lands.
-    input_node=$(jq -r '
-      [.nodes | to_entries[] |
-       select(.value.original.owner == "pragma-org" and
-              .value.original.repo == "amaru") | .key] |
-      if length == 1 then .[0] else empty end
-    ' "$directory/flake.lock")
+    lock_text=$(<"$directory/flake.lock")
+    input_node=$(lock_node_by_origin "$lock_text" pragma-org amaru)
     [ -n "$input_node" ] || die 'expected exactly one stock pragma-org/amaru lock node'
-    input_name=$(jq -r --arg node "$input_node" '
-      [.nodes.root.inputs | to_entries[] |
-       select((if (.value | type) == "array" then .value[0] else .value end) == $node) |
-       .key] | if length == 1 then .[0] else empty end
-    ' "$directory/flake.lock")
+    input_name=$(root_input_for_node "$directory/flake.lock" "$input_node")
     [ -n "$input_name" ] || die 'expected exactly one root input for the stock Amaru node'
+    configs_node=$(lock_node_by_origin "$lock_text" cardano-foundation \
+      cardano-configurations)
+    [ -n "$configs_node" ] ||
+      die 'expected exactly one cardano-configurations lock node'
+    configs_input_name=$(root_input_for_node "$directory/flake.lock" "$configs_node")
+    [ -n "$configs_input_name" ] ||
+      die 'expected exactly one root input for cardano-configurations'
 
     proposal_state=$(classify_proposal_branch \
       "$directory" "$branch" "$upstream_sha" "$input_node") ||
@@ -355,21 +426,45 @@ case "$operation" in
         git -C "$directory" checkout -b "$branch" origin/main
         (
           cd "$directory"
-          nix flake lock --override-input "$input_name" "github:pragma-org/amaru/$upstream_sha"
+          nix flake lock --override-input "$input_name" \
+            "github:pragma-org/amaru/$upstream_sha"
         )
-        mapfile -t changed < <(git -C "$directory" diff --name-only)
-        [ "${#changed[@]}" -eq 1 ] && [ "${changed[0]}" = flake.lock ] ||
-          die 'stock-pin proposal changed a path other than flake.lock'
+        invoke_cloned_resolver "$directory" || true
+        record=$directory/nix/peer-snapshots/resolution.json
+        [ -f "$record" ] || resolver_failed
+        record_amaru=$(jq -er '.amaru_rev' "$record") || resolver_failed
+        record_configs=$(jq -er '.configs_rev' "$record") || resolver_failed
+        [ "$record_amaru" = "$upstream_sha" ] || resolver_failed
+        [[ "$record_configs" =~ ^[0-9a-f]{40}$ ]] || resolver_failed
+        (
+          cd "$directory"
+          nix flake lock --override-input "$configs_input_name" \
+            "github:cardano-foundation/cardano-configurations/$record_configs"
+        )
+        invoke_cloned_resolver "$directory" || resolver_failed
+        record_amaru=$(jq -er '.amaru_rev' "$record") || resolver_failed
+        record_configs=$(jq -er '.configs_rev' "$record") || resolver_failed
         jq -e --arg node "$input_node" --arg sha "$upstream_sha" '
           .nodes[$node].original.owner == "pragma-org" and
           .nodes[$node].original.repo == "amaru" and
           .nodes[$node].locked.rev == $sha
-        ' "$directory/flake.lock" >/dev/null || die 'stock Amaru lock validation failed'
-
-        git -C "$directory" add flake.lock
+        ' "$directory/flake.lock" >/dev/null || resolver_failed
+        jq -e --arg node "$configs_node" --arg sha "$record_configs" '
+          .nodes[$node].locked.rev == $sha
+        ' "$directory/flake.lock" >/dev/null || resolver_failed
+        jq -e --arg amaru "$upstream_sha" --arg configs "$record_configs" '
+          .amaru_rev == $amaru and .configs_rev == $configs
+        ' "$record" >/dev/null || resolver_failed
+        mapfile -t changed < <(git -C "$directory" diff --name-only)
+        atomic_path_census "${changed[@]}" || resolver_failed
+        git -C "$directory" add -- flake.lock nix/peer-snapshots/resolution.json
+        mapfile -t changed < <(git -C "$directory" diff --cached --name-only)
+        atomic_path_census "${changed[@]}" || resolver_failed
         git -C "$directory" -c user.name='daily-amaru' \
           -c user.email='daily-amaru@users.noreply.github.com' \
           commit -m "chore: bump stock Amaru to $upstream_sha"
+        [ "$(git -C "$directory" rev-list --count origin/main..HEAD)" -eq 1 ] ||
+          resolver_failed
         push_branch "$directory" "$branch" "$bootstrap_identity"
         pr_url=$(create_or_find_pr "$bootstrap_repository" "$branch" \
           "chore: bump stock Amaru to ${upstream_sha:0:12}" \

--- a/scripts/daily-amaru.sh
+++ b/scripts/daily-amaru.sh
@@ -273,6 +273,9 @@ write_receipt launch-attempt CLAIMED
 
 bootstrap_sha=''
 if ! bootstrap_sha=$(transport_call propose-bootstrap "$observed_sha"); then
+  if [ "$bootstrap_sha" = RESOLVER-FAILED ]; then
+    fail_stage bootstrap-proposal peer-snapshot-resolution-failed
+  fi
   fail_stage bootstrap-proposal proposal-failed
 fi
 [[ "$bootstrap_sha" =~ ^[0-9a-f]{40}$ ]] ||

--- a/specs/227-atomic-peer-snapshot-bump/data-model.md
+++ b/specs/227-atomic-peer-snapshot-bump/data-model.md
@@ -1,0 +1,43 @@
+# Data model — Issue 227
+
+Artifact ceiling: 3,500 bytes and 90 lines.
+
+## D227-1 — Atomic bootstrap proposal
+
+- **Base:** cloned bootstrap `origin/main`.
+- **History:** exactly one proposal commit above that base.
+- **Changed paths:** exactly `flake.lock` and
+  `nix/peer-snapshots/resolution.json`.
+- **Publication state:** unpublished until D227-2 is valid and final resolver
+  verification succeeds.
+
+## D227-2 — Anchored resolution tuple
+
+Fields consumed from bootstrap-owned artifacts:
+
+- `flake.lock` Amaru revision;
+- `flake.lock` cardano-configurations revision;
+- resolution-record `amaru_rev`;
+- resolution-record `configs_rev`;
+- three per-network hashes and resolution provenance owned by the resolver.
+
+State invariant: both Amaru fields are equal, both configurations fields are
+equal, and the configurations value is the resolver-selected non-default
+revision. Hash/provenance validity remains bootstrap-resolver and anchor-owned.
+
+## D227-3 — Proposal classification
+
+`absent | adoptable | foreign`. `adoptable` requires D227-1 and D227-2 for the
+requested Amaru revision. A missing record, lock-only diff, record-only diff,
+extra path, extra commit, or inconsistent tuple is `foreign`.
+
+## D227-4 — Resolver failure receipt
+
+Existing receipt keys, with values:
+
+- `stage=bootstrap-proposal`;
+- `outcome=FAILED`;
+- `error=peer-snapshot-resolution-failed`.
+
+The state is terminal for that daily run and implies zero proposal push and PR
+creation effects. It does not change cap, claim, or supersede state.

--- a/specs/227-atomic-peer-snapshot-bump/functions-model.md
+++ b/specs/227-atomic-peer-snapshot-bump/functions-model.md
@@ -1,0 +1,31 @@
+# Functions model — Issue 227
+
+Artifact ceiling: 2,500 bytes and 65 lines.
+
+No new public command is introduced.
+
+## F227-1 — `classify_proposal_branch`
+
+- Arguments: `directory: path`, `branch: string`, `upstream_sha: 40-hex`,
+  `input_node: lock-node-name`.
+- Result: one line, `absent | adoptable | foreign`; non-zero on unreadable Git
+  state.
+- Effects: read-only Git and artifact inspection.
+- Changed constraint: `adoptable` entails D227-1 and D227-2, not a lock-only
+  delta.
+
+## F227-2 — transport operation `propose-bootstrap`
+
+- Argument: `upstream_sha: 40-hex`.
+- Environment: existing day, state-root, repository and identity fields.
+- Result: exact 40-hex candidate SHA on success; non-zero with a typed
+  resolver-failure observation on D227-4 failures.
+- Effects: clone workspace; bootstrap-owned input updates and resolver call;
+  one local commit; proposal push and PR creation only after validation.
+- Changed constraint: success entails D227-1 and D227-2.
+
+## F227-3 — `transport_call`
+
+- Existing variadic transport invocation; signature unchanged.
+- Changed result constraint only for the bootstrap proposal: resolver-specific
+  failure remains distinguishable so M227-3 can write D227-4.

--- a/specs/227-atomic-peer-snapshot-bump/modules-model.md
+++ b/specs/227-atomic-peer-snapshot-bump/modules-model.md
@@ -1,0 +1,37 @@
+# Modules model — Issue 227
+
+Artifact ceiling: 3,000 bytes and 70 lines.
+
+Only changed responsibilities are listed. The dependency direction is
+controller → transport orchestrator → cloned bootstrap resolver; the resolver
+never depends on this repository.
+
+## M227-1 — `scripts/daily-amaru-github.sh`
+
+Changed responsibility: `propose-bootstrap` owns the atomic transaction around
+an Amaru pin change. It invokes M227-2, pairs the lock with its generated
+record, validates the exact two-path/one-commit candidate, and permits push/PR
+effects only after the complete transaction succeeds. Existing-branch
+classification enforces the same candidate shape.
+
+It does not own or reproduce the peer-snapshot selection rule.
+
+## M227-2 — cloned `scripts/resolve-peer-snapshots` (read-only dependency)
+
+Unchanged responsibility: sole online bump-time authority for the selected
+configurations revision and recorded snapshot hashes. It is consumed from the
+exact cloned repository and never copied, patched, or invoked by build/verify
+paths.
+
+## M227-3 — Daily Amaru receipt boundary
+
+Changed only as required to preserve the resolver-specific failure identity as
+`peer-snapshot-resolution-failed` within the existing receipt field set.
+Stage ordering, receipt keys, and every other failure class stay unchanged.
+
+## M227-4 — focused Daily Amaru boundary proof
+
+Changed responsibility: the local git boundary models M227-2's command
+contract, observes invocation and effects, proves atomic creation/adoption and
+named failure, and kills lock-only/skip-resolver mutants. It inherits no host
+commands and performs no real publication or launch.

--- a/specs/227-atomic-peer-snapshot-bump/plan.md
+++ b/specs/227-atomic-peer-snapshot-bump/plan.md
@@ -1,0 +1,75 @@
+# Plan — Issue 227 atomic peer-snapshot bump
+
+Artifact ceiling: 6,000 bytes and 140 lines.
+
+## Technical context
+
+The issue lane starts from frozen main `83577835`. The direct baseline
+`just test-daily-amaru` exits 0 in 62.4 seconds; receipt and full output are at
+`/tmp/ms-cardano-node-antithesis-2/e-auto/t227-codex-to-01/evidence/baseline-daily.log`.
+
+The standard local dev shell is cold. Its dry run reports two derivations plus
+one 1.58 MiB download (5.37 MiB unpacked). Durable answer A-001 authorizes no
+realization: local acceptance uses injected shell boundaries, while all exact-
+head hosted contexts supply the omitted actionlint/shellcheck coverage. This
+omission is named in every final gate receipt and in the PR body.
+
+## Architecture decisions
+
+- `scripts/daily-amaru-github.sh` remains the proposal orchestrator. It updates
+  inputs, invokes the cloned repository's rule authority, validates the atomic
+  result, and publishes only after all of those operations succeed.
+- `scripts/resolve-peer-snapshots` in the clone remains the sole resolution
+  authority. Its documented interim mismatch and final verification are
+  treated as one fail-closed bump transaction; no rule is copied into this
+  repository.
+- The existing local git boundary is extended with an injected clone-local
+  resolver and a non-default configurations revision. Real git remains in the
+  boundary because commit count and changed-path atomicity are observable only
+  there. Network, credentials, GitHub publication, and Nix realization remain
+  replaced by deterministic stand-ins.
+- Proposal adoption is the same contract as proposal creation: exactly one
+  commit, exactly the two paths, and coherent lock/record revisions. The PR #86
+  shape is a permanent foreign-branch mutant.
+- A resolver-specific transport failure crosses to the existing receipt model
+  without changing its keys. Only the error value is specialized.
+
+## Slice
+
+One bisect-safe OWNER slice, **S227-01**. Atomic commit history, cross-file
+consistency, external-tool ownership, and typed failure transport require
+semantic audit; the slice is not eligible for LIGHT.
+
+The commit owner supplies the complete RED proof before production changes,
+then lands the production and permanent regression together. Splitting the
+proof, resolver invocation, paired pin, census, or receipt path would create a
+commit that can publish the split state this issue exists to prevent.
+
+## Proof strategy
+
+- Exercise fresh and adoptable proposals through local bare repositories and
+  the real transport with injected `gh`, `nix`, and clone-local resolver
+  boundaries.
+- Use distinguishable old, Amaru, selected-configurations, and foreign values;
+  no default or equal fixture value may satisfy consistency accidentally.
+- Demonstrate the exact lock-only PR #86 mutant and a skip-resolver mutant are
+  applied and rejected for the intended atomicity reason.
+- Force resolver non-zero and malformed-result cases after the Amaru override;
+  require the named failure receipt and prove remote refs plus PR/push effects
+  are unchanged.
+- Derive every marker count from executed observations and retain the existing
+  zero-real-launch/effect fences.
+
+## Verification envelope
+
+- Frozen untracked `./gate.sh` and its runtime backup.
+- Focused atomic-boundary scenario and complete `just test-daily-amaru`.
+- Shell syntax and exact changed-path/invariant marker checks.
+- No local `nix develop -c just ci`; A-001 names this host-forbidden omission.
+- All required hosted contexts green on the exact final head.
+
+## Stop conditions
+
+Stop and ask before editing the bootstrap resolver/anchor, changing receipt
+keys or cap/supersede semantics, using network or credentials in tests,
+launching Antithesis, realizing Nix locally, or widening production scope.

--- a/specs/227-atomic-peer-snapshot-bump/spec.md
+++ b/specs/227-atomic-peer-snapshot-bump/spec.md
@@ -1,0 +1,79 @@
+# Atomically refresh peer snapshots in unattended Amaru bumps
+
+Issue: cardano-foundation/cardano-node-antithesis#227 · parent epic #205
+Frozen main base: `83577835d67bb97af2a19b1680f4aafbc9cc9528`
+
+Artifact ceiling: 8,000 bytes and 180 lines.
+
+## Context
+
+Daily fire run 32447033481 created amaru-bootstrap PR #86 at candidate
+`ecda90be`. It changed only `flake.lock`: the Amaru pin moved while
+`nix/peer-snapshots/resolution.json` and the configurations pin stayed old.
+The unchanged `peer-snapshot-anchor` rejected that split state, and its
+negative control proves the alarm is load-bearing.
+
+## Requirements
+
+- **R227-1 — resolver ownership.** After overriding the cloned bootstrap
+  repository's Amaru input, `propose-bootstrap` invokes that clone's shipped
+  `scripts/resolve-peer-snapshots --write`. The controller consumes it
+  unmodified and does not duplicate its date, revision, or hash rule.
+- **R227-2 — exact paired pin.** The bootstrap candidate locks
+  `cardano-configurations` to exactly the revision selected and recorded by
+  the resolver for the new Amaru revision.
+- **R227-3 — atomic proposal.** One proposal commit contains exactly
+  `flake.lock` and `nix/peer-snapshots/resolution.json`. Its lock and record
+  agree on both revisions; no intermediate or final lock-only proposal is
+  pushed.
+- **R227-4 — exact census.** Fresh and adoptable proposal classification
+  accepts exactly those two paths and rejects any missing or additional path.
+  The PR #86 shape is therefore foreign, never adoptable.
+- **R227-5 — fail closed.** Network, rate-limit, malformed result, rule
+  mismatch, or final resolver verification failure produces the stable
+  receipt error `peer-snapshot-resolution-failed`, returns non-zero, and
+  performs no proposal push or PR creation.
+- **R227-6 — anchored verification stays anchored.** The bootstrap resolver,
+  `peer-snapshot-anchor`, its negative control, and bootstrap checks are
+  unchanged. The proposal passes them by supplying the coherent bundle.
+
+## Rejection behaviour
+
+- Never edit or bypass amaru-bootstrap's resolver or anchor checks.
+- Never accept a lock-only branch, a record-only branch, multiple proposal
+  commits, a third changed path, or a record whose revisions disagree with the
+  lock.
+- Never turn a resolver error into an ordinary candidate SHA or a generic
+  success-path receipt.
+
+## Invariants
+
+All rows are `BLOCKING`: these unattended pins configure a node that consumes
+chain state, so no survivor may be accepted as a residual.
+
+| ID | Severity | Observable truth | Demonstrated failure | Observable success |
+|---|---|---|---|---|
+| INV-227-1 | BLOCKING | The cloned repository's shipped resolver is the rule authority | a skip-resolver mutant reproduces PR #86 and is rejected | the injected boundary records one clone-local resolver invocation after the Amaru override |
+| INV-227-2 | BLOCKING | The lock and resolution record carry the new Amaru rev and exactly the resolver-selected configurations rev | either recorded revision or either lock revision is mutated | both pairs agree and the injected resolver's non-default selected revision is preserved |
+| INV-227-3 | BLOCKING | The proposal is one commit with exactly the two contractual paths | split commits, lock-only, record-only, or an extra path | commit count is one and path census equals the two-path set |
+| INV-227-4 | BLOCKING | Existing-branch adoption applies the same atomic census and consistency checks | the exact PR #86 lock-only branch is offered for adoption | coherent two-path branch is adopted without mutation; incoherent branch is named foreign |
+| INV-227-5 | BLOCKING | Resolver failure is a named red before publication | injected resolver fails after the Amaru override | receipt says `stage=bootstrap-proposal`, `outcome=FAILED`, `error=peer-snapshot-resolution-failed`; push and PR counts stay zero |
+| INV-227-6 | BLOCKING | The proof cannot spend or weaken the anchor | a test reaches a real workflow launch or changes an anchor surface | injected transports only, zero real launches, and no bootstrap-repository edit |
+
+## Observable success
+
+- The workflow-shaped injected boundary proves INV-227-1 through INV-227-6,
+  including a verified-applied skip-resolver mutant and resolver-error control.
+- `just test-daily-amaru` is green without network, credentials, push, PR
+  publication, or Antithesis launch.
+- The local cold Nix CI leg is explicitly omitted under durable A-001 because
+  it would realize two derivations; all required hosted contexts must be green
+  on the exact pushed head and cover actionlint/shellcheck there.
+
+## Scope
+
+Owned production surface is `scripts/daily-amaru-github.sh`, with a minimal
+`scripts/daily-amaru.sh` change only if needed to preserve the named failure in
+the receipt. Focused tests and fixtures plus `specs/227-*` are owned.
+Receipt schema, cap/supersede semantics, credentials, workflows, real launches,
+and every amaru-bootstrap file are forbidden.

--- a/specs/227-atomic-peer-snapshot-bump/tasks.md
+++ b/specs/227-atomic-peer-snapshot-bump/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — Issue 227 atomic peer-snapshot bump
+
+Artifact ceiling: 3,000 bytes and 70 lines.
+
+## Slice S227-01 — Atomic resolved bootstrap proposal
+
+- [ ] **T2271** Commit a complete executable RED proof for the exact PR #86
+  lock-only shape, a verified-applied skip-resolver mutant, inconsistent pin
+  tuples, split/extra paths or commits, and injected resolver failure.
+- [ ] **T2272** Invoke the cloned bootstrap repository's unmodified shipped
+  resolver after the Amaru override and pair the lock with exactly its selected
+  configurations revision and regenerated record.
+- [ ] **T2273** Create and adopt only one-commit proposals whose changed-path
+  census is exactly `flake.lock` plus
+  `nix/peer-snapshots/resolution.json`; reject every incoherent branch as
+  foreign.
+- [ ] **T2274** Preserve resolver failure as
+  `error=peer-snapshot-resolution-failed` with zero push/PR/launch effects and
+  no receipt-schema, cap, supersede, credential, workflow, resolver, or anchor
+  change.
+- [ ] **T2275** Pass the frozen gate and direct full Daily Amaru suite, receive
+  a fresh independent audit, finalize one behavior commit, and obtain all
+  required hosted contexts on its exact head. Name the A-001 local cold-Nix
+  omission in the gate receipt and PR body.
+
+The ticket owner checks these tasks only after a fresh audit passes the exact
+candidate. The parked commit owner then includes this task stamp in the final
+squashed commit.

--- a/specs/227-atomic-peer-snapshot-bump/tasks.md
+++ b/specs/227-atomic-peer-snapshot-bump/tasks.md
@@ -4,21 +4,21 @@ Artifact ceiling: 3,000 bytes and 70 lines.
 
 ## Slice S227-01 — Atomic resolved bootstrap proposal
 
-- [ ] **T2271** Commit a complete executable RED proof for the exact PR #86
+- [x] **T2271** Commit a complete executable RED proof for the exact PR #86
   lock-only shape, a verified-applied skip-resolver mutant, inconsistent pin
   tuples, split/extra paths or commits, and injected resolver failure.
-- [ ] **T2272** Invoke the cloned bootstrap repository's unmodified shipped
+- [x] **T2272** Invoke the cloned bootstrap repository's unmodified shipped
   resolver after the Amaru override and pair the lock with exactly its selected
   configurations revision and regenerated record.
-- [ ] **T2273** Create and adopt only one-commit proposals whose changed-path
+- [x] **T2273** Create and adopt only one-commit proposals whose changed-path
   census is exactly `flake.lock` plus
   `nix/peer-snapshots/resolution.json`; reject every incoherent branch as
   foreign.
-- [ ] **T2274** Preserve resolver failure as
+- [x] **T2274** Preserve resolver failure as
   `error=peer-snapshot-resolution-failed` with zero push/PR/launch effects and
   no receipt-schema, cap, supersede, credential, workflow, resolver, or anchor
   change.
-- [ ] **T2275** Pass the frozen gate and direct full Daily Amaru suite, receive
+- [x] **T2275** Pass the frozen gate and direct full Daily Amaru suite, receive
   a fresh independent audit, finalize one behavior commit, and obtain all
   required hosted contexts on its exact head. Name the A-001 local cold-Nix
   omission in the gate receipt and PR body.

--- a/tests/fixtures/daily-amaru/boundary-nix.sh
+++ b/tests/fixtures/daily-amaru/boundary-nix.sh
@@ -9,21 +9,37 @@ set -euo pipefail
 
 input_name=$4
 reference=$5
-[[ "$reference" =~ ^github:pragma-org/amaru/([0-9a-f]{40})$ ]] || {
+owner=''
+repo=''
+sha=''
+if [[ "$reference" =~ ^github:pragma-org/amaru/([0-9a-f]{40})$ ]]; then
+  owner=pragma-org
+  repo=amaru
+  sha=${BASH_REMATCH[1]}
+elif [[ "$reference" =~ ^github:cardano-foundation/cardano-configurations/([0-9a-f]{40})$ ]]; then
+  owner=cardano-foundation
+  repo=cardano-configurations
+  sha=${BASH_REMATCH[1]}
+else
   printf 'boundary-nix: rejected reference: %s\n' "$reference" >&2
   exit 64
-}
-sha=${BASH_REMATCH[1]}
+fi
 tmp=flake.lock.boundary-new
 
-jq --arg input "$input_name" --arg sha "$sha" '
+jq --arg input "$input_name" --arg sha "$sha" \
+  --arg owner "$owner" --arg repo "$repo" '
   (.nodes.root.inputs[$input] |
     if type == "array" then .[0] else . end) as $node |
-  .nodes[$node].original.owner = "pragma-org" |
-  .nodes[$node].original.repo = "amaru" |
+  .nodes[$node].original.owner = $owner |
+  .nodes[$node].original.repo = $repo |
+  .nodes[$node].original.rev = $sha |
   .nodes[$node].locked.rev = $sha |
   .nodes[$node].locked.narHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" |
   .nodes[$node].locked.lastModified = 1787075200
 ' flake.lock >"$tmp"
 mv "$tmp" flake.lock
+if [ -n "${DAILY_AMARU_BOUNDARY_NIX_LOG:-}" ]; then
+  printf 'nix-override input=%s rev=%s owner=%s repo=%s\n' \
+    "$input_name" "$sha" "$owner" "$repo" >>"$DAILY_AMARU_BOUNDARY_NIX_LOG"
+fi
 printf 'warning: boundary-nix rewrote %s\n' "$input_name" >&2

--- a/tests/fixtures/daily-amaru/boundary-resolver.sh
+++ b/tests/fixtures/daily-amaru/boundary-resolver.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+record=nix/peer-snapshots/resolution.json
+flake_lock=${FLAKE_LOCK:-./flake.lock}
+write=false
+log_file=${DAILY_AMARU_BOUNDARY_RESOLVER_LOG:-}
+selected=${DAILY_AMARU_BOUNDARY_SELECTED_CONFIGS_REV:-4444444444444444444444444444444444444444}
+fail_mode=${DAILY_AMARU_BOUNDARY_RESOLVER_FAIL:-}
+
+fail() {
+  echo "peer-snapshot resolution failed: $*" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  '') ;;
+  --write) write=true ;;
+  *) fail "usage: $0 [--write]" ;;
+esac
+[ "$#" -le 1 ] || fail "usage: $0 [--write]"
+[ -f "$flake_lock" ] || fail "flake lock not found: $flake_lock"
+
+amaru_rev=$(jq -er '.nodes.amaru.locked.rev' "$flake_lock") ||
+  fail 'amaru locked rev is missing'
+pinned_configs_rev=$(
+  jq -er '.nodes["cardano-configurations"].locked.rev' "$flake_lock"
+) || fail 'cardano-configurations locked rev is missing'
+
+if [ -n "$log_file" ]; then
+  printf 'resolver write=%s amaru_rev=%s pinned_configs_rev=%s selected_configs_rev=%s cwd=%s\n' \
+    "$write" "$amaru_rev" "$pinned_configs_rev" "$selected" "$PWD" >>"$log_file"
+fi
+
+if [ "$fail_mode" = network ]; then
+  fail 'network/rate-limit'
+fi
+
+if [ "$fail_mode" = malformed ]; then
+  if $write; then
+    mkdir -p "$(dirname "$record")"
+    printf 'not-json\n' >"$record"
+  fi
+  fail 'malformed result'
+fi
+
+if $write; then
+  mkdir -p "$(dirname "$record")"
+  jq -n \
+    --arg amaru_rev "$amaru_rev" \
+    --arg configs_rev "$selected" \
+    '{
+      amaru_rev: $amaru_rev,
+      amaru_committer_date_utc: "2026-01-01T00:00:00Z",
+      configs_rev: $configs_rev,
+      resolved_at_utc: "2026-01-01T00:00:00Z",
+      query_url: "https://example.invalid/commits",
+      snapshots: {
+        mainnet: {sha256: "aa"},
+        preprod: {sha256: "bb"},
+        preview: {sha256: "cc"}
+      }
+    }' >"$record.boundary-new"
+  mv "$record.boundary-new" "$record"
+  echo "wrote $record"
+fi
+
+if [ "$fail_mode" = nonzero ]; then
+  fail 'injected non-zero'
+fi
+
+if [ "$pinned_configs_rev" != "$selected" ]; then
+  echo "configs revision: pinned=$pinned_configs_rev resolved=$selected MISMATCH" >&2
+  fail 'pinned resolution, input bytes, or committed record differ'
+fi
+
+echo 'peer-snapshot resolution verified for 3 networks'

--- a/tests/fixtures/daily-amaru/test-transport-boundary.sh
+++ b/tests/fixtures/daily-amaru/test-transport-boundary.sh
@@ -33,9 +33,24 @@ guard_sites=0
 upstream_sha=1111111111111111111111111111111111111111
 old_sha=0000000000000000000000000000000000000000
 foreign_sha=2222222222222222222222222222222222222222
+old_configs_sha=3333333333333333333333333333333333333333
+selected_configs_sha=4444444444444444444444444444444444444444
+foreign_configs_sha=5555555555555555555555555555555555555555
 day=2026-08-19
 branch="daily-amaru/bootstrap-$day-${upstream_sha:0:12}"
 workflow_head=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+atomic_paths=$'flake.lock\nnix/peer-snapshots/resolution.json'
+resolver_invocations=0
+amaru_overrides=0
+configs_overrides=0
+changed_paths=0
+proposal_commits=0
+lock_only_mutants=0
+resolver_failures=0
+named_receipts=0
+pushes_after_failure=0
+prs_after_failure=0
+launches=0
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -149,19 +164,41 @@ run_boundary_command() {
 
 write_lock() {
   local path=$1 sha=$2
+  local configs_sha=${3:-$old_configs_sha}
   mkdir -p "$(dirname "$path")"
   printf '%s\n' \
     '{' \
     '  "nodes": {' \
-    '    "root": {"inputs": {"amaru": "stock"}},' \
-    '    "stock": {' \
+    '    "root": {"inputs": {"amaru": "amaru", "cardano-configurations": "cardano-configurations"}},' \
+    '    "amaru": {' \
     '      "original": {"owner": "pragma-org", "repo": "amaru"},' \
     "      \"locked\": {\"rev\": \"$sha\", \"narHash\": \"sha256-old\", \"lastModified\": 1}" \
+    '    },' \
+    '    "cardano-configurations": {' \
+    '      "original": {"owner": "cardano-foundation", "repo": "cardano-configurations"},' \
+    "      \"locked\": {\"rev\": \"$configs_sha\", \"narHash\": \"sha256-old-configs\", \"lastModified\": 1}" \
     '    }' \
     '  },' \
     '  "root": "root",' \
     '  "version": 7' \
     '}' >"$path"
+}
+
+write_resolution() {
+  local path=$1 amaru_rev=$2 configs_rev=$3
+  mkdir -p "$(dirname "$path")"
+  jq -n --arg amaru_rev "$amaru_rev" --arg configs_rev "$configs_rev" '{
+    amaru_rev: $amaru_rev,
+    amaru_committer_date_utc: "2026-01-01T00:00:00Z",
+    configs_rev: $configs_rev,
+    resolved_at_utc: "2026-01-01T00:00:00Z",
+    query_url: "https://example.invalid/commits",
+    snapshots: {
+      mainnet: {sha256: "aa"},
+      preprod: {sha256: "bb"},
+      preview: {sha256: "cc"}
+    }
+  }' >"$path"
 }
 
 create_remote() {
@@ -171,7 +208,12 @@ create_remote() {
   git init --quiet --initial-branch=main "$seed"
   git -C "$seed" config user.name boundary
   git -C "$seed" config user.email boundary@example.invalid
-  write_lock "$seed/flake.lock" "$old_sha"
+  write_lock "$seed/flake.lock" "$old_sha" "$old_configs_sha"
+  write_resolution "$seed/nix/peer-snapshots/resolution.json" \
+    "$old_sha" "$old_configs_sha"
+  mkdir -p "$seed/scripts"
+  cp "$fixture_root/boundary-resolver.sh" "$seed/scripts/resolve-peer-snapshots"
+  chmod +x "$seed/scripts/resolve-peer-snapshots"
   printf 'boundary\n' >"$seed/README.md"
   git -C "$seed" add .
   git -C "$seed" commit --quiet -m base
@@ -206,7 +248,7 @@ seed_proposal() {
   git -C "$work" config user.email boundary@example.invalid
   git -C "$work" checkout --quiet -b "$branch" origin/main
   case "$kind" in
-    adopt)
+    adopt | lock-only)
       (cd "$work" && "$fake_nix" flake lock --override-input amaru \
         "github:pragma-org/amaru/$upstream_sha")
       ;;
@@ -214,11 +256,84 @@ seed_proposal() {
       (cd "$work" && "$fake_nix" flake lock --override-input amaru \
         "github:pragma-org/amaru/$foreign_sha")
       ;;
+    atomic)
+      (cd "$work" && "$fake_nix" flake lock --override-input amaru \
+        "github:pragma-org/amaru/$upstream_sha")
+      (cd "$work" && "$fake_nix" flake lock --override-input \
+        cardano-configurations \
+        "github:cardano-foundation/cardano-configurations/$selected_configs_sha")
+      write_resolution "$work/nix/peer-snapshots/resolution.json" \
+        "$upstream_sha" "$selected_configs_sha"
+      ;;
+    record-only)
+      write_resolution "$work/nix/peer-snapshots/resolution.json" \
+        "$upstream_sha" "$selected_configs_sha"
+      ;;
+    extra-path)
+      (cd "$work" && "$fake_nix" flake lock --override-input amaru \
+        "github:pragma-org/amaru/$upstream_sha")
+      (cd "$work" && "$fake_nix" flake lock --override-input \
+        cardano-configurations \
+        "github:cardano-foundation/cardano-configurations/$selected_configs_sha")
+      write_resolution "$work/nix/peer-snapshots/resolution.json" \
+        "$upstream_sha" "$selected_configs_sha"
+      printf 'extra\n' >>"$work/README.md"
+      ;;
+    split)
+      (cd "$work" && "$fake_nix" flake lock --override-input amaru \
+        "github:pragma-org/amaru/$upstream_sha")
+      git -C "$work" add flake.lock
+      git -C "$work" commit --quiet -m 'split lock'
+      (cd "$work" && "$fake_nix" flake lock --override-input \
+        cardano-configurations \
+        "github:cardano-foundation/cardano-configurations/$selected_configs_sha")
+      write_resolution "$work/nix/peer-snapshots/resolution.json" \
+        "$upstream_sha" "$selected_configs_sha"
+      ;;
     *) fail "unknown seed kind: $kind" ;;
   esac
   git -C "$work" add .
   git -C "$work" commit --quiet -m "$kind proposal"
   git -C "$work" push --quiet origin "HEAD:refs/heads/$branch"
+  git --git-dir="$remote" rev-parse "refs/heads/$branch"
+}
+
+seed_inconsistent_atomic() {
+  local remote=$1 field=$2
+  local work
+  seed_proposal "$remote" atomic >/dev/null
+  work=$(mktemp -d "$tmp_root/inconsistent-$field.XXXXXX")
+  git clone --quiet "file://$remote" "$work"
+  git -C "$work" config user.name boundary
+  git -C "$work" config user.email boundary@example.invalid
+  git -C "$work" checkout --quiet "$branch"
+  case "$field" in
+    lock-amaru)
+      jq --arg sha "$foreign_sha" \
+        '.nodes.amaru.locked.rev = $sha' "$work/flake.lock" >"$work/flake.lock.new"
+      mv "$work/flake.lock.new" "$work/flake.lock"
+      ;;
+    lock-configs)
+      jq --arg sha "$foreign_configs_sha" \
+        '.nodes["cardano-configurations"].locked.rev = $sha' \
+        "$work/flake.lock" >"$work/flake.lock.new"
+      mv "$work/flake.lock.new" "$work/flake.lock"
+      ;;
+    record-amaru)
+      jq --arg sha "$foreign_sha" '.amaru_rev = $sha' \
+        "$work/nix/peer-snapshots/resolution.json" >"$work/resolution.new"
+      mv "$work/resolution.new" "$work/nix/peer-snapshots/resolution.json"
+      ;;
+    record-configs)
+      jq --arg sha "$foreign_configs_sha" '.configs_rev = $sha' \
+        "$work/nix/peer-snapshots/resolution.json" >"$work/resolution.new"
+      mv "$work/resolution.new" "$work/nix/peer-snapshots/resolution.json"
+      ;;
+    *) fail "unknown inconsistent field: $field" ;;
+  esac
+  git -C "$work" add -- flake.lock nix/peer-snapshots/resolution.json
+  git -C "$work" commit --quiet --amend --no-edit
+  git -C "$work" push --quiet --force origin "HEAD:refs/heads/$branch"
   git --git-dir="$remote" rev-parse "refs/heads/$branch"
 }
 
@@ -232,15 +347,24 @@ prepare_case() {
   stdout="$case_root/stdout"
   stderr="$case_root/stderr"
   receipt="$case_root/receipt"
+  resolver_log="$case_root/resolver.log"
+  nix_log="$case_root/nix.log"
   mkdir -p "$state" "$bin"
   : >"$effects"
   : >"$comments"
+  : >"$resolver_log"
+  : >"$nix_log"
+  unset DAILY_AMARU_BOUNDARY_RESOLVER_FAIL
   seed_boundary_path "$bin"
 }
 
 run_transport() {
   local label=$1 remote=$2
+  local fail_mode=${3:-}
   prepare_case "$label"
+  if [ -n "$fail_mode" ]; then
+    export DAILY_AMARU_BOUNDARY_RESOLVER_FAIL=$fail_mode
+  fi
   transport_rc=0
   DAILY_AMARU_DAY="$day" \
     DAILY_AMARU_IDENTITY=boundary-bootstrap-token \
@@ -253,14 +377,18 @@ run_transport() {
     DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
     DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$remote" \
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$remote" \
+    DAILY_AMARU_BOUNDARY_RESOLVER_LOG="$resolver_log" \
+    DAILY_AMARU_BOUNDARY_NIX_LOG="$nix_log" \
+    DAILY_AMARU_BOUNDARY_SELECTED_CONFIGS_REV="$selected_configs_sha" \
     run_boundary_command "$bin" "$transport" propose-bootstrap "$upstream_sha" \
     >"$stdout" 2>"$stderr" || transport_rc=$?
+  unset DAILY_AMARU_BOUNDARY_RESOLVER_FAIL
 }
 
 assert_adopt() {
   local remote before after output
   remote=$(create_remote adopt)
-  before=$(seed_proposal "$remote" adopt)
+  before=$(seed_proposal "$remote" atomic)
   run_transport adopt "$remote"
   output=$(cat "$stdout")
   after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
@@ -298,8 +426,8 @@ assert_fresh() {
   [[ "$output" =~ ^[0-9a-f]{40}$ ]] || fail "fresh proposal emitted malformed head: $output"
   remote_head=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
   [ "$output" = "$remote_head" ] || fail 'fresh output differs from pushed head'
-  changed=$(git --git-dir="$remote" diff --name-only main "$branch")
-  [ "$changed" = flake.lock ] || fail "fresh proposal changed: $changed"
+  changed=$(git --git-dir="$remote" diff --name-only main "$branch" | sort)
+  [ "$changed" = "$atomic_paths" ] || fail "fresh proposal changed: $changed"
   grep -Fq 'gh pr create' "$effects" || fail 'fresh proposal did not create its PR'
 }
 
@@ -325,6 +453,9 @@ assert_pollution_with_remotes() {
     DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
     DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_BOUNDARY_RESOLVER_LOG="$resolver_log" \
+    DAILY_AMARU_BOUNDARY_NIX_LOG="$nix_log" \
+    DAILY_AMARU_BOUNDARY_SELECTED_CONFIGS_REV="$selected_configs_sha" \
     DAILY_AMARU_TRANSPORT="$transport" \
     run_boundary_command "$bin" "$controller" >"$stdout" 2>"$stderr" || controller_rc=$?
   [ -f "$receipt" ] ||
@@ -496,6 +627,9 @@ execute_value_operation() {
     DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
     DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
     DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$consumer_remote" \
+    DAILY_AMARU_BOUNDARY_RESOLVER_LOG="$resolver_log" \
+    DAILY_AMARU_BOUNDARY_NIX_LOG="$nix_log" \
+    DAILY_AMARU_BOUNDARY_SELECTED_CONFIGS_REV="$selected_configs_sha" \
     DAILY_AMARU_BOUNDARY_HEAD_SHA="$workflow_head" \
     DAILY_AMARU_BOUNDARY_INTEGRATED_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
     run_boundary_command "$bin" "$transport" "$operation" "${arguments[@]}" \
@@ -863,6 +997,266 @@ assert_mutants() {
     'classification ran after local branch creation'
 }
 
+receipt_field() {
+  local key=$1 value=''
+  [ -f "$receipt" ] || return 0
+  while IFS='=' read -r field value; do
+    if [ "$field" = "$key" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done <"$receipt"
+}
+
+assert_atomic_fresh() {
+  local remote output remote_head changed commits lock record
+  local lock_amaru lock_configs record_amaru record_configs first_resolver
+  remote=$(create_remote fresh-atomic)
+  run_transport fresh-atomic "$remote"
+  output=$(cat "$stdout")
+  resolver_invocations=$(grep -c '^resolver ' "$resolver_log" || true)
+  [ "$resolver_invocations" -ge 2 ] ||
+    fail "resolver invocations=$resolver_invocations, want >=2 after Amaru override"
+  [ "$transport_rc" -eq 0 ] ||
+    fail "fresh atomic proposal failed: $(tr '\n' ' ' <"$stderr")"
+  [[ "$output" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "fresh atomic proposal emitted malformed head: $output"
+  remote_head=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$output" = "$remote_head" ] || fail 'fresh atomic output differs from pushed head'
+  first_resolver=$(grep '^resolver ' "$resolver_log" | head -n 1)
+  [[ "$first_resolver" == *"amaru_rev=$upstream_sha"* ]] ||
+    fail "first resolver invocation was not after the Amaru override: $first_resolver"
+  [[ "$first_resolver" == *"cwd=$state/bootstrap"* ]] ||
+    fail "resolver was not clone-local: $first_resolver"
+  amaru_overrides=$(grep -c 'input=amaru ' "$nix_log" || true)
+  configs_overrides=$(grep -c 'input=cardano-configurations ' "$nix_log" || true)
+  [ "$amaru_overrides" -ge 1 ] || fail 'Amaru override was not invoked'
+  [ "$configs_overrides" -ge 1 ] || fail 'configurations override was not invoked'
+  changed=$(git --git-dir="$remote" diff --name-only main "$branch" | sort)
+  [ "$changed" = "$atomic_paths" ] ||
+    fail "fresh proposal changed: $changed"
+  changed_paths=$(printf '%s\n' "$changed" | grep -c . || true)
+  commits=$(git --git-dir="$remote" rev-list --count "main..$branch")
+  [ "$commits" -eq 1 ] || fail "fresh proposal commits=$commits, want 1"
+  proposal_commits=$commits
+  lock=$(git --git-dir="$remote" show "$branch:flake.lock")
+  record=$(git --git-dir="$remote" show "$branch:nix/peer-snapshots/resolution.json")
+  lock_amaru=$(jq -er '.nodes.amaru.locked.rev' <<<"$lock")
+  lock_configs=$(jq -er '.nodes["cardano-configurations"].locked.rev' <<<"$lock")
+  record_amaru=$(jq -er '.amaru_rev' <<<"$record")
+  record_configs=$(jq -er '.configs_rev' <<<"$record")
+  [ "$lock_amaru" = "$upstream_sha" ] &&
+    [ "$record_amaru" = "$upstream_sha" ] &&
+    [ "$lock_configs" = "$selected_configs_sha" ] &&
+    [ "$record_configs" = "$selected_configs_sha" ] ||
+    fail "tuple mismatch lock_amaru=$lock_amaru record_amaru=$record_amaru lock_configs=$lock_configs record_configs=$record_configs"
+  grep -Fq 'gh pr create' "$effects" || fail 'fresh atomic proposal did not create its PR'
+}
+
+assert_atomic_adopt() {
+  local remote before after output
+  remote=$(create_remote atomic-adopt)
+  before=$(seed_proposal "$remote" atomic)
+  run_transport atomic-adopt "$remote"
+  output=$(cat "$stdout")
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -eq 0 ] ||
+    fail "coherent two-path branch was not adopted: $(tr '\n' ' ' <"$stderr")"
+  [ "$output" = "$before" ] ||
+    fail "atomic adopt emitted '$output', expected $before"
+  [ "$after" = "$before" ] || fail 'atomic adopt changed the remote ref'
+  ! grep -Fq 'gh pr create' "$effects" || fail 'atomic adopt attempted to create a PR'
+  grep -Fq 'gh pr view' "$effects" || fail 'atomic adopt did not reuse the existing PR'
+}
+
+assert_pr86_foreign() {
+  local remote before after
+  remote=$(create_remote pr86)
+  before=$(seed_proposal "$remote" lock-only)
+  run_transport pr86 "$remote"
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -ne 0 ] || fail 'lock-only PR #86 shape was adopted'
+  [ ! -s "$stdout" ] || fail 'lock-only PR #86 shape emitted a value'
+  grep -Fq 'foreign-proposal-branch' "$stderr" ||
+    fail 'lock-only PR #86 shape lacked its named red'
+  [ "$after" = "$before" ] || fail 'lock-only PR #86 shape changed the remote ref'
+}
+
+assert_foreign_kind() {
+  local kind=$1 remote before after
+  remote=$(create_remote "foreign-$kind")
+  before=$(seed_proposal "$remote" "$kind")
+  run_transport "foreign-$kind" "$remote"
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -ne 0 ] || fail "$kind proposal was adopted"
+  grep -Fq 'foreign-proposal-branch' "$stderr" ||
+    fail "$kind proposal lacked its named red"
+  [ "$after" = "$before" ] || fail "$kind proposal changed the remote ref"
+}
+
+assert_inconsistent_tuple_foreign() {
+  local field=$1 remote before after
+  remote=$(create_remote "inconsistent-$field")
+  before=$(seed_inconsistent_atomic "$remote" "$field")
+  run_transport "inconsistent-$field" "$remote"
+  after=$(git --git-dir="$remote" rev-parse "refs/heads/$branch")
+  [ "$transport_rc" -ne 0 ] || fail "inconsistent $field tuple was adopted"
+  grep -Fq 'foreign-proposal-branch' "$stderr" ||
+    fail "inconsistent $field tuple lacked its named red"
+  [ "$after" = "$before" ] || fail "inconsistent $field tuple changed the remote ref"
+}
+
+run_atomic_controller() {
+  local label=$1 bootstrap_remote=$2
+  local fail_mode=${3:-}
+  local upstream_remote
+  upstream_remote=$(create_remote "$label-upstream")
+  prepare_case "$label"
+  if [ -n "$fail_mode" ]; then
+    export DAILY_AMARU_BOUNDARY_RESOLVER_FAIL=$fail_mode
+  fi
+  controller_rc=0
+  GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0="url.file://$upstream_remote.insteadOf" \
+    GIT_CONFIG_VALUE_0=https://github.com/pragma-org/amaru.git \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    DAILY_AMARU_MODE=production \
+    DAILY_AMARU_DAY="$day" \
+    DAILY_AMARU_HEAD="$workflow_head" \
+    DAILY_AMARU_IDENTITY=boundary-bootstrap-token \
+    GH_TOKEN=boundary-repository-token \
+    DAILY_AMARU_STATE_DIR="$state" \
+    DAILY_AMARU_RECEIPT="$receipt" \
+    DAILY_AMARU_BOUNDARY_GH_LOG="$effects" \
+    DAILY_AMARU_BOUNDARY_COMMENTS="$comments" \
+    DAILY_AMARU_BOUNDARY_BOOTSTRAP_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_BOUNDARY_REPOSITORY_REMOTE="$bootstrap_remote" \
+    DAILY_AMARU_BOUNDARY_RESOLVER_LOG="$resolver_log" \
+    DAILY_AMARU_BOUNDARY_NIX_LOG="$nix_log" \
+    DAILY_AMARU_BOUNDARY_SELECTED_CONFIGS_REV="$selected_configs_sha" \
+    DAILY_AMARU_TRANSPORT="$transport" \
+    run_boundary_command "$bin" "$controller" >"$stdout" 2>"$stderr" ||
+    controller_rc=$?
+  unset DAILY_AMARU_BOUNDARY_RESOLVER_FAIL
+}
+
+assert_named_resolver_failure() {
+  local mode=$1 bootstrap_remote final_error stage
+  bootstrap_remote=$(create_remote "resolver-fail-$mode")
+  run_atomic_controller "resolver-fail-$mode" "$bootstrap_remote" "$mode"
+  resolver_failures=$((resolver_failures + 1))
+  final_error=$(receipt_field error)
+  stage=$(receipt_field stage)
+  if [ "$final_error" != peer-snapshot-resolution-failed ] ||
+    [ "$stage" != bootstrap-proposal ]; then
+    if git --git-dir="$bootstrap_remote" show-ref --verify --quiet \
+      "refs/heads/$branch"; then
+      fail "failing resolver was ignored; proposal was published error=${final_error:-missing}"
+    fi
+    fail "resolver failure receipt was not named: error=${final_error:-missing} stage=${stage:-missing}"
+  fi
+  named_receipts=$((named_receipts + 1))
+  if git --git-dir="$bootstrap_remote" show-ref --verify --quiet \
+    "refs/heads/$branch"; then
+    pushes_after_failure=$((pushes_after_failure + 1))
+    fail 'resolver failure pushed a proposal branch'
+  fi
+  if grep -Fq 'gh pr create' "$effects"; then
+    prs_after_failure=$((prs_after_failure + 1))
+    fail 'resolver failure created a PR'
+  fi
+  if grep -Eq 'workflow run|real-launch' "$effects" "$stderr"; then
+    launches=$((launches + 1))
+    fail 'resolver failure reached a launch effect'
+  fi
+}
+
+assert_resolver_token() {
+  local remote output
+  remote=$(create_remote resolver-token)
+  run_transport resolver-token "$remote" network
+  output=$(cat "$stdout")
+  [ "$transport_rc" -ne 0 ] || fail 'resolver failure returned success'
+  [ "$output" = RESOLVER-FAILED ] ||
+    fail "VALUE-CHANNEL leaked non-token bytes: $(od -An -tx1 "$stdout" | tr -d ' \n')"
+  if git --git-dir="$remote" show-ref --verify --quiet "refs/heads/$branch"; then
+    fail 'resolver failure pushed a proposal branch'
+  fi
+  ! grep -Fq 'gh pr create' "$effects" || fail 'resolver failure created a PR'
+}
+
+assert_skip_resolver_mutant() {
+  local mutant="$tmp_root/skip-resolver.sh" before after
+  before=$(grep -c 'resolve-peer-snapshots' "$transport" || true)
+  [ "$before" -ge 2 ] || fail 'cloned resolver is not invoked'
+  awk '
+    $0 == "invoke_cloned_resolver() {" || $0 == "resolver_failed() {" {
+      print
+      print "  : # skip-resolver-mutant"
+      print "  return 0"
+      print "}"
+      skipfn = 1
+      next
+    }
+    skipfn && $0 == "}" { skipfn = 0; next }
+    skipfn { next }
+    { print }
+  ' "$transport" >"$mutant"
+  after=$(grep -c 'skip-resolver-mutant' "$mutant" || true)
+  [ "$after" -eq 2 ] &&
+    [ "$(grep -c 'resolve-peer-snapshots' "$mutant" || true)" -eq 0 ] ||
+    fail 'skip-resolver mutation did not apply'
+  chmod +x "$mutant"
+  reject_scenario_mutant skip-resolver "$mutant" atomic-fresh \
+    'resolver invocations=0, want >=2 after Amaru override'
+  lock_only_mutants=$((lock_only_mutants + 1))
+}
+
+assert_token_drop_mutant() {
+  local mutant="$tmp_root/token-drop.sh"
+  grep -Fq "emit 'RESOLVER-FAILED'" "$transport" ||
+    fail 'resolver failure token is not emitted on the value channel'
+  sed "s/emit 'RESOLVER-FAILED'/true/g" "$transport" >"$mutant"
+  ! grep -Fq "emit 'RESOLVER-FAILED'" "$mutant" ||
+    fail 'token-drop mutation did not apply'
+  grep -Fq "peer-snapshot-resolution-failed" "$mutant" ||
+    fail 'token-drop mutation removed the failure path'
+  chmod +x "$mutant"
+  reject_scenario_mutant token-drop "$mutant" atomic-resolver-fail \
+    'resolver failure receipt was not named'
+}
+
+assert_atomic_peer_snapshot() {
+  local field kind
+  launches=0
+  assert_atomic_fresh
+  assert_resolver_token
+  assert_atomic_adopt
+  assert_pr86_foreign
+  for kind in record-only extra-path split; do
+    assert_foreign_kind "$kind"
+  done
+  for field in lock-amaru lock-configs record-amaru record-configs; do
+    assert_inconsistent_tuple_foreign "$field"
+  done
+  for kind in network nonzero malformed; do
+    assert_named_resolver_failure "$kind"
+  done
+  assert_skip_resolver_mutant
+  assert_token_drop_mutant
+  [ "$named_receipts" -eq "$resolver_failures" ] ||
+    fail "named_receipts=$named_receipts resolver_failures=$resolver_failures"
+  [ "$pushes_after_failure" -eq 0 ] || fail 'resolver failure had push effects'
+  [ "$prs_after_failure" -eq 0 ] || fail 'resolver failure had PR effects'
+  [ "$launches" -eq 0 ] || fail "launches=$launches, want 0"
+  printf 'PEER-SNAPSHOT-ATOMIC resolver_invocations=%s amaru_overrides=%s configs_overrides=%s changed_paths=%s commits=%s lock_only_mutants=%s resolver_failures=%s named_receipts=%s pushes_after_failure=%s prs_after_failure=%s launches=%s\n' \
+    "$resolver_invocations" "$amaru_overrides" "$configs_overrides" \
+    "$changed_paths" "$proposal_commits" "$lock_only_mutants" \
+    "$resolver_failures" "$named_receipts" "$pushes_after_failure" \
+    "$prs_after_failure" "$launches"
+}
+
 case "$scenario" in
   pollution)
     assert_pollution_closed
@@ -894,6 +1288,7 @@ case "$scenario" in
     assert_boundary_marker_derivation
     assert_boundary_census_derivation
     assert_guard_diagnostics
+    assert_atomic_peer_snapshot
     printf 'VALUE-CHANNEL operations=%s executed=%s census=complete mutants_rejected=%s\n' \
       "$value_operation_count" "$value_executed_count" "$value_mutants_rejected"
     printf 'VALUE-CHANNEL-FIRED reproduced=malformed-candidate-sha real_git=1 real_transport=1\n'
@@ -919,6 +1314,15 @@ case "$scenario" in
     ;;
   guard-marker-derivation)
     assert_boundary_marker_derivation
+    ;;
+  atomic-fresh)
+    assert_atomic_fresh
+    ;;
+  atomic-resolver-fail)
+    assert_named_resolver_failure network
+    ;;
+  atomic-peer-snapshot)
+    assert_atomic_peer_snapshot
     ;;
   *) fail "unknown scenario: $scenario" ;;
 esac

--- a/tests/test-daily-amaru.sh
+++ b/tests/test-daily-amaru.sh
@@ -1634,10 +1634,12 @@ issue_223_declared_mutants=(
 issue_225_allowed_paths=(
   .github/workflows/daily-amaru.yaml
   scripts/daily-amaru-github.sh
+  scripts/daily-amaru.sh
   tests/test-daily-amaru.sh
   tests/fixtures/daily-amaru/boundary-gh.sh
   tests/fixtures/daily-amaru/boundary-docker.sh
   tests/fixtures/daily-amaru/boundary-nix.sh
+  tests/fixtures/daily-amaru/boundary-resolver.sh
   tests/fixtures/daily-amaru/test-transport-boundary.sh
   specs/225-transport-value-channel/data-model.md
   specs/225-transport-value-channel/functions-model.md
@@ -1645,6 +1647,12 @@ issue_225_allowed_paths=(
   specs/225-transport-value-channel/plan.md
   specs/225-transport-value-channel/spec.md
   specs/225-transport-value-channel/tasks.md
+  specs/227-atomic-peer-snapshot-bump/data-model.md
+  specs/227-atomic-peer-snapshot-bump/functions-model.md
+  specs/227-atomic-peer-snapshot-bump/modules-model.md
+  specs/227-atomic-peer-snapshot-bump/plan.md
+  specs/227-atomic-peer-snapshot-bump/spec.md
+  specs/227-atomic-peer-snapshot-bump/tasks.md
 )
 
 register_223_mutant() {


### PR DESCRIPTION
Closes #227

## Summary

- atomically refresh the bootstrap repository's Amaru/configurations lock pair and generated peer-snapshot resolution record
- consume the cloned repository's shipped resolver unmodified and fail closed before publication
- widen proposal creation/adoption census to exactly `flake.lock` plus `nix/peer-snapshots/resolution.json` in one commit
- permanently reject the PR #86 lock-only shape and injected resolver failures

## Verification

- [x] direct baseline `just test-daily-amaru` (exit 0; 102 lines; 62.4 s)
- [x] frozen gate v2 is RED on the pre-implementation tree for the intended missing atomic-boundary scenario
- [x] focused atomic peer-snapshot boundary RED → GREEN
- [x] complete direct `just test-daily-amaru`
- [x] fresh independent commit audit (8/8 invariant rows KILLED; no findings or residuals)
- [x] all required hosted contexts green on the exact final head: Build, Run unit Tests, Check code quality, Compose smoke test, publish-images, and build-docs

Accepted final head: `72c4df362895ae4ee782a6fed547dbc95cd4314a`.

Fresh ticket-owner receipts:

- commit gate: exit 0, sha256 `ab3a723fcb97ca460e59b55108bb199242471ddf20616dc509612a436b338dc7`;
- ticket gate: exit 0 in 84.2 s, sha256 `5b844b1a948dfe7605c922f5a7b8076468f0fd05c164dc9df1849695cdb5eedb`;
- independent audit report: sha256 `6d5b9a32ba5e60d45b65acd834140297da0071fa85f14af4ef846cae1471ae78`.

## Host verification note

Local `nix develop --quiet -c just ci` is intentionally omitted: the host's
cold-realization interlock forbids the measured two-derivation dev-shell
realization. Durable answer A-001 authorizes the direct injected-boundary gate;
the exact-head hosted `Check code quality` context supplies actionlint and
shellcheck coverage. This is a named omission, not a skipped check.

No real Antithesis launch, production dispatch, credential use, or cold Nix
realization is part of this PR's local tests.
